### PR TITLE
feat(llm): support remote API base (Ollama/LM Studio/LiteLLM) + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,43 @@ export PERPLEXITY_API_KEY="your-api-key"
 
 [📚 View supported AI models](https://docs.litellm.ai/docs/providers)
 
+### Using Ollama or LM Studio (Remote)
+
+You can point Strix at a remote, self‑hosted OpenAI‑compatible server (e.g., Ollama or LM Studio) via environment variables. Strix uses LiteLLM under the hood and respects a configurable API base.
+
+Option A: Ollama provider (preferred for Ollama)
+
+```bash
+# Pick any model pulled on the remote Ollama host
+export STRIX_LLM="ollama/llama3.1"
+
+# Point to your remote Ollama instance (no /v1 for the Ollama provider)
+export LLM_API_BASE="http://<remote-host>:11434"
+
+# Strix requires this env to be set even if your server doesn’t need it
+export LLM_API_KEY="not-needed"
+```
+
+Option B: OpenAI‑compatible route (works for Ollama/LM Studio)
+
+```bash
+# Use the OpenAI provider name with the model you want
+export STRIX_LLM="openai/llama3.1"
+
+# Point to the server’s OpenAI‑compatible API (include /v1)
+export LLM_API_BASE="http://<remote-host>:11434/v1"  # Ollama
+# or
+export LLM_API_BASE="http://127.0.0.1:1234/v1"       # LM Studio default
+
+export LLM_API_KEY="not-needed"
+```
+
+Notes
+
+- `LLM_API_BASE` is also honored via `OPENAI_API_BASE`, `LITELLM_BASE_URL`, or `OLLAMA_API_BASE`.
+- Keep `STRIX_LLM` aligned with the server type you’re using (e.g., `ollama/<model>` for Ollama, `openai/<model>` for OpenAI‑compatible base URLs).
+- You can also use a LiteLLM Proxy by pointing `LLM_API_BASE` (or `LITELLM_BASE_URL`) at the proxy URL and selecting any model your proxy exposes.
+
 ## 🏆 Enterprise Platform
 
 Our managed platform provides:

--- a/README.md
+++ b/README.md
@@ -89,52 +89,15 @@ strix --target api.your-app.com --instruction "Prioritize authentication and aut
 ### ⚙️ Configuration
 
 ```bash
-# Required
 export STRIX_LLM="openai/gpt-5"
 export LLM_API_KEY="your-api-key"
 
-# Recommended
-export PERPLEXITY_API_KEY="your-api-key"
+# Optional
+export LLM_API_BASE="your-api-base-url"  # if using a local model, e.g. Ollama, LMStudio
+export PERPLEXITY_API_KEY="your-api-key"  # for search capabilities
 ```
 
 [📚 View supported AI models](https://docs.litellm.ai/docs/providers)
-
-### Using Ollama or LM Studio (Remote)
-
-You can point Strix at a remote, self‑hosted OpenAI‑compatible server (e.g., Ollama or LM Studio) via environment variables. Strix uses LiteLLM under the hood and respects a configurable API base.
-
-Option A: Ollama provider (preferred for Ollama)
-
-```bash
-# Pick any model pulled on the remote Ollama host
-export STRIX_LLM="ollama/llama3.1"
-
-# Point to your remote Ollama instance (no /v1 for the Ollama provider)
-export LLM_API_BASE="http://<remote-host>:11434"
-
-# Strix requires this env to be set even if your server doesn’t need it
-export LLM_API_KEY="not-needed"
-```
-
-Option B: OpenAI‑compatible route (works for Ollama/LM Studio)
-
-```bash
-# Use the OpenAI provider name with the model you want
-export STRIX_LLM="openai/llama3.1"
-
-# Point to the server’s OpenAI‑compatible API (include /v1)
-export LLM_API_BASE="http://<remote-host>:11434/v1"  # Ollama
-# or
-export LLM_API_BASE="http://127.0.0.1:1234/v1"       # LM Studio default
-
-export LLM_API_KEY="not-needed"
-```
-
-Notes
-
-- `LLM_API_BASE` is also honored via `OPENAI_API_BASE`, `LITELLM_BASE_URL`, or `OLLAMA_API_BASE`.
-- Keep `STRIX_LLM` aligned with the server type you’re using (e.g., `ollama/<model>` for Ollama, `openai/<model>` for OpenAI‑compatible base URLs).
-- You can also use a LiteLLM Proxy by pointing `LLM_API_BASE` (or `LITELLM_BASE_URL`) at the proxy URL and selecting any model your proxy exposes.
 
 ## 🏆 Enterprise Platform
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strix-agent"
-version = "0.1.14"
+version = "0.1.18"
 description = "Open-source AI Hackers for your apps"
 authors = ["Strix <hi@usestrix.com>"]
 readme = "README.md"

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -28,6 +28,18 @@ api_key = os.getenv("LLM_API_KEY")
 if api_key:
     litellm.api_key = api_key
 
+# Allow overriding the default API base to target remote/self-hosted OpenAI-compatible
+# endpoints (e.g., Ollama, LM Studio, LiteLLM Proxy). We check several common env vars
+# to make configuration simple without changing code elsewhere.
+api_base = (
+    os.getenv("LLM_API_BASE")
+    or os.getenv("OPENAI_API_BASE")
+    or os.getenv("LITELLM_BASE_URL")
+    or os.getenv("OLLAMA_API_BASE")
+)
+if api_base:
+    litellm.api_base = api_base
+
 
 class LLMRequestFailedError(Exception):
     """Raised when LLM request fails after all retry attempts."""

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -28,9 +28,6 @@ api_key = os.getenv("LLM_API_KEY")
 if api_key:
     litellm.api_key = api_key
 
-# Allow overriding the default API base to target remote/self-hosted OpenAI-compatible
-# endpoints (e.g., Ollama, LM Studio, LiteLLM Proxy). We check several common env vars
-# to make configuration simple without changing code elsewhere.
 api_base = (
     os.getenv("LLM_API_BASE")
     or os.getenv("OPENAI_API_BASE")


### PR DESCRIPTION
This PR adds a simple, backward‑compatible way to point Strix at a remote/self‑hosted OpenAI‑compatible LLM server (e.g., Ollama, LM Studio, or a LiteLLM Proxy), and documents usage.

Changes

- LLM: Read `LLM_API_BASE` (also accepts `OPENAI_API_BASE`, `LITELLM_BASE_URL`, `OLLAMA_API_BASE`) and set `litellm.api_base` accordingly.
- Docs: Add a "Using Ollama or LM Studio (Remote)" section with concrete environment variable examples.

Why

- Enables running Strix against locally hosted or remote LLM endpoints without code changes.
- Keeps `STRIX_LLM` selection consistent with the provider (e.g., `ollama/<model>` vs `openai/<model>` when using an OpenAI‑compatible `/v1` endpoint).

Notes

- `LLM_API_KEY` must be set by the CLI, but remote servers like Ollama/LM Studio typically ignore its value. Use a placeholder when not required.

If you want any naming tweaks (env var name or docs wording), happy to adjust!