### PR TITLE
refactor: share single browser instance across all agents

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && \
 
 RUN useradd -m -s /bin/bash pentester && \
     usermod -aG sudo pentester && \
-    echo "pentester ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+    echo "pentester ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+    touch /home/pentester/.hushlogin
 
 RUN mkdir -p /home/pentester/configs \
              /home/pentester/wordlists \

--- a/strix/tools/browser/browser_actions_schema.xml
+++ b/strix/tools/browser/browser_actions_schema.xml
@@ -91,6 +91,12 @@
       code normally. It can be single line or multi-line.
   13. For form filling, click on the field first, then use 'type' to enter text.
   14. The browser runs in headless mode using Chrome engine for security and performance.
+  15. RESOURCE MANAGEMENT:
+      - ALWAYS close tabs you no longer need using 'close_tab' action.
+      - ALWAYS close the browser with 'close' action when you have completely finished
+        all browser-related tasks. Do not leave the browser running if you're done with it.
+      - If you opened multiple tabs, close them as soon as you've extracted the needed
+        information from each one.
     </notes>
     <examples>
   # Launch browser at URL (creates tab_1)


### PR DESCRIPTION
## Summary
- Use singleton browser with isolated BrowserContext per agent instead of separate Chromium processes per agent
- Add cleanup logic for stale browser/playwright on reconnect
- Add resource management instructions to browser schema (close tabs/browser when done)
- Suppress Kali login message in Dockerfile