### PR TITLE
Add configurable LLM timeout support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ Thank you for your interest in contributing to Strix! This guide will help you g
    ```bash
    export STRIX_LLM="openai/gpt-5"
    export LLM_API_KEY="your-api-key"
+   # Optional: override default 180s timeout
+   export STRIX_LLM_TIMEOUT="240"
    ```
 
 4. **Run Strix in development mode**

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ pipx install strix-agent
 # Configure AI provider
 export STRIX_LLM="openai/gpt-5"
 export LLM_API_KEY="your-api-key"
+# Optional: adjust the LLM timeout (default 180s)
+export STRIX_LLM_TIMEOUT="240"
 
 # Run security assessment
 strix --target ./app-directory
@@ -149,6 +151,19 @@ strix -t https://github.com/org/app -t https://your-app.com
 strix --target api.your-app.com --instruction "Focus on business logic flaws and IDOR vulnerabilities"
 ```
 
+### ⚙️ Configuration
+
+```bash
+export STRIX_LLM="openai/gpt-5"
+export LLM_API_KEY="your-api-key"
+
+# Optional
+export STRIX_LLM_TIMEOUT="240"
+export LLM_API_BASE="your-api-base-url"  # if using a local model, e.g. Ollama, LMStudio
+export PERPLEXITY_API_KEY="your-api-key"  # for search capabilities
+```
+
+[📚 View supported AI models](https://docs.litellm.ai/docs/providers)
 ### 🤖 Headless Mode
 
 Run Strix programmatically without interactive UI using the `-n/--non-interactive` flag—perfect for servers and automated jobs. The CLI prints real-time vulnerability findings, and the final report before exiting. Exits with non-zero code when vulnerabilities are found.
@@ -184,18 +199,6 @@ jobs:
         run: strix -n -t ./
 ```
 
-### ⚙️ Configuration
-
-```bash
-export STRIX_LLM="openai/gpt-5"
-export LLM_API_KEY="your-api-key"
-
-# Optional
-export LLM_API_BASE="your-api-base-url"  # if using a local model, e.g. Ollama, LMStudio
-export PERPLEXITY_API_KEY="your-api-key"  # for search capabilities
-```
-
-[📚 View supported AI models](https://docs.litellm.ai/docs/providers)
 
 ## 🤝 Contributing
 

--- a/strix/llm/config.py
+++ b/strix/llm/config.py
@@ -1,4 +1,44 @@
+import logging
 import os
+
+DEFAULT_LLM_TIMEOUT_SECONDS = 180
+TIMEOUT_ENV_VAR = "STRIX_LLM_TIMEOUT"
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_timeout(value: int | str) -> int:
+    if isinstance(value, str):
+        value = value.strip()
+
+    try:
+        timeout_int = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Timeout must be a positive integer") from exc
+
+    if timeout_int <= 0:
+        raise ValueError("Timeout must be a positive integer")
+
+    return timeout_int
+
+
+def resolve_timeout(timeout: int | None = None) -> int:
+    if timeout is not None:
+        return _coerce_timeout(timeout)
+
+    env_timeout = os.getenv(TIMEOUT_ENV_VAR)
+    if env_timeout:
+        try:
+            return _coerce_timeout(env_timeout)
+        except ValueError:
+            logger.warning(
+                "Invalid %s value '%s'; falling back to default of %s seconds",
+                TIMEOUT_ENV_VAR,
+                env_timeout,
+                DEFAULT_LLM_TIMEOUT_SECONDS,
+            )
+
+    return DEFAULT_LLM_TIMEOUT_SECONDS
 
 
 class LLMConfig:
@@ -8,6 +48,7 @@ class LLMConfig:
         temperature: float = 0,
         enable_prompt_caching: bool = True,
         prompt_modules: list[str] | None = None,
+        timeout: int | None = None,
     ):
         self.model_name = model_name or os.getenv("STRIX_LLM", "openai/gpt-5")
 
@@ -17,3 +58,4 @@ class LLMConfig:
         self.temperature = max(0.0, min(1.0, temperature))
         self.enable_prompt_caching = enable_prompt_caching
         self.prompt_modules = prompt_modules or []
+        self.timeout = resolve_timeout(timeout)

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -123,7 +123,7 @@ class LLM:
         self._total_stats = RequestStats()
         self._last_request_stats = RequestStats()
 
-        self.memory_compressor = MemoryCompressor()
+        self.memory_compressor = MemoryCompressor(timeout=self.config.timeout)
 
         if agent_name:
             prompt_dir = Path(__file__).parent.parent / "agents" / agent_name
@@ -359,7 +359,7 @@ class LLM:
             "model": self.config.model_name,
             "messages": messages,
             "temperature": self.config.temperature,
-            "timeout": 180,
+            "timeout": self.config.timeout,
         }
 
         if self._should_include_stop_param():

--- a/strix/llm/memory_compressor.py
+++ b/strix/llm/memory_compressor.py
@@ -3,6 +3,7 @@ import os
 from typing import Any
 
 import litellm
+from strix.llm.config import resolve_timeout
 
 
 logger = logging.getLogger(__name__)
@@ -85,6 +86,7 @@ def _extract_message_text(msg: dict[str, Any]) -> str:
 def _summarize_messages(
     messages: list[dict[str, Any]],
     model: str,
+    timeout: int,
 ) -> dict[str, Any]:
     if not messages:
         empty_summary = "<context_summary message_count='0'>{text}</context_summary>"
@@ -106,7 +108,7 @@ def _summarize_messages(
         completion_args = {
             "model": model,
             "messages": [{"role": "user", "content": prompt}],
-            "timeout": 180,
+            "timeout": timeout,
         }
 
         response = litellm.completion(**completion_args)
@@ -146,9 +148,11 @@ class MemoryCompressor:
         self,
         max_images: int = 3,
         model_name: str | None = None,
+        timeout: int | None = None,
     ):
         self.max_images = max_images
         self.model_name = model_name or os.getenv("STRIX_LLM", "openai/gpt-5")
+        self.timeout = resolve_timeout(timeout)
 
         if not self.model_name:
             raise ValueError("STRIX_LLM environment variable must be set and not empty")
@@ -202,7 +206,7 @@ class MemoryCompressor:
         chunk_size = 10
         for i in range(0, len(old_msgs), chunk_size):
             chunk = old_msgs[i : i + chunk_size]
-            summary = _summarize_messages(chunk, model_name)
+            summary = _summarize_messages(chunk, model_name, self.timeout)
             if summary:
                 compressed.append(summary)
 


### PR DESCRIPTION
Fixes #58

This PR adds configurable timeout support for LLM requests via the `STRIX_LLM_TIMEOUT` environment variable, while maintaining 180 seconds as the default.

## Changes
- Added `resolve_timeout()` helper function in `strix/llm/config.py` to read timeout from environment variable
- Updated `LLMConfig` to accept and store timeout configuration
- Updated `LLM._make_request()` to use configured timeout instead of hardcoded 180s
- Updated `MemoryCompressor` to use configured timeout for summarization requests
- Added documentation in README.md and CONTRIBUTING.md

## Testing
- All code changes have been verified with linters (no errors)
- Note: The repository currently has no test suite, so pytest fails on coverage requirements