### PR TITLE
fix: persist scan data on exit and save partial reports

### DIFF
--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -629,6 +629,7 @@ def main() -> None:  # noqa: PLR0912, PLR0915
     finally:
         tracer = get_global_tracer()
         if tracer:
+            tracer.cleanup()
             posthog.end(tracer, exit_reason=exit_reason)
 
     results_path = Path("strix_runs") / args.run_name

--- a/strix/tools/finish/finish_actions.py
+++ b/strix/tools/finish/finish_actions.py
@@ -99,19 +99,11 @@ def finish_scan(
     if active_agents_error:
         return active_agents_error
 
-    validation_errors = []
-
-    if not executive_summary or not executive_summary.strip():
-        validation_errors.append("Executive summary cannot be empty")
-    if not methodology or not methodology.strip():
-        validation_errors.append("Methodology cannot be empty")
-    if not technical_analysis or not technical_analysis.strip():
-        validation_errors.append("Technical analysis cannot be empty")
-    if not recommendations or not recommendations.strip():
-        validation_errors.append("Recommendations cannot be empty")
-
-    if validation_errors:
-        return {"success": False, "message": "Validation failed", "errors": validation_errors}
+    _NOT_PROVIDED = "[Not provided by model]"
+    executive_summary = (executive_summary or "").strip() or _NOT_PROVIDED
+    methodology = (methodology or "").strip() or _NOT_PROVIDED
+    technical_analysis = (technical_analysis or "").strip() or _NOT_PROVIDED
+    recommendations = (recommendations or "").strip() or _NOT_PROVIDED
 
     try:
         from strix.telemetry.tracer import get_global_tracer


### PR DESCRIPTION
Fixes #294

## Problem

Two related issues cause scan reports to be lost when Strix exits:

**1. `tracer.cleanup()` never called in `main.py`'s `finally` block**

`cli.py` and `tui.py` register `atexit` + signal handlers that call `tracer.cleanup()`, but `main.py`'s `finally` block only calls `posthog.end()`. On Windows (where `asyncio.WindowsSelectorEventLoopPolicy()` is used), the `atexit` handlers may not fire reliably when the asyncio event loop tears down, so vulnerability reports and the final scan summary are never written to disk.

**2. Strict validation in `finish_actions.py` silently discards partial reports**

`finish_scan` rejects any call where one of the four required fields is empty and returns an error without saving. When the LLM doesn't populate every field, the entire report is dropped — even though vulnerabilities were already saved incrementally via `add_vulnerability_report()`.

## Solution

**Fix 1 (`strix/interface/main.py`):** Call `tracer.cleanup()` in the `finally` block before `posthog.end()`. `cleanup()` calls `save_run_data(mark_complete=True)` which is idempotent (tracks already-saved vuln IDs and the `_run_completed_emitted` flag), so calling it from both the `finally` block and an `atexit` handler is safe.

**Fix 2 (`strix/tools/finish/finish_actions.py`):** Replace the all-or-nothing validation with a graceful fallback: missing or empty fields are filled with the placeholder `"[Not provided by model]"` so partial reports are saved rather than silently discarded.

## Testing

- Verified `tracer.cleanup()` is idempotent by reviewing `_saved_vuln_ids` set tracking and `_run_completed_emitted` flag in `tracer.py`.
- Existing tests in `tests/telemetry/test_tracer.py` call `save_run_data(mark_complete=True)` multiple times, confirming the idempotency assumption holds.