### PR TITLE
fix: Change VERTEXAI_LOCATION from 'us-central1' to 'global'

### DIFF
--- a/docs/llm-providers/vertex.mdx
+++ b/docs/llm-providers/vertex.mdx
@@ -44,7 +44,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
 
 ```bash
 export VERTEXAI_PROJECT="your-project-id"
-export VERTEXAI_LOCATION="us-central1"
+export VERTEXAI_LOCATION="global"
 ```
 
 ## Prerequisites


### PR DESCRIPTION
Took me days to figure out :

us-central1 doesn't have access to the latest gemini models like gemini-3-flash-preview, the best you can get is gemini-2.5

As can be seen here https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#united-states

<img width="2331" height="792" alt="Untitled" src="https://github.com/user-attachments/assets/7b5a7774-267a-4985-bcb8-1960c84e1113" />

Changing it finally allows me to use gemini-3-flash-preview, I tested it and it finally launches. I had wrongly assumed it wasn't possible to use gemini-3!

Edit: screenshot to show it works now:
<img width="2279" height="1572" alt="image" src="https://github.com/user-attachments/assets/d8a7eb7d-9d23-42fc-81c8-97b04689b2ba" />
