### PR TITLE
fix: Add explicit UTF-8 encoding to read_text() calls

### DIFF
--- a/strix/skills/__init__.py
+++ b/strix/skills/__init__.py
@@ -130,7 +130,7 @@ def load_skills(skill_names: list[str]) -> dict[str, str]:
             if skill_path and (skills_dir / skill_path).exists():
                 full_path = skills_dir / skill_path
                 var_name = skill_name.split("/")[-1]
-                content = full_path.read_text()
+                content = full_path.read_text(encoding="utf-8")
                 content = _FRONTMATTER_PATTERN.sub("", content).lstrip()
                 skill_content[var_name] = content
                 logger.info(f"Loaded skill: {skill_name} -> {var_name}")

--- a/strix/tools/registry.py
+++ b/strix/tools/registry.py
@@ -48,7 +48,7 @@ def _load_xml_schema(path: Path) -> Any:
     if not path.exists():
         return None
     try:
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
 
         content = _process_dynamic_content(content)
 


### PR DESCRIPTION
## Summary
- `Path.read_text()` without encoding uses the system default (e.g. `cp949` on Korean Windows, `shift_jis` on Japanese Windows), causing `UnicodeDecodeError` when reading UTF-8 files
- Added `encoding="utf-8"` to all `read_text()` calls that were missing it:
  - `strix/tools/registry.py` — XML schema loading
  - `strix/skills/__init__.py` — skill markdown loading

Solves #302 

## Error reproduced
```
Error loading schema file ...\finish_actions_schema.xml:
'cp949' codec can't decode byte 0xe2 in position 2495: illegal multibyte sequence
```

## Test plan
- [x] Verify Strix launches without encoding errors on non-English Windows (Korean, Japanese, etc.)
- [x] Verify no regression on Linux/macOS where default encoding is already UTF-8