### PR TITLE
chore(prompt): remove stop words and enforce single tool call per message

### DIFF
--- a/strix/agents/StrixAgent/system_prompt.jinja
+++ b/strix/agents/StrixAgent/system_prompt.jinja
@@ -308,9 +308,9 @@ Tool calls use XML format:
 
 CRITICAL RULES:
 0. While active in the agent loop, EVERY message you output MUST be a single tool call. Do not send plain text-only responses.
-1. One tool call per message
+1. Exactly one tool call per message — never include more than one <function>...</function> block in a single LLM message.
 2. Tool call must be last in message
-3. EVERY tool call MUST end with </function>. This is MANDATORY. Never omit the closing tag. The </function> tag is your stop word - end your response immediately after it.
+3. EVERY tool call MUST end with </function>. This is MANDATORY. Never omit the closing tag. End your response immediately after </function>.
 4. Use ONLY the exact XML format shown above. NEVER use JSON/YAML/INI or any other syntax for tools or parameters.
 5. Tool names must match exactly the tool "name" defined (no module prefixes, dots, or variants).
    - Correct: <function=think> ... </function>

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -141,6 +141,8 @@ class LLM:
                     accumulated = accumulated[
                         : accumulated.find("</function>") + len("</function>")
                     ]
+                    yield LLMResponse(content=accumulated)
+                    break
                 yield LLMResponse(content=accumulated)
 
         if chunks:
@@ -189,7 +191,6 @@ class LLM:
             "messages": messages,
             "timeout": self.config.timeout,
             "stream_options": {"include_usage": True},
-            "stop": ["</function>"],
         }
 
         if api_key := Config.get("llm_api_key"):


### PR DESCRIPTION
## Changes

- **Remove `</function>` stop word** from LLM completion args - caused infinite loops as model would stop before outputting the closing tag
- **Add early break** in streaming once complete tool call detected - saves tokens and prevents over-generation
- **Update system prompt** to explicitly require exactly one tool call per LLM message
- Remove confusing "stop word" terminology from prompt

## Why

The stop word `</function>` was preventing the model from outputting the closing tag, causing:
1. Streaming to never detect completion (infinite loop)
2. Incomplete tool calls that needed fixing
3. Extra token usage and confusion

## Solution

Let the model naturally complete tool calls and break early once `</function>` is detected in the stream.