### PR TITLE
fix(config): canonicalize LLM env handling

### DIFF
--- a/strix/config/config.py
+++ b/strix/config/config.py
@@ -126,8 +126,9 @@ class Config:
                 env_vars.pop(var_name, None)
             cls.save({"env": env_vars})
         if cls._llm_env_changed(env_vars):
-            cls.save({"env": {}})
-            return {}
+            for var_name in cls._llm_env_vars():
+                env_vars.pop(var_name, None)
+            cls.save({"env": env_vars})
         applied = {}
 
         for var_name, var_value in env_vars.items():


### PR DESCRIPTION
## Summary
- Discard saved LLM config when any current LLM env var differs
- Treat explicitly empty env vars as cleared so saved values are removed