### PR TITLE
fix: recover from BadRequestError caused by oversized payloads

### DIFF
--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any
@@ -171,6 +172,8 @@ class LLM:
                 if self._is_bad_request(e):
                     if not bad_request_retried:
                         bad_request_retried = True
+                        if attempt >= max_retries:
+                            self._raise_error(e)
                         await asyncio.sleep(2)
                         continue
                     truncate_enabled = Config.get("strix_truncate_on_oversize") or ""
@@ -180,6 +183,8 @@ class LLM:
                         and self._truncate_large_tool_results(messages)
                     ):
                         bad_request_truncated = True
+                        if attempt >= max_retries:
+                            self._raise_error(e)
                         continue
                 if attempt >= max_retries or not self._should_retry(e):
                     self._raise_error(e)
@@ -339,31 +344,32 @@ class LLM:
         Scans messages in reverse for tool_result XML blocks that exceed max_chars and
         replaces their content with a truncated version plus a skip notice. Returns True
         if any truncation was performed (caller should retry the request).
-        """
-        import re
 
+        Note: All oversized tool_result blocks within a single message are truncated
+        in one pass — this is intentional to maximise payload size reduction per retry.
+        """
         truncated_any = False
         pattern = re.compile(
             r"(<tool_result>\s*<tool_name>[^<]*</tool_name>\s*<result>)(.*?)(</result>\s*</tool_result>)",
             re.DOTALL,
         )
 
+        def _truncate_match(m: re.Match) -> str:
+            nonlocal truncated_any
+            prefix, body, suffix = m.group(1), m.group(2), m.group(3)
+            if len(body) <= max_chars:
+                return m.group(0)
+            truncated_any = True
+            kept = body[:1000]
+            return (
+                f"{prefix}{kept}\n\n... [content truncated from {len(body)} to {len(kept)} chars "
+                f"due to request size limit — file requires manual review] ...{suffix}"
+            )
+
         for msg in reversed(messages):
             content = msg.get("content")
             if not isinstance(content, str) or "<tool_result>" not in content:
                 continue
-
-            def _truncate_match(m: re.Match) -> str:
-                prefix, body, suffix = m.group(1), m.group(2), m.group(3)
-                if len(body) <= max_chars:
-                    return m.group(0)
-                nonlocal truncated_any
-                truncated_any = True
-                kept = body[:1000]
-                return (
-                    f"{prefix}{kept}\n\n... [content truncated from {len(body)} to {len(kept)} chars "
-                    f"due to request size limit — file requires manual review] ...{suffix}"
-                )
 
             msg["content"] = pattern.sub(_truncate_match, content)
             if truncated_any:

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -161,7 +161,6 @@ class LLM:
         max_retries = int(Config.get("strix_llm_max_retries") or "5")
 
         bad_request_retried = False
-        bad_request_truncated = False
 
         for attempt in range(max_retries + 1):
             try:
@@ -178,11 +177,9 @@ class LLM:
                         continue
                     truncate_enabled = Config.get("strix_truncate_on_oversize") or ""
                     if (
-                        not bad_request_truncated
-                        and truncate_enabled.lower() in ("1", "true", "yes")
+                        truncate_enabled.lower() in ("1", "true", "yes")
                         and self._truncate_large_tool_results(messages)
                     ):
-                        bad_request_truncated = True
                         if attempt >= max_retries:
                             self._raise_error(e)
                         continue
@@ -339,14 +336,10 @@ class LLM:
     def _truncate_large_tool_results(
         messages: list[dict[str, Any]], max_chars: int = 2000
     ) -> bool:
-        """Aggressively truncate large tool results in messages to recover from BadRequestError.
+        """Truncate large tool_result XML blocks to recover from BadRequestError.
 
