### PR TITLE
feat: enable container access to localhost targets

### DIFF
--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -30,9 +30,10 @@ from strix.interface.utils import (
     image_exists,
     infer_target_type,
     process_pull_line,
+    rewrite_localhost_targets,
     validate_llm_response,
 )
-from strix.runtime.docker_runtime import STRIX_IMAGE
+from strix.runtime.docker_runtime import HOST_GATEWAY_HOSTNAME, STRIX_IMAGE
 from strix.telemetry.tracer import get_global_tracer
 
 
@@ -377,6 +378,7 @@ Examples:
             parser.error(f"Invalid target '{target}'")
 
     assign_workspace_subdirs(args.targets_info)
+    rewrite_localhost_targets(args.targets_info, HOST_GATEWAY_HOSTNAME)
 
     return args
 

--- a/strix/runtime/docker_runtime.py
+++ b/strix/runtime/docker_runtime.py
@@ -15,6 +15,7 @@ from .runtime import AbstractRuntime, SandboxInfo
 
 
 STRIX_IMAGE = os.getenv("STRIX_IMAGE", "ghcr.io/usestrix/strix-sandbox:0.1.10")
+HOST_GATEWAY_HOSTNAME = "host.docker.internal"
 logger = logging.getLogger(__name__)
 
 
@@ -121,7 +122,9 @@ class DockerRuntime(AbstractRuntime):
                         "CAIDO_PORT": str(caido_port),
                         "TOOL_SERVER_PORT": str(tool_server_port),
                         "TOOL_SERVER_TOKEN": tool_server_token,
+                        "HOST_GATEWAY": HOST_GATEWAY_HOSTNAME,
                     },
+                    extra_hosts=self._get_extra_hosts(),
                     tty=True,
                 )
 
@@ -380,6 +383,9 @@ class DockerRuntime(AbstractRuntime):
             return parsed.hostname
 
         return "127.0.0.1"
+
+    def _get_extra_hosts(self) -> dict[str, str]:
+        return {HOST_GATEWAY_HOSTNAME: "host-gateway"}
 
     async def destroy_sandbox(self, container_id: str) -> None:
         logger.info("Destroying scan container %s", container_id)


### PR DESCRIPTION
Rewrite localhost/127.x.x.x/0.0.0.0 target URLs to use host.docker.internal, allowing the container to reach services running on the host machine.

- Add extra_hosts mapping for host.docker.internal on Linux
- Add HOST_GATEWAY env var to container
- Add rewrite_localhost_targets() to transform localhost URLs
- Support full 127.0.0.0/8 loopback range and IPv6 ::1