### PR TITLE
fix: inherit proxy config in sub-agent terminal sessions

### DIFF
--- a/strix/tools/terminal/terminal_session.py
+++ b/strix/tools/terminal/terminal_session.py
@@ -77,6 +77,9 @@ class TerminalSession:
         self.pane = self.window.active_pane
         _initial_window.kill()
 
+        # Source proxy config so sub-agent terminals inherit Caido proxy + CA certs
+        self.pane.send_keys('source /etc/profile.d/proxy.sh 2>/dev/null; source ~/.bashrc 2>/dev/null; true')
+        time.sleep(0.3)
         self.pane.send_keys(f'export PROMPT_COMMAND=\'export PS1="{self.PS1}"\'; export PS2=""')
         time.sleep(0.1)
         self._clear_screen()

--- a/strix/tools/terminal/terminal_session.py
+++ b/strix/tools/terminal/terminal_session.py
@@ -77,9 +77,12 @@ class TerminalSession:
         self.pane = self.window.active_pane
         _initial_window.kill()
 
-        # Source proxy config so sub-agent terminals inherit Caido proxy + CA certs
-        self.pane.send_keys('source /etc/profile.d/proxy.sh 2>/dev/null; source ~/.bashrc 2>/dev/null; true')
-        time.sleep(0.3)
+        # Inherit Caido proxy config (small file, completes instantly)
+        self.pane.send_keys(
+            'source /etc/profile.d/proxy.sh 2>/dev/null; '
+            'export HTTP_PROXY HTTPS_PROXY REQUESTS_CA_BUNDLE; true'
+        )
+        time.sleep(0.1)
         self.pane.send_keys(f'export PROMPT_COMMAND=\'export PS1="{self.PS1}"\'; export PS2=""')
         time.sleep(0.1)
         self._clear_screen()


### PR DESCRIPTION
Fixes #430

## Problem

When the Root Agent creates sub-agents via `create_agent`, each sub-agent gets a new tmux terminal session. These sessions don't inherit the Caido proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `REQUESTS_CA_BUNDLE`) set by `docker-entrypoint.sh` in `/etc/profile.d/proxy.sh`.

This causes sub-agent commands (`curl`, `httpx`, `sqlmap`) to fail when testing external HTTPS targets.

## Fix

Source `/etc/profile.d/proxy.sh` and `~/.bashrc` in `TerminalSession.initialize()` before setting the custom PS1 prompt.

## Testing

- Ran Strix in deep mode against OWASP Juice Shop
- Sub-agents (SQLi Discovery, XSS Discovery, SSRF Discovery) were able to make HTTP requests after the fix
- Confirmed SQLi, tested XSS, and ran 118 SSRF tool calls successfully