-        Scans messages in reverse for tool_result XML blocks that exceed max_chars and
-        replaces their content with a truncated version plus a skip notice. Returns True
-        if any truncation was performed (caller should retry the request).
-
-        Note: All oversized tool_result blocks within a single message are truncated
-        in one pass — this is intentional to maximise payload size reduction per retry.
+        Scans all messages for tool_result blocks exceeding max_chars and truncates them.
+        Called repeatedly on each 400 until it returns False (nothing left to truncate).
         """
         truncated_any = False
         pattern = re.compile(
@@ -370,10 +363,7 @@ class LLM:
             content = msg.get("content")
             if not isinstance(content, str) or "<tool_result>" not in content:
                 continue
-
             msg["content"] = pattern.sub(_truncate_match, content)
-            if truncated_any:
-                break
 
         return truncated_any
 

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -159,12 +159,28 @@ class LLM:
         messages = self._prepare_messages(conversation_history)
         max_retries = int(Config.get("strix_llm_max_retries") or "5")
 
+        bad_request_retried = False
+        bad_request_truncated = False
+
         for attempt in range(max_retries + 1):
             try:
                 async for response in self._stream(messages):
                     yield response
                 return  # noqa: TRY300
             except Exception as e:  # noqa: BLE001
+                if self._is_bad_request(e):
+                    if not bad_request_retried:
+                        bad_request_retried = True
+                        await asyncio.sleep(2)
+                        continue
+                    truncate_enabled = Config.get("strix_truncate_on_oversize") or ""
+                    if (
+                        not bad_request_truncated
+                        and truncate_enabled.lower() in ("1", "true", "yes")
+                        and self._truncate_large_tool_results(messages)
+                    ):
+                        bad_request_truncated = True
+                        continue
                 if attempt >= max_retries or not self._should_retry(e):
                     self._raise_error(e)
                 wait = min(90, 2 * (2**attempt))
@@ -313,6 +329,53 @@ class LLM:
             return completion_cost(response, model=self.config.canonical_model) or 0.0
         except Exception:  # noqa: BLE001
             return 0.0
+
+    @staticmethod
+    def _truncate_large_tool_results(
+        messages: list[dict[str, Any]], max_chars: int = 2000
+    ) -> bool:
+        """Aggressively truncate large tool results in messages to recover from BadRequestError.
+
+        Scans messages in reverse for tool_result XML blocks that exceed max_chars and
+        replaces their content with a truncated version plus a skip notice. Returns True
+        if any truncation was performed (caller should retry the request).
+        """
+        import re
+
+        truncated_any = False
+        pattern = re.compile(
+            r"(<tool_result>\s*<tool_name>[^<]*</tool_name>\s*<result>)(.*?)(</result>\s*</tool_result>)",
+            re.DOTALL,
+        )
+
+        for msg in reversed(messages):
+            content = msg.get("content")
+            if not isinstance(content, str) or "<tool_result>" not in content:
+                continue
+
+            def _truncate_match(m: re.Match) -> str:
+                prefix, body, suffix = m.group(1), m.group(2), m.group(3)
+                if len(body) <= max_chars:
+                    return m.group(0)
+                nonlocal truncated_any
+                truncated_any = True
+                kept = body[:1000]
+                return (
+                    f"{prefix}{kept}\n\n... [content truncated from {len(body)} to {len(kept)} chars "
+                    f"due to request size limit — file requires manual review] ...{suffix}"
+                )
+
+            msg["content"] = pattern.sub(_truncate_match, content)
+            if truncated_any:
+                break
+
+        return truncated_any
+
+    def _is_bad_request(self, e: Exception) -> bool:
+        code = getattr(e, "status_code", None) or getattr(
+            getattr(e, "response", None), "status_code", None
+        )
+        return code == 400
 
     def _should_retry(self, e: Exception) -> bool:
         code = getattr(e, "status_code", None) or getattr(

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -27,6 +27,12 @@ litellm.drop_params = True
 litellm.modify_params = True
 
 
+_TOOL_RESULT_PATTERN = re.compile(
+    r"(<tool_result>\s*<tool_name>[^<]*</tool_name>\s*<result>)(.*?)(</result>\s*</tool_result>)",
+    re.DOTALL,
+)
+
+
 class LLMRequestFailedError(Exception):
     def __init__(self, message: str, details: str | None = None):
         super().__init__(message)
@@ -355,10 +361,6 @@ class LLM:
         already acceptable.
         """
         truncated_any = False
-        pattern = re.compile(
-            r"(<tool_result>\s*<tool_name>[^<]*</tool_name>\s*<result>)(.*?)(</result>\s*</tool_result>)",
-            re.DOTALL,
-        )
 
         def _truncate_match(m: re.Match) -> str:
             nonlocal truncated_any
@@ -374,9 +376,17 @@ class LLM:
 
         for msg in reversed(messages):
             content = msg.get("content")
