### PR TITLE
Add support for file-based instructions

### DIFF
--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -267,8 +267,12 @@ Examples:
   strix --target https://github.com/user/repo --target https://example.com
   strix --target ./my-project --target https://staging.example.com --target https://prod.example.com
 
-  # Custom instructions
+  # Custom instructions (inline)
   strix --target example.com --instruction "Focus on authentication vulnerabilities"
+
+  # Custom instructions (from file)
+  strix --target example.com --instruction ./instructions.txt
+  strix --target https://app.com --instruction /path/to/detailed_instructions.md
         """,
     )
 
@@ -289,7 +293,9 @@ Examples:
         "testing approaches (e.g., 'Perform thorough authentication testing'), "
         "test credentials (e.g., 'Use the following credentials to access the app: "
         "admin:password123'), "
-        "or areas of interest (e.g., 'Check login API endpoint for security issues')",
+        "or areas of interest (e.g., 'Check login API endpoint for security issues'). "
+        "You can also provide a path to a file containing detailed instructions "
+        "(e.g., '--instruction ./instructions.txt').",
     )
 
     parser.add_argument(
@@ -309,6 +315,17 @@ Examples:
     )
 
     args = parser.parse_args()
+
+    if args.instruction:
+        instruction_path = Path(args.instruction)
+        if instruction_path.exists() and instruction_path.is_file():
+            try:
+                with instruction_path.open(encoding="utf-8") as f:
+                    args.instruction = f.read().strip()
+                    if not args.instruction:
+                        parser.error(f"Instruction file '{instruction_path}' is empty")
+            except Exception as e:  # noqa: BLE001
+                parser.error(f"Failed to read instruction file '{instruction_path}': {e}")
 
     args.targets_info = []
     for target in args.target:


### PR DESCRIPTION
This PR adds the ability to provide detailed penetration test instructions via a file path, making Strix more focused and aware of the solution being tested.

Previously, users could only provide instructions as inline command-line arguments, which was limiting for complex scenarios.

The `--instruction` argument now accepts either:
1. **Inline text** (existing behavior): `--instruction "Focus on auth vulnerabilities"`
2. **File path** (new): `--instruction ./instructions.txt`

Closes #116 