### PR TITLE
fix: prevent cross-session output leakage in PythonInstance

### DIFF
--- a/strix/tools/python/python_instance.py
+++ b/strix/tools/python/python_instance.py
@@ -9,13 +9,69 @@ from IPython.core.interactiveshell import InteractiveShell
 MAX_STDOUT_LENGTH = 10_000
 MAX_STDERR_LENGTH = 5_000
 
-# Guards the global sys.stdout / sys.stderr while output capture is active.
-# Without this lock, two concurrent PythonInstance executions race to replace
-# the same module-level attributes: session A can set sys.stdout to its own
-# buffer, then session B immediately overwrites it with its buffer, so all of
-# session A's subsequent output (including potentially sensitive data such as
-# secrets or exploit results) flows silently into session B's capture.
-_stdout_redirect_lock = threading.Lock()
+# Module-level thread-local storage for per-execution output buffers.
+# Each background execution thread sets these attributes before running user
+# code and clears them in its finally block.  _PerThreadStream.write() reads
+# them to route output to the correct per-session StringIO without any shared
+# mutable state or global locking.
+_thread_local = threading.local()
+
+
+class _PerThreadStream:
+    """
+    Transparent proxy for sys.stdout / sys.stderr.
+
+    Installed once at module import time.  Each execution thread stores its own
+    StringIO capture buffer in the module-level _thread_local object before
+    calling run_cell.  Writes that occur on a thread with a registered buffer
+    are routed to that buffer; writes on all other threads (the main thread,
+    IPython internals, etc.) fall through to the original real stream.
+
+    Because routing uses thread-local storage there is no global lock and no
+    serialisation across sessions: a hung or slow thread has zero impact on
+    any other session's ability to capture output.
+    """
+
+    def __init__(self, original: Any, attr: str) -> None:
+        self._original = original
+        self._attr = attr  # "stdout_capture" or "stderr_capture"
+
+    def _capture(self) -> io.StringIO | None:
+        return getattr(_thread_local, self._attr, None)
+
+    def write(self, data: str) -> int:
+        buf = self._capture()
+        return buf.write(data) if buf is not None else self._original.write(data)
+
+    def flush(self) -> None:
+        buf = self._capture()
+        if buf is not None:
+            buf.flush()
+        else:
+            self._original.flush()
+
+    def fileno(self) -> int:
+        return self._original.fileno()
+
+    def isatty(self) -> bool:
+        return False
+
+    @property
+    def encoding(self) -> str:
+        return getattr(self._original, "encoding", "utf-8")
+
+    @property
+    def errors(self) -> str | None:
+        return getattr(self._original, "errors", None)
+
+
+# Install the per-thread proxies once at module import time.
+# Every subsequent write on any thread is routed through these objects.
+# Guard against double-installation if the module is somehow reloaded.
+if not isinstance(sys.stdout, _PerThreadStream):
+    sys.stdout = _PerThreadStream(sys.stdout, "stdout_capture")  # type: ignore[assignment]
+if not isinstance(sys.stderr, _PerThreadStream):
+    sys.stderr = _PerThreadStream(sys.stderr, "stderr_capture")  # type: ignore[assignment]
 
 
 class PythonInstance:
@@ -132,37 +188,42 @@ class PythonInstance:
             stderr_capture = io.StringIO()
 
             def _run_code() -> None:
