### PR TITLE
fix: use shlex.quote() to prevent shell injection in file tools

### DIFF
--- a/strix/tools/file_edit/file_edit_actions.py
+++ b/strix/tools/file_edit/file_edit_actions.py
@@ -1,5 +1,6 @@
 import json
 import re
+import shlex
 from pathlib import Path
 from typing import Any, cast
 
@@ -77,7 +78,7 @@ def list_files(
         if not path_obj.is_dir():
             return {"error": f"Path is not a directory: {path}"}
 
-        cmd = f"find '{path}' -type f -o -type d | head -500" if recursive else f"ls -1a '{path}'"
+        cmd = f"find {shlex.quote(path)} -type f -o -type d | head -500" if recursive else f"ls -1a {shlex.quote(path)}"
 
         exit_code, stdout, stderr = run_shell_cmd(cmd)
 
@@ -127,9 +128,7 @@ def search_files(
         if not Path(path).exists():
             return {"error": f"Directory not found: {path}"}
 
-        escaped_regex = regex.replace("'", "'\"'\"'")
-
-        cmd = f"rg --line-number --glob '{file_pattern}' '{escaped_regex}' '{path}'"
+        cmd = f"rg --line-number --glob {shlex.quote(file_pattern)} {shlex.quote(regex)} {shlex.quote(path)}"
 
         exit_code, stdout, stderr = run_shell_cmd(cmd)
 


### PR DESCRIPTION
## What

`list_files` and `search_files` build their shell commands by interpolating user-controlled values directly into f-strings with single-quote wrapping:

```python
# list_files (before)
cmd = f"find '{path}' -type f -o -type d | head -500"

# search_files (before)
escaped_regex = regex.replace("'", "'\"'\"'")
cmd = f"rg --line-number --glob '{file_pattern}' '{escaped_regex}' '{path}'"
```

A value containing a single quote (e.g. a workspace directory named `it's`, a glob like `*.{js,ts}'`, or a crafted regex) breaks out of the quoting context and allows arbitrary shell commands to execute inside the sandbox container.

The manual `regex.replace("'", "'\"'\"'")` escaping also only handled the regex argument — `file_pattern` and `path` had no escaping at all.

## Fix

Replace all interpolated arguments with `shlex.quote()`, which produces a properly shell-escaped token for any input:

```python
# list_files (after)
cmd = f"find {shlex.quote(path)} -type f -o -type d | head -500"

# search_files (after)
cmd = f"rg --line-number --glob {shlex.quote(file_pattern)} {shlex.quote(regex)} {shlex.quote(path)}"
```

The manual escaping of `regex` is no longer needed and has been removed.

## Files changed

- `strix/tools/file_edit/file_edit_actions.py`

## Test plan

- [ ] `search_files` with `file_pattern="*.py'; echo pwned; echo '"` — no shell execution, command returns error or no matches
- [ ] `list_files` with a path containing a single quote — lists correctly without shell breakout
- [ ] `make check-all` passes