-            if not isinstance(content, str) or "<tool_result>" not in content:
-                continue
-            msg["content"] = pattern.sub(_truncate_match, content)
+
+            if isinstance(content, list):
+                for block in content:
+                    if (
+                        block.get("type") == "text"
+                        and isinstance(block.get("text"), str)
+                        and "<tool_result>" in block["text"]
+                    ):
+                        block["text"] = _TOOL_RESULT_PATTERN.sub(_truncate_match, block["text"])
+            elif isinstance(content, str) and "<tool_result>" in content:
+                msg["content"] = _TOOL_RESULT_PATTERN.sub(_truncate_match, content)
 
         return truncated_any
 

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -182,6 +182,10 @@ class LLM:
                     ):
                         if attempt >= max_retries:
                             self._raise_error(e)
+                        # Pace the provider — matches the 2s sleep on the bare-retry
+                        # path so a throttled provider isn't hit back-to-back after the
+                        # original 400.
+                        await asyncio.sleep(2)
                         continue
                 if attempt >= max_retries or not self._should_retry(e):
                     self._raise_error(e)
@@ -334,12 +338,21 @@ class LLM:
 
     @staticmethod
     def _truncate_large_tool_results(
-        messages: list[dict[str, Any]], max_chars: int = 2000
+        messages: list[dict[str, Any]],
+        threshold_chars: int = 2000,
+        truncate_to_chars: int = 1000,
     ) -> bool:
         """Truncate large tool_result XML blocks to recover from BadRequestError.
 
-        Scans all messages for tool_result blocks exceeding max_chars and truncates them.
-        Called repeatedly on each 400 until it returns False (nothing left to truncate).
+        Scans all messages for tool_result blocks whose body exceeds threshold_chars
+        and shrinks them to truncate_to_chars. Called repeatedly on each 400 until it
+        returns False (nothing left to truncate).
+
+        threshold_chars and truncate_to_chars are independent: the threshold decides
+        which blocks qualify for truncation, and truncate_to_chars is the size of the
+        retained prefix. They are not the same value to allow aggressive shrinking of
+        blocks that are well over the threshold without re-processing blocks that are
+        already acceptable.
         """
         truncated_any = False
         pattern = re.compile(
@@ -350,10 +363,10 @@ class LLM:
         def _truncate_match(m: re.Match) -> str:
             nonlocal truncated_any
             prefix, body, suffix = m.group(1), m.group(2), m.group(3)
-            if len(body) <= max_chars:
+            if len(body) <= threshold_chars:
                 return m.group(0)
             truncated_any = True
-            kept = body[:1000]
+            kept = body[:truncate_to_chars]
             return (
                 f"{prefix}{kept}\n\n... [content truncated from {len(body)} to {len(kept)} chars "
                 f"due to request size limit — file requires manual review] ...{suffix}"


### PR DESCRIPTION
**Title:** `fix: recover from BadRequestError caused by oversized payloads`

## Summary
- Adds BadRequestError (HTTP 400) recovery to the LLM retry loop — first retries bare, then optionally truncates large `<tool_result>` XML blocks when `STRIX_TRUNCATE_ON_OVERSIZE=true`
- Truncation is opt-in (default off) to avoid lossy recovery for users who don't want it
- Observed on repos with 50KB+ config files (CIS benchmark YAML, large tfvars.json) that push Bedrock payload past its limit at ~6M tokens

## Context
During large-scale scanning (700+ repos), certain repos with very large files caused persistent HTTP 400s that killed scans immediately. The two-stage approach handles both transient 400s (bare retry) and genuine payload oversize (truncation + retry).

## How it works
1. On HTTP 400, retry once after 2s (handles transient provider hiccups)
2. If still failing and `STRIX_TRUNCATE_ON_OVERSIZE=true`, scan messages in reverse for `<tool_result>` blocks exceeding 2000 chars, truncate to 1000 chars with a "requires manual review" notice, retry
3. If neither works, fall through to existing retry/error logic

## Test plan
- [x] Confirmed bare retry resolves transient 400s in production scanning
- [x] Confirmed truncation triggers on repos with large tool results hitting Bedrock payload limits
- [ ] Verify truncation notice appears in scan output when triggered
- [ ] Verify flag defaults to off — no behavior change without explicit opt-in