### PR TITLE
fix: retry transient 'thinking blocks cannot be modified' 400s from Bedrock

### DIFF
--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -160,6 +160,7 @@ class LLM:
         max_retries = int(Config.get("strix_llm_max_retries") or "5")
 
         transient_thinking_retries = 0
+        max_transient_thinking_retries = 6
 
         for attempt in range(max_retries + 1):
             try:
@@ -171,14 +172,23 @@ class LLM:
                 # blocks have been modified — even when the payload is structurally
                 # valid and the same payload succeeds on replay. Observed on
                 # claude-sonnet-4-6 with adaptive thinking. Retry with exponential
-                # backoff (5s, 10s, 20s, 40s, 80s, 160s — ~5 min total budget) before
-                # falling through to the generic retry path.
-                if self._is_transient_thinking_error(e) and transient_thinking_retries < 6:
+                # backoff (5s, 10s, 20s, 40s, 80s, 160s — ~5 min total budget), using
+                # an inner loop so the transient retry counter does not share slots
+                # with the outer max_retries budget. Once the inner budget is
+                # exhausted (or a non-transient error is raised), fall through to the
+                # generic retry path below.
+                while (
+                    self._is_transient_thinking_error(e)
+                    and transient_thinking_retries < max_transient_thinking_retries
+                ):
                     transient_thinking_retries += 1
-                    if attempt >= max_retries:
-                        self._raise_error(e)
                     await asyncio.sleep(min(240, 5 * (2 ** (transient_thinking_retries - 1))))
-                    continue
+                    try:
+                        async for response in self._stream(messages):
+                            yield response
+                        return  # noqa: TRY300
+                    except Exception as e2:  # noqa: BLE001
+                        e = e2
                 if attempt >= max_retries or not self._should_retry(e):
                     self._raise_error(e)
                 wait = min(90, 2 * (2**attempt))

--- a/strix/llm/llm.py
+++ b/strix/llm/llm.py
@@ -159,12 +159,26 @@ class LLM:
         messages = self._prepare_messages(conversation_history)
         max_retries = int(Config.get("strix_llm_max_retries") or "5")
 
+        transient_thinking_retries = 0
+
         for attempt in range(max_retries + 1):
             try:
                 async for response in self._stream(messages):
                     yield response
                 return  # noqa: TRY300
             except Exception as e:  # noqa: BLE001
+                # Bedrock occasionally returns a 400 claiming the assistant's thinking
+                # blocks have been modified — even when the payload is structurally
+                # valid and the same payload succeeds on replay. Observed on
+                # claude-sonnet-4-6 with adaptive thinking. Retry with exponential
+                # backoff (5s, 10s, 20s, 40s, 80s, 160s — ~5 min total budget) before
+                # falling through to the generic retry path.
+                if self._is_transient_thinking_error(e) and transient_thinking_retries < 6:
+                    transient_thinking_retries += 1
+                    if attempt >= max_retries:
+                        self._raise_error(e)
+                    await asyncio.sleep(min(240, 5 * (2 ** (transient_thinking_retries - 1))))
+                    continue
                 if attempt >= max_retries or not self._should_retry(e):
                     self._raise_error(e)
                 wait = min(90, 2 * (2**attempt))
@@ -322,6 +336,22 @@ class LLM:
             return completion_cost(response, model=self.config.canonical_model) or 0.0
         except Exception:  # noqa: BLE001
             return 0.0
+
+    @staticmethod
+    def _is_transient_thinking_error(e: Exception) -> bool:
+        """Detect Bedrock's transient 'thinking blocks cannot be modified' 400.
+
+        Observed on claude-sonnet-4-6 with adaptive thinking: Bedrock occasionally
+        rejects a well-formed payload with this error, and the identical payload
+        succeeds on replay. Treat it as transient rather than a structural issue.
+        """
+        code = getattr(e, "status_code", None) or getattr(
+            getattr(e, "response", None), "status_code", None
+        )
+        if code != 400:
+            return False
+        message = str(e).lower()
+        return "thinking" in message and "cannot be modified" in message
 
     def _should_retry(self, e: Exception) -> bool:
         code = getattr(e, "status_code", None) or getattr(


### PR DESCRIPTION
## Summary

Bedrock occasionally returns HTTP 400 claiming the assistant's thinking blocks have been modified, even when the payload is structurally valid. The identical payload replayed immediately succeeds. This is a transient server-side condition, not a client bug.

Observed on `bedrock/us.anthropic.claude-sonnet-4-6` with adaptive thinking (`reasoning_effort=high` → `{type: "adaptive"}` on claude-4-6). Error text:

```
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest
assistant message cannot be modified. These blocks must remain as they were
in the original response.
```

## Fix

- Add `_is_transient_thinking_error()` that matches on `status_code == 400` **and** the characteristic message (`"thinking"` + `"cannot be modified"`). Deliberately strict to avoid hijacking unrelated 400s.
- On detection, retry with exponential backoff: 5s, 10s, 20s, 40s, 80s, 160s (~5 min total budget) before falling through to generic retry.
- Self-contained detector — works independently of other 400 handlers.

## Evidence

- Replayed 33 captured payloads from around an observed failure: all succeeded on replay, confirming transience.
- In a multi-repo variance study (21+ scans × 7 repos of Sonnet 4.6 on real production code), the 3-retry budget was exhausted in one case (~30s). A 6-retry budget succeeded on a subsequent attempt with the same repo, same model, same config.

## Test plan

- [x] Backoff schedule unit-check: `5s, 10s, 20s, 40s, 80s, 160s; total 315s`
- [x] Detector smoke test: correctly matches a BedrockException with the thinking-blocks message, rejects oversize-payload 400s and generic 400s
- [x] No change to behaviour when the detector returns False (fall-through to existing retry path)