### PR TITLE
fix: MiniMax tool call normalization and thinking block handling

### DIFF
--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any
@@ -188,7 +189,10 @@ class LLM:
             delta = self._get_chunk_content(chunk)
             if delta:
                 accumulated += delta
-                if "</function>" in accumulated or "</invoke>" in accumulated:
+                check_content = re.sub(
+                    r"<thinking[^>]*>.*?</thinking>", "", accumulated, flags=re.DOTALL
+                )
+                if "</function>" in check_content or "</invoke>" in check_content:
                     end_tag = "</function>" if "</function>" in accumulated else "</invoke>"
                     pos = accumulated.find(end_tag)
                     accumulated = accumulated[: pos + len(end_tag)]
@@ -203,11 +207,7 @@ class LLM:
         accumulated = normalize_tool_format(accumulated)
         accumulated = fix_incomplete_tool_call(_truncate_to_first_function(accumulated))
 
-        thinking_content = ""
-        for match in re.finditer(r"<thinking[^>]*>(.*?)</thinking>", accumulated, re.DOTALL):
-            thinking_content += match.group(1) + "\n"
-        if thinking_content:
-            accumulated = accumulated.replace(thinking_content, "")
+        accumulated = re.sub(r"<thinking[^>]*>.*?</thinking>", "", accumulated, flags=re.DOTALL)
 
         yield LLMResponse(
             content=accumulated,

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -27,6 +27,17 @@ litellm.drop_params = True
 litellm.modify_params = True
 
 _THINKING_BLOCK_RE = re.compile(r"<thinking[^>]*>.*?</thinking>", re.DOTALL)
+_THINKING_BLOCK_OR_OPEN_RE = re.compile(r"<thinking[^>]*>.*?(?:</thinking>|\Z)", re.DOTALL)
+
+
+def _find_end_tag_outside_thinking(content: str, end_tag: str) -> int:
+    thinking_spans = [(m.start(), m.end()) for m in _THINKING_BLOCK_OR_OPEN_RE.finditer(content)]
+    start = 0
+    while (idx := content.find(end_tag, start)) != -1:
+        if not any(s <= idx < e for s, e in thinking_spans):
+            return idx
+        start = idx + 1
+    return -1
 
 
 class LLMRequestFailedError(Exception):
@@ -190,10 +201,11 @@ class LLM:
                 continue
             delta = self._get_chunk_content(chunk)
             if delta:
-                accumulated = _THINKING_BLOCK_RE.sub("", accumulated + delta)
-                if "</function>" in accumulated or "</invoke>" in accumulated:
-                    end_tag = "</function>" if "</function>" in accumulated else "</invoke>"
-                    pos = accumulated.find(end_tag)
+                accumulated += delta
+                check_content = _THINKING_BLOCK_OR_OPEN_RE.sub("", accumulated)
+                if "</function>" in check_content or "</invoke>" in check_content:
+                    end_tag = "</function>" if "</function>" in check_content else "</invoke>"
+                    pos = _find_end_tag_outside_thinking(accumulated, end_tag)
                     accumulated = accumulated[: pos + len(end_tag)]
                     yield LLMResponse(content=accumulated)
                     done_streaming = 1
@@ -203,6 +215,7 @@ class LLM:
         if chunks:
             self._update_usage_stats(stream_chunk_builder(chunks))
 
+        accumulated = _THINKING_BLOCK_RE.sub("", accumulated)
         accumulated = normalize_tool_format(accumulated)
         accumulated = fix_incomplete_tool_call(_truncate_to_first_function(accumulated))
 

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -26,6 +26,8 @@ from strix.utils.resource_paths import get_strix_resource_path
 litellm.drop_params = True
 litellm.modify_params = True
 
+_THINKING_BLOCK_RE = re.compile(r"<thinking[^>]*>.*?</thinking>", re.DOTALL)
+
 
 class LLMRequestFailedError(Exception):
     def __init__(self, message: str, details: str | None = None):
@@ -188,11 +190,8 @@ class LLM:
                 continue
             delta = self._get_chunk_content(chunk)
             if delta:
-                accumulated += delta
-                check_content = re.sub(
-                    r"<thinking[^>]*>.*?</thinking>", "", accumulated, flags=re.DOTALL
-                )
-                if "</function>" in check_content or "</invoke>" in check_content:
+                accumulated = _THINKING_BLOCK_RE.sub("", accumulated + delta)
+                if "</function>" in accumulated or "</invoke>" in accumulated:
                     end_tag = "</function>" if "</function>" in accumulated else "</invoke>"
                     pos = accumulated.find(end_tag)
                     accumulated = accumulated[: pos + len(end_tag)]
@@ -206,8 +205,6 @@ class LLM:
 
         accumulated = normalize_tool_format(accumulated)
         accumulated = fix_incomplete_tool_call(_truncate_to_first_function(accumulated))
-
-        accumulated = re.sub(r"<thinking[^>]*>.*?</thinking>", "", accumulated, flags=re.DOTALL)
 
         yield LLMResponse(
             content=accumulated,

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -202,6 +202,13 @@ class LLM:
 
         accumulated = normalize_tool_format(accumulated)
         accumulated = fix_incomplete_tool_call(_truncate_to_first_function(accumulated))
+
+        thinking_content = ""
+        for match in re.finditer(r"<thinking[^>]*>(.*?)</thinking>", accumulated, re.DOTALL):
+            thinking_content += match.group(1) + "\n"
+        if thinking_content:
+            accumulated = accumulated.replace(thinking_content, "")
+
         yield LLMResponse(
             content=accumulated,
             tool_invocations=parse_tool_invocations(accumulated),

--- a/strix/llm/utils.py
+++ b/strix/llm/utils.py
@@ -20,7 +20,7 @@ def normalize_tool_format(content: str) -> str:
       <function="X">                        → <function=X>
       <parameter="X">                       → <parameter=X>
     """
-    if "<invoke" in content or "<function_calls" in content:
+    if "<invoke" in content or "<function_calls" in content or '<parameter name="' in content:
         content = _FUNCTION_CALLS_TAG.sub("", content)
         content = _INVOKE_OPEN.sub(r"<function=\1>", content)
         content = _PARAM_NAME_ATTR.sub(r"<parameter=\1>", content)

--- a/strix/llm/utils.py
+++ b/strix/llm/utils.py
@@ -20,7 +20,12 @@ def normalize_tool_format(content: str) -> str:
       <function="X">                        → <function=X>
       <parameter="X">                       → <parameter=X>
     """
-    if "<invoke" in content or "<function_calls" in content or '<parameter name="' in content:
+    if (
+        "<invoke" in content
+        or "<function_calls" in content
+        or '<parameter name="' in content
+        or "<parameter name='" in content
+    ):
         content = _FUNCTION_CALLS_TAG.sub("", content)
         content = _INVOKE_OPEN.sub(r"<function=\1>", content)
         content = _PARAM_NAME_ATTR.sub(r"<parameter=\1>", content)


### PR DESCRIPTION
## Summary

This PR fixes two issues when using MiniMax models (M2.5, M2.7) with Strix:

1. **Parameter format mismatch** - MiniMax outputs tool parameters in Anthropic-style XML with name attribute (<parameter name="x">) but Strix expects OpenAI-style format (<parameter=x>)

2. **Thinking blocks interfering with parsing** - MiniMax outputs thinking in <thinking>...</thinking> blocks inline, causing false </function> detections

## Changes

### strix/llm/utils.py
- Extended the trigger condition in normalize_tool_format() to include '<parameter name="' check
- This ensures parameter name attribute conversion runs even when only '<parameter name="x">' format is present

### strix/llm/llm.py
- Added stripping of <thinking>...</thinking> blocks from accumulated content before checking for </function> tags
- This prevents false positives when thinking blocks contain text that looks like closing tags

## Testing

The fix can be tested with MiniMax models:


Fixes #439