### PR TITLE
Replace libasound2  with libasound2t64

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -40,9 +40,10 @@ RUN apt-get update && \
     gdb \
     tmux \
     libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libatspi2.0-0 \
-    libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libxkbcommon0 libpango-1.0-0 libcairo2 libasound2 \
+    libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libxkbcommon0 libpango-1.0-0 libcairo2 libasound2t64 \
     fonts-unifont fonts-noto-color-emoji fonts-freefont-ttf fonts-dejavu-core ttf-bitstream-vera \
     libnss3-tools
+
 
 RUN setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip $(which nmap)
 


### PR DESCRIPTION
When I built Docker  image 

docker build --platform linux/arm64 -t hongchao-strix-sandbox:latest -f containers/Dockerfile .

I got  and error 

`ERROR: failed to build: failed to solve: process "/bin/sh -c apt-get update &&     apt-get install -y --no-install-recommends     wget curl git vim nano unzip tar     apt-transport-https ca-certificates gnupg lsb-release     build-essential software-properties-common     gcc libc6-dev pkg-config libpcap-dev libssl-dev     python3 python3-pip python3-dev python3-venv python3-setuptools     golang-go     net-tools dnsutils whois     jq parallel ripgrep grep     less man-db procps htop     iproute2 iputils-ping netcat-traditional     nmap ncat ndiff     sqlmap nuclei subfinder naabu ffuf     nodejs npm pipx     libcap2-bin     gdb     tmux     libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libatspi2.0-0     libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libxkbcommon0 libpango-1.0-0 libcairo2 libasound2     fonts-unifont fonts-noto-color-emoji fonts-freefont-ttf fonts-dejavu-core ttf-bitstream-vera     libnss3-tools" did not complete successfully: exit code: 100`

The error is due to libasound2 being a virtual package in newer Kali/Debian. Replace it with libasound2t64.