### PR TITLE
fix(llm): include system prompt tokens in memory compressor budget

### DIFF
--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -10,7 +10,7 @@ from litellm.utils import supports_prompt_caching, supports_vision
 
 from strix.config import Config
 from strix.llm.config import LLMConfig
-from strix.llm.memory_compressor import MemoryCompressor
+from strix.llm.memory_compressor import MemoryCompressor, _get_message_tokens
 from strix.llm.utils import (
     _truncate_to_first_function,
     fix_incomplete_tool_call,
@@ -210,7 +210,12 @@ class LLM:
                 }
             )
 
-        compressed = list(self.memory_compressor.compress_history(conversation_history))
+        reserved_tokens = sum(
+            _get_message_tokens(msg, self.config.litellm_model) for msg in messages
+        )
+        compressed = list(
+            self.memory_compressor.compress_history(conversation_history, reserved_tokens)
+        )
         conversation_history.clear()
         conversation_history.extend(compressed)
         messages.extend(compressed)

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -10,7 +10,7 @@ from litellm.utils import supports_prompt_caching, supports_vision
 
 from strix.config import Config
 from strix.llm.config import LLMConfig
-from strix.llm.memory_compressor import MemoryCompressor, _get_message_tokens
+from strix.llm.memory_compressor import MemoryCompressor, get_message_tokens
 from strix.llm.utils import (
     _truncate_to_first_function,
     fix_incomplete_tool_call,
@@ -211,7 +211,7 @@ class LLM:
             )
 
         reserved_tokens = sum(
-            _get_message_tokens(msg, self.config.litellm_model) for msg in messages
+            get_message_tokens(msg, self.config.litellm_model) for msg in messages
         )
         compressed = list(
             self.memory_compressor.compress_history(conversation_history, reserved_tokens)

--- a/strix/llm/memory_compressor.py
+++ b/strix/llm/memory_compressor.py
@@ -52,7 +52,7 @@ def _count_tokens(text: str, model: str) -> int:
         return len(text) // 4  # Rough estimate
 
 
-def _get_message_tokens(msg: dict[str, Any], model: str) -> int:
+def get_message_tokens(msg: dict[str, Any], model: str) -> int:
     content = msg.get("content", "")
     if isinstance(content, str):
         return _count_tokens(content, model)
@@ -209,7 +209,7 @@ class MemoryCompressor:
         model_name: str = self.model_name  # type: ignore[assignment]
 
         total_tokens = reserved_tokens + sum(
-            _get_message_tokens(msg, model_name) for msg in system_msgs + regular_msgs
+            get_message_tokens(msg, model_name) for msg in system_msgs + regular_msgs
         )
 
         if total_tokens <= MAX_TOTAL_TOKENS * 0.9:

--- a/strix/llm/memory_compressor.py
+++ b/strix/llm/memory_compressor.py
@@ -166,8 +166,15 @@ class MemoryCompressor:
     def compress_history(
         self,
         messages: list[dict[str, Any]],
+        reserved_tokens: int = 0,
     ) -> list[dict[str, Any]]:
         """Compress conversation history to stay within token limits.
+
+        Args:
+            messages: Conversation history messages to compress.
+            reserved_tokens: Tokens already reserved for system prompt and
+                other framing messages outside the conversation history.
+                Subtracted from the budget before checking limits.
 
         Strategy:
         1. Handle image limits first
@@ -201,7 +208,7 @@ class MemoryCompressor:
         # Type assertion since we ensure model_name is not None in __init__
         model_name: str = self.model_name  # type: ignore[assignment]
 
-        total_tokens = sum(
+        total_tokens = reserved_tokens + sum(
             _get_message_tokens(msg, model_name) for msg in system_msgs + regular_msgs
         )
 


### PR DESCRIPTION
## Summary

The memory compressor was not accounting for system prompt and agent identity tokens when calculating the conversation budget. This caused premature history truncation on long scans with large system prompts.

## Changes

- Add `reserved_tokens` parameter to `compress_history()` that subtracts already-accounted tokens from the budget before applying limits
- Calculate `reserved_tokens` from system prompt and agent identity messages in `_prepare_messages()`

## Files Changed

- `strix/llm/llm.py` (+7/-2)
- `strix/llm/memory_compressor.py` (+8/-1)

Split from #328.