### PR TITLE
fix: add thinking blocks

### DIFF
--- a/strix/agents/base_agent.py
+++ b/strix/agents/base_agent.py
@@ -269,7 +269,7 @@ class BaseAgent(metaclass=AgentMeta):
 
         if self.state.has_waiting_timeout():
             self.state.resume_from_waiting()
-            self.state.add_message("assistant", "Waiting timeout reached. Resuming execution.")
+            self.state.add_message("user", "Waiting timeout reached. Resuming execution.")
 
             from strix.telemetry.tracer import get_global_tracer
 
@@ -369,7 +369,8 @@ class BaseAgent(metaclass=AgentMeta):
             self.state.add_message("user", corrective_message)
             return False
 
-        self.state.add_message("assistant", response.content)
+        thinking_blocks = getattr(response, "thinking_blocks", None)
+        self.state.add_message("assistant", response.content, thinking_blocks=thinking_blocks)
         if tracer:
             tracer.log_chat_message(
                 content=clean_content(response.content),

--- a/strix/agents/state.py
+++ b/strix/agents/state.py
@@ -43,8 +43,11 @@ class AgentState(BaseModel):
         self.iteration += 1
         self.last_updated = datetime.now(UTC).isoformat()
 
-    def add_message(self, role: str, content: Any) -> None:
-        self.messages.append({"role": role, "content": content})
+    def add_message(self, role: str, content: Any, thinking_blocks: list[dict[str, Any]] | None = None) -> None:
+        message = {"role": role, "content": content}
+        if thinking_blocks:
+            message["thinking_blocks"] = thinking_blocks
+        self.messages.append(message)
         self.last_updated = datetime.now(UTC).isoformat()
 
     def add_action(self, action: dict[str, Any]) -> None:


### PR DESCRIPTION
This PR fixes a critical issue https://github.com/usestrix/strix/issues/156 that makes impossible to use important reasoning models, such as claude-4.5 or haiku, by returning `thinking_blocks` when the previous assistant response had them. 

Recently a related PR (https://github.com/BerriAI/litellm/pull/17106) was merged in litellm. That PR basically removes thinking when thinking_blocks are not returned as a workaround to avoid errors. Having said that, that limits the capabilities of the reasoning LLMs. For that reason, litellm clients such as Strix need to handle the return of the thinking_blocks by themshelves, at least for reasoning models.

Ref: https://docs.litellm.ai/docs/reasoning_content
Ref: https://github.com/BerriAI/litellm/issues/14194
Ref: https://github.com/BerriAI/litellm/issues/9020

NOTE: I considered that one of the messages that was being sent as 'assistant' was incorrect and had to be sent as 'user' so I changed that as well. Please correct me if I'm wrong.

Tested with 
- "anthropic/claude-haiku-4-5" 
- on a Mac air M2.
- python 3.12.9
- latest strix commit
- see errors in the issues