### PR TITLE
chore(prompt): reduce literal \n in tool parameters

### DIFF
--- a/strix/agents/StrixAgent/system_prompt.jinja
+++ b/strix/agents/StrixAgent/system_prompt.jinja
@@ -312,13 +312,14 @@ CRITICAL RULES:
 2. Tool call must be last in message
 3. EVERY tool call MUST end with </function>. This is MANDATORY. Never omit the closing tag. End your response immediately after </function>.
 4. Use ONLY the exact XML format shown above. NEVER use JSON/YAML/INI or any other syntax for tools or parameters.
-5. Tool names must match exactly the tool "name" defined (no module prefixes, dots, or variants).
+5. When sending ANY multi-line content in tool parameters, use real newlines (actual line breaks). Do NOT emit literal "\n" sequences. If you send "\n" instead of real line breaks inside the XML parameter value, tools may fail or behave incorrectly.
+6. Tool names must match exactly the tool "name" defined (no module prefixes, dots, or variants).
    - Correct: <function=think> ... </function>
    - Incorrect: <thinking_tools.think> ... </function>
    - Incorrect: <think> ... </think>
    - Incorrect: {"think": {...}}
-6. Parameters must use <parameter=param_name>value</parameter> exactly. Do NOT pass parameters as JSON or key:value lines. Do NOT add quotes/braces around values.
-7. Do NOT wrap tool calls in markdown/code fences or add any text before or after the tool block.
+7. Parameters must use <parameter=param_name>value</parameter> exactly. Do NOT pass parameters as JSON or key:value lines. Do NOT add quotes/braces around values.
+8. Do NOT wrap tool calls in markdown/code fences or add any text before or after the tool block.
 
 Example (agent creation tool):
 <function=create_agent>

--- a/strix/tools/python/python_actions_schema.xml
+++ b/strix/tools/python/python_actions_schema.xml
@@ -55,6 +55,7 @@
          - Print statements and stdout are captured
          - Variables persist between executions in the same session
          - Imports, function definitions, etc. persist in the session
+         - IMPORTANT (multiline): Put real line breaks in <parameter=code>. Do NOT emit literal "\n" sequences.
          - IPython magic commands are fully supported (%pip, %time, %whos, %%writefile, etc.)
          - Line magics (%) and cell magics (%%) work as expected
       6. CLOSE: Terminates the session completely and frees memory
@@ -71,6 +72,14 @@
       import base64
       import json
       print("Security analysis session started")</parameter>
+      </function>
+
+      <function=python_action>
+      <parameter=action>execute</parameter>
+      <parameter=code>import requests
+url = "https://example.com"
+resp = requests.get(url, timeout=10)
+print(resp.status_code)</parameter>
       </function>
 
       # Analyze security data in the default session

--- a/strix/tools/terminal/terminal_actions_schema.xml
+++ b/strix/tools/terminal/terminal_actions_schema.xml
@@ -95,6 +95,12 @@
   <parameter=command>ls -la</parameter>
   </function>
 
+  <function=terminal_execute>
+  <parameter=command>cd /workspace
+pwd
+ls -la</parameter>
+  </function>
+
   # Run a command with custom timeout
   <function=terminal_execute>
   <parameter=command>npm install</parameter>


### PR DESCRIPTION
## Problem
Some models sometimes emit literal \n sequences inside XML tool parameter values (e.g., python code), instead of real line breaks. This can cause tools to receive a single-line string and fail or behave incorrectly.

## Changes
- Strengthen Strix system prompt rule: multi-line tool parameters must use real newlines, and literal \n can break tools
- Add clearer multi-line examples in tool schemas (terminal/python) to bias models toward real newlines

## Notes
This doesn't change tool execution logic; it improves instruction/examples to reduce malformed tool calls.