### PR TITLE
fix: wrap acompletion in asyncio.wait_for to prevent indefinite hangs

### DIFF
--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -176,7 +176,11 @@ class LLM:
         done_streaming = 0
 
         self._total_stats.requests += 1
-        response = await acompletion(**self._build_completion_args(messages), stream=True)
+        timeout = self.config.timeout
+        response = await asyncio.wait_for(
+            acompletion(**self._build_completion_args(messages), stream=True),
+            timeout=timeout,
+        )
 
         async for chunk in response:
             chunks.append(chunk)

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -182,7 +182,12 @@ class LLM:
             timeout=timeout,
         )
 
-        async for chunk in response:
+        async_iter = response.__aiter__()
+        while True:
+            try:
+                chunk = await asyncio.wait_for(async_iter.__anext__(), timeout=timeout)
+            except StopAsyncIteration:
+                break
             chunks.append(chunk)
             if done_streaming:
                 done_streaming += 1


### PR DESCRIPTION
## Problem

When using Bedrock as the LLM provider, `acompletion(stream=True)` can hang indefinitely. The Bedrock endpoint accepts the TCP connection but never starts streaming chunks. litellm's `timeout` parameter doesn't always propagate to the underlying httpx transport for the Bedrock converse handler, leaving the await stuck forever.

This manifests as zombie scans — the strix process is alive, the Docker container is healthy, but the asyncio event loop is idle in `selectors.select()` with no pending callbacks. The scan produces no output after the initial banner.

## Root Cause

Diagnosed via `faulthandler` thread dump on a consistently-hanging target:

```
Current thread 0x00000001fab4d8c0 (most recent call first):
  File "selectors.py", line 548 in select
  File "base_events.py", line 2012 in _run_once
  File "base_events.py", line 683 in run_forever
  ...
  File "strix/interface/main.py", line 613 in main
```

The main thread is stuck in `asyncio.selectors.select()` — the event loop has no pending tasks. The `acompletion` coroutine completed (Bedrock accepted the connection) but never yielded a streaming chunk, and litellm's timeout was not enforced at the httpx transport level (`Connection timed out after None seconds`).

## Fix

Wrap the `acompletion` call in `asyncio.wait_for()` using the existing configured `LLM_TIMEOUT` (default 300s):

```python
response = await asyncio.wait_for(
    acompletion(**self._build_completion_args(messages), stream=True),
    timeout=timeout,
)
```

`asyncio.TimeoutError` has no `status_code`, so `_should_retry` returns `True` — the existing retry loop handles it automatically.

## Testing

Tested against a repository that consistently triggered the hang (5 consecutive zombie failures across Haiku and Sonnet). With the fix:

- First attempt hung as before (~5.5 min)
- `asyncio.wait_for` raised `TimeoutError`
- Retry connected successfully
- Scan completed with 4 findings ($37.69, 18M input tokens)

Also tested at scale across ~500 repos with 8 parallel workers using Bedrock Sonnet 4.6 — the fix converts indefinite hangs into recoverable timeouts.