### PR TITLE
[codex] clarify Vertex AI env vars

### DIFF
--- a/docs/llm-providers/vertex.mdx
+++ b/docs/llm-providers/vertex.mdx
@@ -47,6 +47,13 @@ export VERTEXAI_PROJECT="your-project-id"
 export VERTEXAI_LOCATION="global"
 ```
 
+Strix passes Vertex AI requests through LiteLLM, which reads the project and location
+from `VERTEXAI_PROJECT` and `VERTEXAI_LOCATION`. Do not add an underscore after
+`VERTEX`: `VERTEX_AI_PROJECT` and `VERTEX_AI_LOCATION` are not recognized.
+
+If Strix reports `Could not resolve project_id`, check these variable names before
+retrying the scan.
+
 ## Prerequisites
 
 1. Enable the Vertex AI API in your Google Cloud project


### PR DESCRIPTION
## What changed

- clarify that Strix reads Vertex AI project and location through LiteLLM's `VERTEXAI_PROJECT` and `VERTEXAI_LOCATION` variables
- call out that `VERTEX_AI_PROJECT` and `VERTEX_AI_LOCATION` are not recognized
- point users who see `Could not resolve project_id` back to the variable names

## Why

The Vertex provider page already documents the supported variable names, but the
LiteLLM naming differs from the common `VERTEX_AI_*` spelling. A user can reach
Vertex AI successfully with Google Cloud credentials and still have Strix fail its
LiteLLM warm-up with a project resolution error when the unsupported spelling is
used.

## Validation

- `git diff --check`
