### PR TITLE
docs: fix Discord badge expired invite code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <a href="https://docs.strix.ai"><img src="https://img.shields.io/badge/Docs-docs.strix.ai-2b9246?style=for-the-badge&logo=gitbook&logoColor=white" alt="Docs"></a>
 <a href="https://strix.ai"><img src="https://img.shields.io/badge/Website-strix.ai-f0f0f0?style=for-the-badge&logoColor=000000" alt="Website"></a>
-[![](https://dcbadge.limes.pink/api/server/8Suzzd9z)](https://discord.gg/strix-ai)
+[![](https://dcbadge.limes.pink/api/server/strix-ai)](https://discord.gg/strix-ai)
 
 <a href="https://deepwiki.com/usestrix/strix"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 <a href="https://github.com/usestrix/strix"><img src="https://img.shields.io/github/stars/usestrix/strix?style=flat-square" alt="GitHub Stars"></a>


### PR DESCRIPTION
## Summary

Fix the Discord badge in README.md that displays "Invalid invite" error.

Fixes #313

## Changes

- Update the Discord badge URL from `dcbadge.limes.pink/api/server/8Suzzd9z` (expired invite code) to `dcbadge.limes.pink/api/server/strix-ai` (valid vanity URL)
- The clickable invite link (`discord.gg/strix-ai`) was already correct -- only the badge image source needed updating

## Test plan

- [x] Verified `https://dcbadge.limes.pink/api/server/strix-ai` returns a valid badge SVG showing correct server name and member count
- [x] Verified the expired code `8Suzzd9z` renders "Invalid invite" error
- [x] No other files affected