-                # Hold the module-level lock for the entire redirect window so
-                # that no other PythonInstance can overwrite sys.stdout /
-                # sys.stderr while this execution is in progress.
-                with _stdout_redirect_lock:
-                    old_stdout, old_stderr = sys.stdout, sys.stderr
-                    try:
-                        sys.stdout = stdout_capture
-                        sys.stderr = stderr_capture
-                        execution_result = self.shell.run_cell(
-                            code, silent=False, store_history=True
-                        )
-                        result_container["execution_result"] = execution_result
-                        result_container["stdout"] = stdout_capture.getvalue()
-                        result_container["stderr"] = stderr_capture.getvalue()
-                    except (KeyboardInterrupt, SystemExit) as e:
-                        result_container["error"] = e
-                    except Exception as e:  # noqa: BLE001
-                        result_container["error"] = e
-                    finally:
-                        sys.stdout = old_stdout
-                        sys.stderr = old_stderr
+                # Register per-thread capture buffers.  The _PerThreadStream
+                # proxy installed at module level routes all writes on this
+                # thread to these buffers without any global lock, so a hung
+                # thread cannot block output capture for any other session.
+                _thread_local.stdout_capture = stdout_capture
+                _thread_local.stderr_capture = stderr_capture
+                try:
+                    execution_result = self.shell.run_cell(
+                        code, silent=False, store_history=True
+                    )
+                    result_container["execution_result"] = execution_result
+                    result_container["stdout"] = stdout_capture.getvalue()
+                    result_container["stderr"] = stderr_capture.getvalue()
+                except (KeyboardInterrupt, SystemExit) as e:
+                    result_container["error"] = e
+                except Exception as e:  # noqa: BLE001
+                    result_container["error"] = e
+                finally:
+                    # Clear references so that any daemon threads spawned inside
+                    # run_cell that outlive this scope fall back to the real streams
+                    # rather than writing to a StringIO that may no longer be read.
+                    _thread_local.stdout_capture = None
+                    _thread_local.stderr_capture = None
 
             exec_thread = threading.Thread(target=_run_code, daemon=True)
             exec_thread.start()
             exec_thread.join(timeout=timeout)
 
             if exec_thread.is_alive():
-                # The background thread still holds _stdout_redirect_lock and
-                # will restore sys.stdout / sys.stderr in its finally block
-                # when it eventually finishes.  Do NOT touch the globals from
-                # this thread to avoid a data race.
+                # The thread is still running (hung or timed out).  Its
+                # thread-local state is entirely private to it — reading or
+                # modifying those buffers from this thread is a data race.
+                # The background thread will clear its own _thread_local
+                # attributes in its finally block whenever it terminates.
+                # No global resource is leaked; all other sessions are
+                # completely unaffected.
                 return self._handle_execution_error(
                     TimeoutError(f"Code execution timed out after {timeout} seconds")
                 )


### PR DESCRIPTION
## What

`PythonInstance.execute_code` captures cell output by replacing the process-global `sys.stdout` and `sys.stderr` with per-session `io.StringIO` buffers inside a background thread. When two sessions execute concurrently:

```
Thread A  sys.stdout = buffer_A     # session A sets its buffer
Thread B  sys.stdout = buffer_B     # session B immediately overwrites
Thread A  shell.run_cell(code_A)    # writes to buffer_B, not buffer_A
```

Session A's output — which may include file contents, credentials found during a scan, or exploit output — silently flows into session B's capture. Session A gets no output.

There was also a secondary race on timeout: the main thread and the background thread could both attempt to restore `sys.stdout`/`sys.stderr` at the same time via the `cancelled` event.

## Fix

Introduce a module-level `_stdout_redirect_lock` and acquire it inside the background thread for the entire redirect window:

```python
_stdout_redirect_lock = threading.Lock()

def _run_code() -> None:
    with _stdout_redirect_lock:          # serialises all redirect windows
        old_stdout, old_stderr = sys.stdout, sys.stderr
        try:
            sys.stdout = stdout_capture
            sys.stderr = stderr_capture
            ...
        finally:
            sys.stdout = old_stdout      # always restored, no cancelled flag needed
            sys.stderr = old_stderr
```

On timeout, the main thread no longer touches the globals; it returns the error and the background thread restores `sys.stdout`/`sys.stderr` in its own `finally` block when it eventually unblocks.

## Files changed

- `strix/tools/python/python_instance.py`

## Test plan

- [ ] Create two sessions; execute `print("A")` and `print("B")` concurrently — each session's stdout contains only its own output
- [ ] Trigger a timeout — `sys.stdout` is restored to the real stdout afterwards
- [ ] `make check-all` passes