### PR TITLE
fix: remove agent IDs from unauthenticated /health endpoint

### DIFF
--- a/strix/runtime/tool_server.py
+++ b/strix/runtime/tool_server.py
@@ -137,13 +137,15 @@ async def register_agent(
 
 @app.get("/health")
 async def health_check() -> dict[str, Any]:
+    # NOTE: this endpoint is intentionally unauthenticated so that the host
+    # process can poll readiness without a token.  Do NOT add internal state
+    # (agent IDs, token presence, etc.) here; any process that can reach the
+    # container's bound port would be able to enumerate that information.
     return {
         "status": "healthy",
         "sandbox_mode": str(SANDBOX_MODE),
         "environment": "sandbox" if SANDBOX_MODE else "main",
-        "auth_configured": "true" if EXPECTED_TOKEN else "false",
         "active_agents": len(agent_tasks),
-        "agents": list(agent_tasks.keys()),
     }
 
 


### PR DESCRIPTION
## What

The `/health` endpoint in the tool server is intentionally unauthenticated — it exists so the host process can poll container readiness without a token. However the response included two fields that should not be visible to unauthenticated callers:

```python
# Before
return {
    "status": "healthy",
    "sandbox_mode": str(SANDBOX_MODE),
    "environment": "sandbox" if SANDBOX_MODE else "main",
    "auth_configured": "true" if EXPECTED_TOKEN else "false",   # leaks token presence
    "active_agents": len(agent_tasks),
    "agents": list(agent_tasks.keys()),                         # leaks agent IDs
}
```

**`agents`** — exposes the full list of active agent IDs to any process that can reach the container's bound port. In a shared-network or multi-tenant environment (CI runners, shared Docker hosts) this lets an unauthenticated observer enumerate scan session identifiers, correlate scan activity, and potentially craft requests to the `/execute` endpoint using a known agent ID.

**`auth_configured`** — tells an attacker whether the server is protected by a token at all. An empty or absent token would surface here before they attempt any authenticated request.

## Fix

Remove both fields. `active_agents` (the count) is kept as a coarse liveness indicator; it reveals nothing session-specific.

```python
# After
return {
    "status": "healthy",
    "sandbox_mode": str(SANDBOX_MODE),
    "environment": "sandbox" if SANDBOX_MODE else "main",
    "active_agents": len(agent_tasks),
}
```

## Why the endpoint must stay unauthenticated

`DockerRuntime._wait_for_tool_server` polls `/health` before the sandbox token is available to the host process, so requiring auth here would break container startup. The fix keeps the endpoint public but strips the sensitive payload.

## Files changed

- `strix/runtime/tool_server.py`

## Test plan

- [ ] `GET /health` (no auth header) returns `status`, `sandbox_mode`, `environment`, `active_agents` — no `agents` list, no `auth_configured`
- [ ] Container readiness polling in `DockerRuntime._wait_for_tool_server` still works (checks `data.get("status") == "healthy"`)
- [ ] `make check-all` passes