### PR TITLE
fix: --config flag now fully overrides ~/.strix/cli-config.json

### DIFF
--- a/strix/config/config.py
+++ b/strix/config/config.py
@@ -2,7 +2,7 @@ import contextlib
 import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 
 STRIX_API_BASE = "https://models.strix.ai/api/v1"
@@ -55,6 +55,10 @@ class Config:
 
     # Config file override (set via --config CLI arg)
     _config_file_override: Path | None = None
+
+    # Tracks env vars set by the initial default-config load so they can be
+    # cleared when a --config override is later applied (avoids leakage).
+    _applied_from_default: ClassVar[dict[str, str]] = {}
 
     @classmethod
     def _tracked_names(cls) -> list[str]:
@@ -150,6 +154,11 @@ class Config:
             if var_name in cls.tracked_vars() and (force or var_name not in os.environ):
                 os.environ[var_name] = var_value
                 applied[var_name] = var_value
+
+        # Record what was applied from the default config so it can be cleared
+        # if a --config override is later provided (prevents leakage).
+        if cls._config_file_override is None and not force:
+            cls._applied_from_default = applied
 
         return applied
 

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -6,6 +6,7 @@ Strix Agent Interface
 import argparse
 import asyncio
 import logging
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -528,6 +529,12 @@ def pull_docker_image() -> None:
 
 
 def apply_config_override(config_path: str) -> None:
+    # Clear env vars that were automatically applied from the default config file
+    # so they don't leak into the custom config context.
+    for var_name in Config._applied_from_default:
+        os.environ.pop(var_name, None)
+    Config._applied_from_default = {}
+
     Config._config_file_override = validate_config_file(config_path)
     apply_saved_config(force=True)
 

--- a/tests/config/test_config_override.py
+++ b/tests/config/test_config_override.py
@@ -1,0 +1,31 @@
+import json
+import os
+import sys
+
+from strix.config.config import Config
+
+
+def test_apply_config_override_clears_default_only_vars(monkeypatch, tmp_path) -> None:
+    default_cfg = tmp_path / "cli-config.json"
+    default_cfg.write_text(
+        json.dumps({"env": {"LLM_API_BASE": "https://default.api", "STRIX_LLM": "default-model"}}),
+        encoding="utf-8",
+    )
+    custom_cfg = tmp_path / "custom.json"
+    custom_cfg.write_text(json.dumps({"env": {"STRIX_LLM": "custom-model"}}), encoding="utf-8")
+
+    monkeypatch.setattr(Config, "_config_file_override", None)
+    monkeypatch.setattr(Config, "_applied_from_default", {})
+    monkeypatch.setattr(Config, "config_dir", classmethod(lambda cls: tmp_path))
+    for var_name in Config._llm_env_vars():
+        monkeypatch.delenv(var_name, raising=False)
+    sys.modules.pop("strix.interface.main", None)
+
+    from strix.interface.main import apply_config_override
+
+    assert os.environ.get("LLM_API_BASE") == "https://default.api"
+
+    apply_config_override(str(custom_cfg))
+
+    assert os.environ.get("STRIX_LLM") == "custom-model"
+    assert "LLM_API_BASE" not in os.environ

--- a/tests/config/test_config_override.py
+++ b/tests/config/test_config_override.py
@@ -1,11 +1,12 @@
 import json
 import os
-import sys
 
-from strix.config.config import Config
+from strix.config.config import Config, apply_saved_config
 
 
 def test_apply_config_override_clears_default_only_vars(monkeypatch, tmp_path) -> None:
+    from strix.interface.main import apply_config_override
+
     default_cfg = tmp_path / "cli-config.json"
     default_cfg.write_text(
         json.dumps({"env": {"LLM_API_BASE": "https://default.api", "STRIX_LLM": "default-model"}}),
@@ -19,9 +20,8 @@ def test_apply_config_override_clears_default_only_vars(monkeypatch, tmp_path) -
     monkeypatch.setattr(Config, "config_dir", classmethod(lambda cls: tmp_path))
     for var_name in Config._llm_env_vars():
         monkeypatch.delenv(var_name, raising=False)
-    sys.modules.pop("strix.interface.main", None)
 
-    from strix.interface.main import apply_config_override
+    apply_saved_config()
 
     assert os.environ.get("LLM_API_BASE") == "https://default.api"
 


### PR DESCRIPTION
Fixes #377

## Problem

When `--config custom.json` is provided, Strix still applies settings from `~/.strix/cli-config.json` for any keys that are *absent* from the custom config file.

**Root cause:** `apply_saved_config()` is called at module import time (before args are parsed), loading `~/.strix/cli-config.json` and setting those env vars in `os.environ`. Later, `apply_config_override()` loads the custom config and re-applies it with `force=True`, overwriting keys that exist in the custom file — but vars that were set from the default file and are **missing** from the custom file remain in `os.environ` unchanged.

## Solution

Track which env vars were actually set by the initial default-config load in `Config._applied_from_default`. In `apply_config_override`, clear those vars from `os.environ` before applying the custom config. This ensures:

- Keys present only in `~/.strix/cli-config.json` are cleared (no leakage).  
- Keys present only in the custom config are applied as usual.  
- User-set env vars (e.g. `export STRIX_LLM=...`) are never cleared — they were not set by `apply_saved_config`, so they are not in `_applied_from_default`.

## Changes

- `strix/config/config.py`: add `Config._applied_from_default` class var; populate it in `apply_saved` when loading the default config.  
- `strix/interface/main.py`: clear `_applied_from_default` entries in `apply_config_override` before applying the custom config.

## Testing

Manually verified with two config files:

```json
// ~/.strix/cli-config.json
{"env": {"STRIX_LLM": "default-model", "LLM_API_BASE": "https://default.api"}}

// custom.json
{"env": {"STRIX_LLM": "custom-model"}}
```

Before fix: running `strix --config custom.json` still inherited `LLM_API_BASE` from the default file.  
After fix: `LLM_API_BASE` is not set, only `STRIX_LLM=custom-model` is applied from the custom file.