### PR TITLE
fix: web_search tool not loading when API key is in config file

### DIFF
--- a/strix/tools/__init__.py
+++ b/strix/tools/__init__.py
@@ -24,9 +24,22 @@ from .registry import (
 
 SANDBOX_MODE = os.getenv("STRIX_SANDBOX_MODE", "false").lower() == "true"
 
-HAS_PERPLEXITY_API = bool(Config.get("perplexity_api_key"))
 
-DISABLE_BROWSER = (Config.get("strix_disable_browser") or "false").lower() == "true"
+def _is_browser_disabled() -> bool:
+    if os.getenv("STRIX_DISABLE_BROWSER", "").lower() == "true":
+        return True
+    val: str = Config.load().get("env", {}).get("STRIX_DISABLE_BROWSER", "")
+    return str(val).lower() == "true"
+
+
+DISABLE_BROWSER = _is_browser_disabled()
+
+
+def _has_perplexity_api() -> bool:
+    if os.getenv("PERPLEXITY_API_KEY"):
+        return True
+    return bool(Config.load().get("env", {}).get("PERPLEXITY_API_KEY"))
+
 
 if not SANDBOX_MODE:
     from .agents_graph import *  # noqa: F403
@@ -43,7 +56,7 @@ if not SANDBOX_MODE:
     from .thinking import *  # noqa: F403
     from .todo import *  # noqa: F403
 
-    if HAS_PERPLEXITY_API:
+    if _has_perplexity_api():
         from .web_search import *  # noqa: F403
 else:
     if not DISABLE_BROWSER:


### PR DESCRIPTION
## Summary

- Fixes the `web_search` tool never being loaded when the Perplexity API key is set via `~/.strix/cli-config.json` rather than as an environment variable

## Root Cause

`strix/tools/__init__.py` checked `Config.get("perplexity_api_key")` at import time, which calls `os.getenv("PERPLEXITY_API_KEY")`. But the config file hasn't been applied to env vars yet at that point (that happens later in `apply_saved_config()`), so the check always returned `False`.

The module gets imported early via: `main.py` → `strix.llm.utils` → `strix.llm.llm` → `from strix.tools import get_tools_prompt` — all before `apply_saved_config()` on line 25 of `main.py`.

## Fix

Replace the eager `HAS_PERPLEXITY_API = bool(Config.get(...))` with a `_has_perplexity_api()` function that:
1. Checks `os.getenv("PERPLEXITY_API_KEY")` first (fast path, works for SaaS/env var)
2. Falls back to `Config.load()` which reads `~/.strix/cli-config.json` directly (works at import time, no env var dependency)