### PR TITLE
feat: Expose Caido proxy port for human-in-the-loop

### DIFF
--- a/containers/docker-entrypoint.sh
+++ b/containers/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ ! -f /app/certs/ca.p12 ]; then
   exit 1
 fi
 
-caido-cli --listen 127.0.0.1:${CAIDO_PORT} \
+caido-cli --listen 0.0.0.0:${CAIDO_PORT} \
           --allow-guests \
           --no-logging \
           --no-open \

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -51,7 +51,7 @@ Configure Strix using environment variables or a config file.
 
 ## Docker Configuration
 
-<ParamField path="STRIX_IMAGE" default="ghcr.io/usestrix/strix-sandbox:0.1.11" type="string">
+<ParamField path="STRIX_IMAGE" default="ghcr.io/usestrix/strix-sandbox:0.1.12" type="string">
   Docker image to use for the sandbox container.
 </ParamField>
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 APP=strix
 REPO="usestrix/strix"
-STRIX_IMAGE="ghcr.io/usestrix/strix-sandbox:0.1.11"
+STRIX_IMAGE="ghcr.io/usestrix/strix-sandbox:0.1.12"
 
 MUTED='\033[0;2m'
 RED='\033[0;31m'

--- a/strix/agents/base_agent.py
+++ b/strix/agents/base_agent.py
@@ -333,6 +333,14 @@ class BaseAgent(metaclass=AgentMeta):
 
                 if "agent_id" in sandbox_info:
                     self.state.sandbox_info["agent_id"] = sandbox_info["agent_id"]
+
+                caido_port = sandbox_info.get("caido_port")
+                if caido_port:
+                    from strix.telemetry.tracer import get_global_tracer
+
+                    tracer = get_global_tracer()
+                    if tracer:
+                        tracer.caido_url = f"localhost:{caido_port}"
             except Exception as e:
                 from strix.telemetry import posthog
 

--- a/strix/config/config.py
+++ b/strix/config/config.py
@@ -40,7 +40,7 @@ class Config:
     strix_disable_browser = "false"
 
     # Runtime Configuration
-    strix_image = "ghcr.io/usestrix/strix-sandbox:0.1.11"
+    strix_image = "ghcr.io/usestrix/strix-sandbox:0.1.12"
     strix_runtime_backend = "docker"
     strix_sandbox_execution_timeout = "120"
     strix_sandbox_connect_timeout = "10"

--- a/strix/interface/assets/tui_styles.tcss
+++ b/strix/interface/assets/tui_styles.tcss
@@ -77,11 +77,20 @@ Toast.-information .toast--title {
     margin-bottom: 0;
 }
 
-#stats_display {
+#stats_scroll {
     height: auto;
     max-height: 15;
     background: transparent;
     padding: 0;
+    margin: 0;
+    border: round #333333;
+    scrollbar-size: 0 0;
+}
+
+#stats_display {
+    height: auto;
+    background: transparent;
+    padding: 0 1;
     margin: 0;
 }
 

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -462,7 +462,7 @@ def display_completion_message(args: argparse.Namespace, results_path: Path) -> 
     console.print("\n")
     console.print(panel)
     console.print()
-    console.print("[#60a5fa]models.strix.ai[/]")
+    console.print("[#60a5fa]models.strix.ai[/]  [dim]·[/]  [#60a5fa]discord.gg/strix-ai[/]")
     console.print()
 
 

--- a/strix/interface/tui.py
+++ b/strix/interface/tui.py
@@ -829,11 +829,11 @@ class StrixTUIApp(App):  # type: ignore[misc]
             agents_tree.guide_style = "dashed"
 
             stats_display = Static("", id="stats_display")
-            stats_display.ALLOW_SELECT = False
+            stats_scroll = VerticalScroll(stats_display, id="stats_scroll")
 
             vulnerabilities_panel = VulnerabilitiesPanel(id="vulnerabilities_panel")
 
-            sidebar = Vertical(agents_tree, vulnerabilities_panel, stats_display, id="sidebar")
+            sidebar = Vertical(agents_tree, vulnerabilities_panel, stats_scroll, id="sidebar")
 
             content_container.mount(chat_area_container)
             content_container.mount(sidebar)
@@ -1272,6 +1272,9 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if not self._is_widget_safe(stats_display):
             return
 
+        if self.screen.selections:
+            return
+
         stats_content = Text()
 
         stats_text = build_tui_stats_text(self.tracer, self.agent_config)
@@ -1281,15 +1284,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         version = get_package_version()
         stats_content.append(f"\nv{version}", style="white")
 
-        from rich.panel import Panel
-
-        stats_panel = Panel(
-            stats_content,
-            border_style="#333333",
-            padding=(0, 1),
-        )
-
-        self._safe_widget_operation(stats_display.update, stats_panel)
+        self._safe_widget_operation(stats_display.update, stats_content)
 
     def _update_vulnerabilities_panel(self) -> None:
         """Update the vulnerabilities panel with current vulnerability data."""

--- a/strix/interface/utils.py
+++ b/strix/interface/utils.py
@@ -390,6 +390,12 @@ def build_tui_stats_text(tracer: Any, agent_config: dict[str, Any] | None = None
         stats_text.append(" · ", style="white")
         stats_text.append(f"${total_stats['cost']:.2f}", style="white")
 
+    caido_url = getattr(tracer, "caido_url", None)
+    if caido_url:
+        stats_text.append("\n")
+        stats_text.append("Caido: ", style="bold white")
+        stats_text.append(caido_url, style="white")
+
     return stats_text
 
 

--- a/strix/runtime/runtime.py
+++ b/strix/runtime/runtime.py
@@ -7,6 +7,7 @@ class SandboxInfo(TypedDict):
     api_url: str
     auth_token: str | None
     tool_server_port: int
+    caido_port: int
     agent_id: str
 
 

--- a/strix/telemetry/tracer.py
+++ b/strix/telemetry/tracer.py
@@ -56,6 +56,7 @@ class Tracer:
         self._next_message_id = 1
         self._saved_vuln_ids: set[str] = set()
 
+        self.caido_url: str | None = None
         self.vulnerability_found_callback: Callable[[dict[str, Any]], None] | None = None
 
     def set_run_name(self, run_name: str) -> None:


### PR DESCRIPTION
## Summary
- Exposes the Caido proxy port (48080) from the Docker container to a random host port, allowing users to access the Caido web UI in their browser for human-in-the-loop testing
- Displays the Caido URL in the TUI sidebar stats panel with selectable/copyable text
- Bumps sandbox image to 0.1.12, restores discord link in exit screen