### PR TITLE
feat(agent): async sub-agents, NovaRouter, and Docker/OTEL hardening

### DIFF
--- a/BUILD_DOCKER.md
+++ b/BUILD_DOCKER.md
@@ -1,0 +1,75 @@
+# Building Docker Image with Local Changes
+
+## Quick Build
+
+To build the Docker image with your local code changes:
+
+```bash
+# Build the image (this will take a while the first time)
+docker build -f containers/Dockerfile -t strix-sandbox:local .
+
+# Set environment variable to use your local image
+export STRIX_IMAGE=strix-sandbox:local
+
+# Now run Strix - it will use your local image
+poetry run strix --target https://example.com
+```
+
+## What Gets Copied
+
+The Dockerfile copies these files into the image:
+- `strix/tools/executor.py` ✅ (your changes are here)
+- `strix/tools/registry.py`
+- `strix/tools/argument_parser.py`
+- All tool directories (browser, file_edit, notes, python, terminal, proxy)
+- Runtime files
+
+**Note:** `agents_graph_actions.py` runs on the **host** (not in the container), so those changes work immediately without rebuilding.
+
+## Using Your Local Image
+
+After building, you can either:
+
+### Option 1: Set Environment Variable (Recommended)
+```bash
+export STRIX_IMAGE=strix-sandbox:local
+strix --target https://example.com
+```
+
+### Option 2: Set in Your Shell Profile
+Add to `~/.zshrc` or `~/.bashrc`:
+```bash
+export STRIX_IMAGE=strix-sandbox:local
+```
+
+## Verifying Your Changes
+
+To verify your changes are in the image:
+
+```bash
+# Build the image
+docker build -f containers/Dockerfile -t strix-sandbox:local .
+
+# Check the executor.py file in the image
+docker run --rm strix-sandbox:local cat /app/strix/tools/executor.py | grep -A 5 "asyncio.gather"
+```
+
+You should see your parallel execution code with `asyncio.gather()`.
+
+## Development Workflow
+
+For active development:
+
+1. **Make code changes** to files that run in the container (like `executor.py`)
+2. **Rebuild the image**: `docker build -f containers/Dockerfile -t strix-sandbox:local .`
+3. **Test your changes**: `export STRIX_IMAGE=strix-sandbox:local && strix --target ...`
+
+For changes to host-side code (like `agents_graph_actions.py`), no rebuild needed!
+
+## Troubleshooting
+
+If you see old behavior after rebuilding:
+- Make sure you're using the local image: `echo $STRIX_IMAGE` should show `strix-sandbox:local`
+- Check if Docker is using a cached layer: add `--no-cache` to build command
+- Verify the file in the image: `docker run --rm strix-sandbox:local cat /app/strix/tools/executor.py`
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev-install format lint type-check test test-cov clean pre-commit setup-dev
+.PHONY: help install dev-install format lint type-check test test-cov clean pre-commit setup-dev docker-build docker-build-no-cache docker-push
 
 help:
 	@echo "Available commands:"
@@ -20,6 +20,11 @@ help:
 	@echo "Development:"
 	@echo "  pre-commit    - Run pre-commit hooks on all files"
 	@echo "  clean         - Clean up cache files and artifacts"
+	@echo ""
+	@echo "Docker:"
+	@echo "  docker-build  - Build Docker image with local code changes"
+	@echo "  docker-build-no-cache - Build Docker image without cache"
+	@echo "  docker-push   - Push Docker image to registry (requires auth)"
 
 install:
 	uv sync --no-dev
@@ -88,3 +93,27 @@ clean:
 
 dev: format lint type-check test
 	@echo "✅ Development cycle complete!"
+
+docker-build:
+	@echo "🐳 Building Docker image with local code changes..."
+	@echo "   This will tag the image as 'strix-sandbox:local'"
+	@echo "   Set STRIX_IMAGE=strix-sandbox:local to use it"
+	docker build -f containers/Dockerfile -t strix-sandbox:local .
+	@echo "✅ Docker image built successfully!"
+	@echo "   To use this image, run: export STRIX_IMAGE=strix-sandbox:local"
+
+docker-build-no-cache:
+	@echo "🐳 Building Docker image without cache (fresh build)..."
+	@echo "   This will take longer but ensures all changes are included"
+	docker build --no-cache -f containers/Dockerfile -t strix-sandbox:local .
+	@echo "✅ Docker image built successfully!"
+	@echo "   To use this image, run: export STRIX_IMAGE=strix-sandbox:local"
+
+docker-push:
+	@echo "🚀 Pushing Docker image to registry..."
+	@echo "   Note: This requires authentication and proper image tag"
+	@echo "   Current image tag: strix-sandbox:local"
+	@echo "   Update the tag below to match your registry"
+	@echo "   Example: docker tag strix-sandbox:local ghcr.io/usestrix/strix-sandbox:0.1.11"
+	@echo "   Then: docker push ghcr.io/usestrix/strix-sandbox:0.1.11"
+	@echo "⚠️  This command is a placeholder - customize the tag as needed"

--- a/QUICK_EXTRACT.md
+++ b/QUICK_EXTRACT.md
@@ -1,0 +1,74 @@
+# Quick Guide: Extract Workspace Files
+
+## The Problem
+
+The `docker cp` command requires the **destination directory to exist first**. If it doesn't exist, the command will fail silently or with an error.
+
+## Solution: Use This Exact Command
+
+For your current container, run:
+
+```bash
+# 1. Create the destination directory first
+mkdir -p strix_runs/app-dev-complynova-us-orbitronai_eebc/evidence
+
+# 2. Copy the workspace
+docker cp strix-scan-app-dev-complynova-us-orbitronai_eebc:/workspace strix_runs/app-dev-complynova-us-orbitronai_eebc/evidence/workspace
+```
+
+## Or Use the Helper Script
+
+```bash
+./extract_workspace.sh strix-scan-app-dev-complynova-us-orbitronai_eebc
+```
+
+## Why Your Command Failed
+
+The command `docker cp <container-name>:/workspace/evidence.png ./strix_runs/<run-name>` likely failed because:
+
+1. **Destination directory doesn't exist** - `./strix_runs/<run-name>` must exist first
+2. **Wrong container name** - Use exact name from `docker ps`
+3. **File doesn't exist** - The specific file path might not exist
+
+## Correct Format
+
+```bash
+# Format: docker cp <container>:<source-path> <destination-path>
+# Destination must be a directory that EXISTS, or a new filename
+
+# ✅ CORRECT - Copy to existing directory
+mkdir -p strix_runs/my-run/evidence
+docker cp container-name:/workspace/file.txt strix_runs/my-run/evidence/
+
+# ✅ CORRECT - Copy entire directory to existing parent
+mkdir -p strix_runs/my-run/evidence
+docker cp container-name:/workspace strix_runs/my-run/evidence/workspace
+
+# ❌ WRONG - Destination directory doesn't exist
+docker cp container-name:/workspace/file.txt strix_runs/my-run/evidence/
+
+# ✅ FIX - Create directory first
+mkdir -p strix_runs/my-run/evidence
+docker cp container-name:/workspace/file.txt strix_runs/my-run/evidence/
+```
+
+## Find Your Container Name
+
+```bash
+# List all Strix containers
+docker ps --format "{{.Names}}" | grep strix-scan
+
+# Or with more details
+docker ps -a --filter "label=strix-scan-id" --format "table {{.Names}}\t{{.Status}}"
+```
+
+## Find Your Run Name
+
+The run name matches the scan-id, which is in the container label:
+
+```bash
+CONTAINER="strix-scan-app-dev-complynova-us-orbitronai_eebc"
+SCAN_ID=$(docker inspect "$CONTAINER" --format '{{index .Config.Labels "strix-scan-id"}}')
+echo "Run directory: strix_runs/$SCAN_ID"
+```
+

--- a/RESULTS_LOCATION.md
+++ b/RESULTS_LOCATION.md
@@ -1,0 +1,165 @@
+# Where Strix Stores Results and Evidence
+
+## Summary
+
+Strix uses **two separate locations** for data:
+
+1. **`/workspace`** - Inside the Docker container (where agents work)
+2. **`strix_runs/<run-name>/`** - On your host machine (where results are saved)
+
+## Host Machine Results Location
+
+**Location:** `strix_runs/<run-name>/` (in the current working directory where you ran Strix)
+
+**What gets saved here:**
+- ✅ Vulnerability reports (markdown files in `vulnerabilities/` subdirectory)
+- ✅ Vulnerability index (`vulnerabilities.csv`)
+- ✅ Final penetration test report (`penetration_test_report.md`)
+- ✅ Run metadata and agent execution traces
+
+**Example structure:**
+```
+strix_runs/
+└── your-run-name/
+    ├── penetration_test_report.md
+    ├── vulnerabilities.csv
+    └── vulnerabilities/
+        ├── vuln-001.md
+        ├── vuln-002.md
+        └── ...
+```
+
+## Container Workspace Location
+
+**Location:** `/workspace` inside the Docker container
+
+**What's stored here:**
+- Source code (if scanning local code or repositories)
+- Files created by agents during testing
+- Evidence files, screenshots, logs created during the scan
+- Temporary files and working data
+
+## ⚠️ Important Limitation
+
+**Evidence files created by agents in `/workspace` are NOT automatically copied back to the host machine.**
+
+Currently, only vulnerability reports (text-based findings) are saved to `strix_runs/`. Any files, screenshots, or evidence that agents create in the container's `/workspace` directory remain inside the container and are not accessible on your host machine unless you manually extract them.
+
+## How to Access Container Workspace Files
+
+### Option 1: Use the Helper Script (Easiest)
+
+```bash
+# Run the extraction helper script
+./extract_workspace.sh
+
+# Or specify container name directly
+./extract_workspace.sh strix-scan-app-dev-complynova-us-orbitronai_eebc
+```
+
+The script will:
+- List all Strix containers
+- Let you select which one to extract from
+- Copy files to `strix_runs/<run-name>/evidence/`
+
+### Option 2: Manual Docker Commands
+
+**Step 1: Find your container**
+
+```bash
+# List all Strix containers
+docker ps -a --filter "label=strix-scan-id" --format "table {{.Names}}\t{{.Status}}"
+
+# Or find by name pattern
+docker ps --format "{{.Names}}" | grep strix-scan
+```
+
+**Step 2: Copy files (IMPORTANT: destination directory must exist!)**
+
+```bash
+# First, create the destination directory
+mkdir -p strix_runs/<run-name>/evidence
+
+# Copy entire workspace
+docker cp <container-name>:/workspace strix_runs/<run-name>/evidence/workspace
+
+# Or copy specific file/directory
+docker cp <container-name>:/workspace/specific-file.txt strix_runs/<run-name>/evidence/
+
+# Example with actual container name:
+docker cp strix-scan-app-dev-complynova-us-orbitronai_eebc:/workspace strix_runs/app-dev-complynova-us-orbitronai_eebc/evidence/workspace
+```
+
+**Common Issues:**
+- ❌ `docker cp` fails if destination directory doesn't exist - create it first!
+- ❌ Container name must match exactly (use `docker ps` to see exact name)
+- ✅ Container can be running or stopped (will auto-start if stopped)
+
+### Option 3: Access Container Shell
+
+```bash
+# Access the container shell
+docker exec -it <container-name> bash
+
+# Navigate to workspace
+cd /workspace
+ls -la
+
+# Then use docker cp from another terminal to copy files out
+```
+
+### Option 3: Mount Workspace as Volume (Future Enhancement)
+
+This would require code changes to mount the workspace directory as a Docker volume, making it directly accessible on the host.
+
+## Finding Your Results
+
+### Quick Check
+
+```bash
+# See all Strix runs
+ls -la strix_runs/
+
+# View a specific run's results
+cat strix_runs/<run-name>/penetration_test_report.md
+
+# List all vulnerabilities found
+cat strix_runs/<run-name>/vulnerabilities.csv
+```
+
+### Full Path
+
+The results are saved relative to where you ran the `strix` command:
+
+```bash
+# If you ran: strix --target https://example.com
+# From: /Users/ashu/Github/strix
+# Results will be at: /Users/ashu/Github/strix/strix_runs/<run-name>/
+```
+
+## Container Information
+
+To find which container belongs to your scan:
+
+```bash
+# List containers with their labels
+docker ps --filter "label=strix-scan-id" --format "table {{.Names}}\t{{.Labels}}"
+
+# Or check container names (format: strix-scan-<scan-id>)
+docker ps --format "{{.Names}}" | grep strix-scan
+```
+
+## Recommended Workflow
+
+1. **Check `strix_runs/` first** - This has all the vulnerability reports and findings
+2. **If you need evidence files** - Access the container using `docker exec` or `docker cp`
+3. **Save important evidence** - Copy files you need to `strix_runs/<run-name>/evidence/` manually
+
+## Future Improvements
+
+Potential enhancements:
+- Automatic extraction of evidence files from container to host
+- Volume mounting for direct workspace access
+- Evidence collection and organization in results directory
+- Automatic cleanup or archival of container workspaces
+

--- a/SETUP_LOCAL.md
+++ b/SETUP_LOCAL.md
@@ -1,0 +1,124 @@
+# Running Strix Locally
+
+## Quick Setup Guide
+
+### Option 1: Using Poetry (Recommended)
+
+If Poetry isn't working, reinstall it first:
+
+```bash
+# Reinstall Poetry with current Python
+curl -sSL https://install.python-poetry.org | python3 -
+# Or if you have pipx:
+pipx install poetry
+```
+
+Then install dependencies:
+
+```bash
+cd /Users/ashu/Github/strix
+poetry install --with=dev
+```
+
+### Option 2: Using pip directly
+
+```bash
+cd /Users/ashu/Github/strix
+python3 -m pip install -e .
+```
+
+For development dependencies:
+
+```bash
+python3 -m pip install -e ".[dev]"
+```
+
+## Prerequisites Check
+
+1. **Docker Desktop** - Should be running (we fixed the connection issue!)
+2. **Python 3.12+** - You have Python 3.13.3 ✅
+3. **LLM API Key** - You'll need to set this up
+
+## Configuration
+
+Set up your LLM provider environment variables:
+
+```bash
+# Required
+export STRIX_LLM="openai/gpt-5"  # or "anthropic/claude-sonnet-4-5"
+export LLM_API_KEY="your-api-key-here"
+
+# Optional (for local models like Ollama)
+# export LLM_API_BASE="http://localhost:11434"
+
+# Optional (for web search capabilities)
+# export PERPLEXITY_API_KEY="your-perplexity-key"
+```
+
+## Running Strix
+
+### Using Poetry:
+
+```bash
+poetry run strix --target https://app.dev.complynova.us.orbitronai.com/landing
+```
+
+### Using pip installation:
+
+```bash
+# If installed with -e flag, you can run directly:
+python3 -m strix.interface.main --target https://app.dev.complynova.us.orbitronai.com/landing
+
+# Or create an alias:
+alias strix='python3 -m strix.interface.main'
+strix --target https://app.dev.complynova.us.orbitronai.com/landing
+```
+
+### Development Mode (with editable install):
+
+```bash
+# Install in editable mode
+python3 -m pip install -e .
+
+# Then run directly
+strix --target https://app.dev.complynova.us.orbitronai.com/landing
+```
+
+## Example Commands
+
+```bash
+# Scan a web application
+strix --target https://example.com
+
+# Scan a local directory
+strix --target ./my-app
+
+# Scan with custom instructions
+strix --target https://example.com --instruction "Focus on authentication vulnerabilities"
+
+# Non-interactive mode (for CI/CD)
+strix -n --target https://example.com
+```
+
+## Troubleshooting
+
+### Docker Connection Issues
+- ✅ Already fixed! The code now automatically detects Docker Desktop on macOS.
+
+### Poetry Issues
+- If Poetry has wrong Python interpreter, reinstall it or use pip directly
+
+### Missing Dependencies
+- Run: `python3 -m pip install -e .` to install all dependencies
+
+### LLM Connection Issues
+- Verify your API key is correct
+- Check if you need to set `LLM_API_BASE` for local models
+- Test with: `python3 -c "import litellm; print('LiteLLM installed')"`
+
+## Next Steps
+
+1. Set your `STRIX_LLM` and `LLM_API_KEY` environment variables
+2. Make sure Docker Desktop is running
+3. Run your first scan!
+

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -19,6 +19,10 @@ Configure Strix using environment variables or a config file.
   Custom API base URL. Also accepts `OPENAI_API_BASE`, `LITELLM_BASE_URL`, or `OLLAMA_API_BASE`.
 </ParamField>
 
+<ParamField path="LLM_NOVAROUTER_BASE" type="string">
+  NovaRouter gateway base URL when using `novarouter/` model prefix. Defaults to production. Set to `https://api.stg.novarouter.orbitronai.com` for staging.
+</ParamField>
+
 <ParamField path="LLM_TIMEOUT" default="300" type="integer">
   Request timeout in seconds for LLM calls.
 </ParamField>

--- a/docs/llm-providers/novarouter.mdx
+++ b/docs/llm-providers/novarouter.mdx
@@ -1,0 +1,61 @@
+---
+title: "NovaRouter"
+description: "Configure Strix with OrbitronAI NovaRouter LLM gateway"
+---
+
+NovaRouter is an OpenAI-compatible LLM gateway that supports multiple models. Use it with Strix by pointing to the gateway base URL.
+
+## Setup
+
+### Production
+
+```bash
+export STRIX_LLM="novarouter/qwen3-coder-30b"
+export LLM_API_KEY="<your-novarouter-api-key>"
+```
+
+### Staging
+
+```bash
+export STRIX_LLM="novarouter/qwen3-coder-30b"
+export LLM_API_KEY="<your-novarouter-api-key>"
+export LLM_NOVAROUTER_BASE="https://api.stg.novarouter.orbitronai.com"
+```
+
+## Base URLs
+
+| Environment | Base URL |
+| --- | --- |
+| Staging | `https://api.stg.novarouter.orbitronai.com` |
+| Production | `https://api.novarouter.orbitronai.com` |
+
+## Available Models
+
+List models your API key can access:
+
+```bash
+curl "https://api.novarouter.orbitronai.com/v1/models" \
+  -H "Authorization: Bearer <your-api-key>"
+```
+
+Example models from the [NovaRouter Developer Guide](https://app.clickup.com/90181480068/docs/2kzkrbm4-4978/2kzkrbm4-27838):
+
+| Model | STRIX_LLM |
+| --- | --- |
+| Qwen3 Coder 30B | `novarouter/qwen3-coder-30b` |
+| GPT-OSS 120B | `novarouter/gpt-oss-120b` |
+| Qwen3 Embedding 8B | (embeddings only) |
+
+## Alternative: OpenAI-Compatible Format
+
+You can also use the generic OpenAI-compatible format:
+
+```bash
+export STRIX_LLM="openai/qwen3-coder-30b"
+export LLM_API_BASE="https://api.novarouter.orbitronai.com/v1"
+export LLM_API_KEY="<your-novarouter-api-key>"
+```
+
+## Authentication
+
+NovaRouter accepts `Authorization: Bearer <key>`. Ensure `LLM_API_KEY` is set to your NovaRouter API key.

--- a/docs/llm-providers/overview.mdx
+++ b/docs/llm-providers/overview.mdx
@@ -55,6 +55,9 @@ See the [Local Models guide](/llm-providers/local) for setup instructions and re
   <Card title="Local Models" href="/llm-providers/local">
     Llama 4, Mistral, and self-hosted models.
   </Card>
+  <Card title="NovaRouter" href="/llm-providers/novarouter">
+    OrbitronAI LLM gateway with multiple models.
+  </Card>
 </CardGroup>
 
 ## Model Format

--- a/extract_workspace.sh
+++ b/extract_workspace.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Helper script to extract workspace files from Strix Docker container to host
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Strix Workspace Extraction Helper${NC}"
+echo "=================================="
+echo ""
+
+# Find Strix containers
+echo "Looking for Strix containers..."
+CONTAINERS=$(docker ps -a --filter "label=strix-scan-id" --format "{{.Names}}")
+
+if [ -z "$CONTAINERS" ]; then
+    echo -e "${RED}No Strix containers found.${NC}"
+    exit 1
+fi
+
+# Display containers
+echo -e "${GREEN}Found Strix containers:${NC}"
+echo "$CONTAINERS" | nl -w2 -s'. '
+echo ""
+
+# If container name provided as argument, use it
+if [ -n "$1" ]; then
+    CONTAINER_NAME="$1"
+else
+    # Ask user to select
+    echo -e "${YELLOW}Enter container number or name:${NC}"
+    read -r SELECTION
+    
+    # Check if it's a number
+    if [[ "$SELECTION" =~ ^[0-9]+$ ]]; then
+        CONTAINER_NAME=$(echo "$CONTAINERS" | sed -n "${SELECTION}p")
+    else
+        CONTAINER_NAME="$SELECTION"
+    fi
+fi
+
+# Verify container exists
+if ! docker ps -a --format "{{.Names}}" | grep -q "^${CONTAINER_NAME}$"; then
+    echo -e "${RED}Container '${CONTAINER_NAME}' not found.${NC}"
+    exit 1
+fi
+
+# Get scan-id from container label
+SCAN_ID=$(docker inspect "$CONTAINER_NAME" --format '{{index .Config.Labels "strix-scan-id"}}')
+
+if [ -z "$SCAN_ID" ]; then
+    echo -e "${YELLOW}Warning: Could not find scan-id label. Using container name.${NC}"
+    SCAN_ID="${CONTAINER_NAME#strix-scan-}"
+fi
+
+# Determine destination directory
+RUN_DIR="strix_runs/${SCAN_ID}"
+if [ ! -d "$RUN_DIR" ]; then
+    echo -e "${YELLOW}Run directory '$RUN_DIR' doesn't exist. Creating it...${NC}"
+    mkdir -p "$RUN_DIR"
+fi
+
+EVIDENCE_DIR="${RUN_DIR}/evidence"
+mkdir -p "$EVIDENCE_DIR"
+
+echo ""
+echo -e "${GREEN}Container:${NC} $CONTAINER_NAME"
+echo -e "${GREEN}Scan ID:${NC} $SCAN_ID"
+echo -e "${GREEN}Destination:${NC} $EVIDENCE_DIR"
+echo ""
+
+# Check if container is running
+if ! docker ps --format "{{.Names}}" | grep -q "^${CONTAINER_NAME}$"; then
+    echo -e "${YELLOW}Container is not running. Starting it...${NC}"
+    docker start "$CONTAINER_NAME"
+    sleep 2
+fi
+
+# List workspace contents
+echo -e "${GREEN}Workspace contents:${NC}"
+docker exec "$CONTAINER_NAME" ls -lah /workspace
+echo ""
+
+# Ask what to copy
+echo -e "${YELLOW}What would you like to copy?${NC}"
+echo "1. Entire /workspace directory"
+echo "2. Specific file or directory"
+echo "3. List files and choose interactively"
+read -r CHOICE
+
+case $CHOICE in
+    1)
+        echo -e "${GREEN}Copying entire workspace...${NC}"
+        docker cp "${CONTAINER_NAME}:/workspace" "${EVIDENCE_DIR}/workspace"
+        echo -e "${GREEN}✓ Copied to: ${EVIDENCE_DIR}/workspace${NC}"
+        ;;
+    2)
+        echo -e "${YELLOW}Enter file or directory path (relative to /workspace):${NC}"
+        read -r SOURCE_PATH
+        docker cp "${CONTAINER_NAME}:/workspace/${SOURCE_PATH}" "${EVIDENCE_DIR}/"
+        echo -e "${GREEN}✓ Copied to: ${EVIDENCE_DIR}/${SOURCE_PATH}${NC}"
+        ;;
+    3)
+        echo -e "${YELLOW}Enter file or directory paths (one per line, empty line to finish):${NC}"
+        while IFS= read -r SOURCE_PATH; do
+            [ -z "$SOURCE_PATH" ] && break
+            echo "Copying: $SOURCE_PATH"
+            docker cp "${CONTAINER_NAME}:/workspace/${SOURCE_PATH}" "${EVIDENCE_DIR}/"
+        done
+        echo -e "${GREEN}✓ Files copied to: ${EVIDENCE_DIR}${NC}"
+        ;;
+    *)
+        echo -e "${RED}Invalid choice${NC}"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo -e "${GREEN}✓ Extraction complete!${NC}"
+echo -e "Files are available at: ${EVIDENCE_DIR}"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "opentelemetry-exporter-otlp-proto-http>=1.40.0",
   "scrubadub>=2.0.1",
   "defusedxml>=0.7.1",
+  "python-dotenv>=1.0.0",
 ]
 
 [project.scripts]

--- a/strix/config/config.py
+++ b/strix/config/config.py
@@ -6,6 +6,8 @@ from typing import Any, ClassVar
 
 
 STRIX_API_BASE = "https://models.strix.ai/api/v1"
+NOVAROUTER_API_BASE = "https://api.novarouter.orbitronai.com/v1"
+NOVAROUTER_STAGING_BASE = "https://api.stg.novarouter.orbitronai.com/v1"
 
 
 class Config:
@@ -15,6 +17,7 @@ class Config:
     strix_llm = None
     llm_api_key = None
     llm_api_base = None
+    llm_novarouter_base = None
     openai_api_base = None
     litellm_base_url = None
     ollama_api_base = None
@@ -26,6 +29,7 @@ class Config:
         "strix_llm",
         "llm_api_key",
         "llm_api_base",
+        "llm_novarouter_base",
         "openai_api_base",
         "litellm_base_url",
         "ollama_api_base",
@@ -214,6 +218,12 @@ def resolve_llm_config() -> tuple[str | None, str | None, str | None]:
 
     if model.startswith("strix/"):
         api_base: str | None = STRIX_API_BASE
+    elif model.startswith("novarouter/"):
+        base = Config.get("llm_novarouter_base")
+        if base:
+            api_base = base.rstrip("/") + "/v1" if not base.endswith("/v1") else base
+        else:
+            api_base = NOVAROUTER_API_BASE
     else:
         api_base = (
             Config.get("llm_api_base")

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -3,6 +3,12 @@
 Strix Agent Interface
 """
 
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[2] / ".env")
+
 import argparse
 import asyncio
 import logging

--- a/strix/interface/utils.py
+++ b/strix/interface/utils.py
@@ -1349,28 +1349,66 @@ def clone_repository(repo_url: str, run_name: str, dest_name: str | None = None)
 
 # Docker utilities
 def check_docker_connection() -> Any:
+    import os
+    import platform
+
+    # Method 1: Try docker.from_env() (default)
     try:
-        return docker.from_env()
+        client = docker.from_env()
+        client.ping()
+        return client
     except DockerException:
-        console = Console()
-        error_text = Text()
-        error_text.append("DOCKER NOT AVAILABLE", style="bold red")
-        error_text.append("\n\n", style="white")
-        error_text.append("Cannot connect to Docker daemon.\n", style="white")
+        pass
+
+    # Method 2: Try macOS Docker Desktop socket
+    socket_paths = [
+        str(Path.home() / ".docker" / "run" / "docker.sock"),
+        "/var/run/docker.sock",
+    ]
+    for socket_path in socket_paths:
+        if Path(socket_path).exists():
+            try:
+                client = docker.DockerClient(base_url=f"unix://{socket_path}")
+                client.ping()
+                return client
+            except DockerException:
+                pass
+
+    # Method 3: Try DOCKER_HOST environment variable
+    docker_host = os.getenv("DOCKER_HOST")
+    if docker_host:
+        try:
+            client = docker.DockerClient(base_url=docker_host)
+            client.ping()
+            return client
+        except DockerException:
+            pass
+
+    # All connection attempts failed
+    console = Console()
+    error_text = Text()
+    error_text.append("DOCKER NOT AVAILABLE", style="bold red")
+    error_text.append("\n\n", style="white")
+    error_text.append("Cannot connect to Docker daemon.\n", style="white")
+    if platform.system() == "Darwin":
         error_text.append(
-            "Please ensure Docker Desktop is installed and running, and try running strix again.\n",
+            "On macOS: ensure Docker Desktop is running. Try: open -a Docker\n",
             style="white",
         )
+    error_text.append(
+        "Please ensure Docker Desktop is installed and running, and try running strix again.\n",
+        style="white",
+    )
 
-        panel = Panel(
-            error_text,
-            title="[bold white]STRIX",
-            title_align="left",
-            border_style="red",
-            padding=(1, 2),
-        )
-        console.print("\n", panel, "\n")
-        raise RuntimeError("Docker not available") from None
+    panel = Panel(
+        error_text,
+        title="[bold white]STRIX",
+        title_align="left",
+        border_style="red",
+        padding=(1, 2),
+    )
+    console.print("\n", panel, "\n")
+    raise RuntimeError("Docker not available") from None
 
 
 def image_exists(client: Any, image_name: str) -> bool:

--- a/strix/llm/utils.py
+++ b/strix/llm/utils.py
@@ -55,20 +55,27 @@ STRIX_MODEL_MAP: dict[str, str] = {
 
 
 def resolve_strix_model(model_name: str | None) -> tuple[str | None, str | None]:
-    """Resolve a strix/ model into names for API calls and capability lookups.
+    """Resolve a strix/ or novarouter/ model into names for API calls and capability lookups.
 
     Returns (api_model, canonical_model):
-    - api_model: openai/<base> for API calls (Strix API is OpenAI-compatible)
+    - api_model: openai/<base> for API calls (OpenAI-compatible endpoints)
     - canonical_model: actual provider model name for litellm capability lookups
-    Non-strix models return the same name for both.
+    Non-prefixed models return the same name for both.
     """
-    if not model_name or not model_name.startswith("strix/"):
+    if not model_name:
         return model_name, model_name
 
-    base_model = model_name[6:]
-    api_model = f"openai/{base_model}"
-    canonical_model = STRIX_MODEL_MAP.get(base_model, api_model)
-    return api_model, canonical_model
+    if model_name.startswith("strix/"):
+        base_model = model_name[6:]
+        api_model = f"openai/{base_model}"
+        canonical_model = STRIX_MODEL_MAP.get(base_model, api_model)
+        return api_model, canonical_model
+
+    if model_name.startswith("novarouter/"):
+        base_model = model_name[11:]
+        return f"openai/{base_model}", f"openai/{base_model}"
+
+    return model_name, model_name
 
 
 def _truncate_to_first_function(content: str) -> str:

--- a/strix/runtime/docker_runtime.py
+++ b/strix/runtime/docker_runtime.py
@@ -18,6 +18,7 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import Timeout as RequestsTimeout
 
 from strix.config import Config
+from strix.interface.utils import check_docker_connection
 
 from . import SandboxInitializationError
 from .runtime import AbstractRuntime, SandboxInfo
@@ -32,8 +33,8 @@ CONTAINER_CAIDO_PORT = 48080
 class DockerRuntime(AbstractRuntime):
     def __init__(self) -> None:
         try:
-            self.client = docker.from_env(timeout=DOCKER_TIMEOUT)
-        except (DockerException, RequestsConnectionError, RequestsTimeout) as e:
+            self.client = check_docker_connection()
+        except RuntimeError as e:
             raise SandboxInitializationError(
                 "Docker is not available",
                 "Please ensure Docker Desktop is installed and running.",

--- a/strix/telemetry/tracer.py
+++ b/strix/telemetry/tracer.py
@@ -7,8 +7,13 @@ from pathlib import Path
 from typing import Any, Optional
 from uuid import uuid4
 
-from opentelemetry import trace
-from opentelemetry.trace import SpanContext, SpanKind
+try:
+    from opentelemetry import trace
+    from opentelemetry.trace import SpanContext, SpanKind
+except ImportError:
+    trace = None  # type: ignore[assignment]
+    SpanContext = None  # type: ignore[assignment,misc]
+    SpanKind = None  # type: ignore[assignment,misc]
 
 from strix.config import Config
 from strix.telemetry import posthog
@@ -206,9 +211,10 @@ class Tracer:
         span_id: str | None = None
         parent_span_id: str | None = None
 
-        current_context = trace.get_current_span().get_span_context()
-        if isinstance(current_context, SpanContext) and current_context.is_valid:
-            parent_span_id = format_span_id(current_context.span_id)
+        if trace is not None and SpanContext is not None:
+            current_context = trace.get_current_span().get_span_context()
+            if isinstance(current_context, SpanContext) and current_context.is_valid:
+                parent_span_id = format_span_id(current_context.span_id)
 
         if self._otel_tracer is not None:
             try:

--- a/strix/telemetry/utils.py
+++ b/strix/telemetry/utils.py
@@ -7,14 +7,26 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from opentelemetry import trace
-from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
-from opentelemetry.sdk.trace.export import (
-    BatchSpanProcessor,
-    SimpleSpanProcessor,
-    SpanExporter,
-    SpanExportResult,
-)
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        SimpleSpanProcessor,
+        SpanExporter,
+        SpanExportResult,
+    )
+    _OTEL_AVAILABLE = True
+except ImportError:
+    trace = None  # type: ignore[assignment]
+    ReadableSpan = None  # type: ignore[assignment,misc]
+    TracerProvider = None  # type: ignore[assignment,misc]
+    BatchSpanProcessor = None  # type: ignore[assignment,misc]
+    SimpleSpanProcessor = None  # type: ignore[assignment,misc]
+    SpanExporter = None  # type: ignore[assignment,misc]
+    SpanExportResult = None  # type: ignore[assignment,misc]
+    _OTEL_AVAILABLE = False
+
 from scrubadub import Scrubber
 from scrubadub.detectors import RegexDetector
 from scrubadub.filth import Filth
@@ -203,102 +215,107 @@ def prune_otel_span_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
     return filtered
 
 
-class JsonlSpanExporter(SpanExporter):  # type: ignore[misc]
-    """Append OTEL spans to JSONL for local run artifacts."""
+if _OTEL_AVAILABLE:
 
-    def __init__(
-        self,
-        output_path_getter: Callable[[], Path],
-        run_metadata_getter: Callable[[], dict[str, Any]],
-        sanitizer: Callable[[Any], Any],
-        write_lock_getter: Callable[[Path], threading.Lock],
-    ):
-        self._output_path_getter = output_path_getter
-        self._run_metadata_getter = run_metadata_getter
-        self._sanitize = sanitizer
-        self._write_lock_getter = write_lock_getter
+    class JsonlSpanExporter(SpanExporter):  # type: ignore[misc]
+        """Append OTEL spans to JSONL for local run artifacts."""
 
-    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
-        records: list[dict[str, Any]] = []
-        for span in spans:
-            attributes = prune_otel_span_attributes(dict(span.attributes or {}))
-            if "strix.event_type" in attributes:
-                # Tracer events are written directly in Tracer._emit_event.
-                continue
-            records.append(self._span_to_record(span, attributes))
+        def __init__(
+            self,
+            output_path_getter: Callable[[], Path],
+            run_metadata_getter: Callable[[], dict[str, Any]],
+            sanitizer: Callable[[Any], Any],
+            write_lock_getter: Callable[[Path], threading.Lock],
+        ):
+            self._output_path_getter = output_path_getter
+            self._run_metadata_getter = run_metadata_getter
+            self._sanitize = sanitizer
+            self._write_lock_getter = write_lock_getter
 
-        if not records:
+        def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+            records: list[dict[str, Any]] = []
+            for span in spans:
+                attributes = prune_otel_span_attributes(dict(span.attributes or {}))
+                if "strix.event_type" in attributes:
+                    # Tracer events are written directly in Tracer._emit_event.
+                    continue
+                records.append(self._span_to_record(span, attributes))
+
+            if not records:
+                return SpanExportResult.SUCCESS
+
+            try:
+                output_path = self._output_path_getter()
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                with self._write_lock_getter(output_path), output_path.open("a", encoding="utf-8") as f:
+                    for record in records:
+                        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+            except OSError:
+                logger.exception("Failed to write OTEL span records to JSONL")
+                return SpanExportResult.FAILURE
+
             return SpanExportResult.SUCCESS
 
-        try:
-            output_path = self._output_path_getter()
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            with self._write_lock_getter(output_path), output_path.open("a", encoding="utf-8") as f:
-                for record in records:
-                    f.write(json.dumps(record, ensure_ascii=False) + "\n")
-        except OSError:
-            logger.exception("Failed to write OTEL span records to JSONL")
-            return SpanExportResult.FAILURE
+        def shutdown(self) -> None:
+            return None
 
-        return SpanExportResult.SUCCESS
+        def force_flush(self, timeout_millis: int = 30_000) -> bool:  # noqa: ARG002
+            return True
 
-    def shutdown(self) -> None:
-        return None
+        def _span_to_record(
+            self,
+            span: ReadableSpan,
+            attributes: dict[str, Any],
+        ) -> dict[str, Any]:
+            span_context = span.get_span_context()
+            parent_context = span.parent
 
-    def force_flush(self, timeout_millis: int = 30_000) -> bool:  # noqa: ARG002
-        return True
+            status = None
+            if span.status and span.status.status_code:
+                status = span.status.status_code.name.lower()
 
-    def _span_to_record(
-        self,
-        span: ReadableSpan,
-        attributes: dict[str, Any],
-    ) -> dict[str, Any]:
-        span_context = span.get_span_context()
-        parent_context = span.parent
-
-        status = None
-        if span.status and span.status.status_code:
-            status = span.status.status_code.name.lower()
-
-        event_type = str(attributes.get("gen_ai.operation.name", span.name))
-        run_metadata = self._run_metadata_getter()
-        run_id_attr = (
-            attributes.get("strix.run_id")
-            or attributes.get("strix_run_id")
-            or run_metadata.get("run_id")
-            or span.resource.attributes.get("strix.run_id")
-        )
-
-        record: dict[str, Any] = {
-            "timestamp": iso_from_unix_ns(span.end_time) or datetime.now(UTC).isoformat(),
-            "event_type": event_type,
-            "run_id": str(run_id_attr or run_metadata.get("run_id") or ""),
-            "trace_id": format_trace_id(span_context.trace_id),
-            "span_id": format_span_id(span_context.span_id),
-            "parent_span_id": format_span_id(parent_context.span_id if parent_context else None),
-            "actor": None,
-            "payload": None,
-            "status": status,
-            "error": None,
-            "source": "otel.span",
-            "span_name": span.name,
-            "span_kind": span.kind.name.lower(),
-            "attributes": self._sanitize(attributes),
-        }
-
-        if span.events:
-            record["otel_events"] = self._sanitize(
-                [
-                    {
-                        "name": event.name,
-                        "timestamp": iso_from_unix_ns(event.timestamp),
-                        "attributes": dict(event.attributes or {}),
-                    }
-                    for event in span.events
-                ]
+            event_type = str(attributes.get("gen_ai.operation.name", span.name))
+            run_metadata = self._run_metadata_getter()
+            run_id_attr = (
+                attributes.get("strix.run_id")
+                or attributes.get("strix_run_id")
+                or run_metadata.get("run_id")
+                or span.resource.attributes.get("strix.run_id")
             )
 
-        return record
+            record: dict[str, Any] = {
+                "timestamp": iso_from_unix_ns(span.end_time) or datetime.now(UTC).isoformat(),
+                "event_type": event_type,
+                "run_id": str(run_id_attr or run_metadata.get("run_id") or ""),
+                "trace_id": format_trace_id(span_context.trace_id),
+                "span_id": format_span_id(span_context.span_id),
+                "parent_span_id": format_span_id(parent_context.span_id if parent_context else None),
+                "actor": None,
+                "payload": None,
+                "status": status,
+                "error": None,
+                "source": "otel.span",
+                "span_name": span.name,
+                "span_kind": span.kind.name.lower(),
+                "attributes": self._sanitize(attributes),
+            }
+
+            if span.events:
+                record["otel_events"] = self._sanitize(
+                    [
+                        {
+                            "name": event.name,
+                            "timestamp": iso_from_unix_ns(event.timestamp),
+                            "attributes": dict(event.attributes or {}),
+                        }
+                        for event in span.events
+                    ]
+                )
+
+            return record
+
+else:
+    JsonlSpanExporter = None  # type: ignore[assignment,misc]
 
 
 def bootstrap_otel(
@@ -316,6 +333,9 @@ def bootstrap_otel(
     write_lock_getter: Callable[[Path], threading.Lock],
     tracer_name: str = "strix.telemetry.tracer",
 ) -> tuple[Any, bool, bool, bool]:
+    if not _OTEL_AVAILABLE or trace is None:
+        return (None, False, bootstrapped, remote_enabled_state)
+
     with bootstrap_lock:
         if bootstrapped:
             return (

--- a/strix/tools/agents_graph/agents_graph_actions.py
+++ b/strix/tools/agents_graph/agents_graph_actions.py
@@ -1,6 +1,7 @@
+import asyncio
+import re
 import threading
 from datetime import UTC, datetime
-import re
 from typing import Any, Literal
 
 from strix.tools.registry import register_tool
@@ -15,7 +16,7 @@ _root_agent_id: str | None = None
 
 _agent_messages: dict[str, list[dict[str, Any]]] = {}
 
-_running_agents: dict[str, threading.Thread] = {}
+_running_agents: dict[str, asyncio.Task[Any]] = {}
 
 _agent_instances: dict[str, Any] = {}
 
@@ -202,7 +203,7 @@ def _append_wiki_update_on_finish(
         return
 
 
-def _run_agent_in_thread(
+async def _run_agent_async(
     agent: Any, state: Any, inherited_messages: list[dict[str, Any]]
 ) -> dict[str, Any]:
     try:
@@ -269,14 +270,7 @@ def _run_agent_in_thread(
 
         _agent_graph["nodes"][state.agent_id]["state"] = state.model_dump()
 
-        import asyncio
-
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            result = loop.run_until_complete(agent.agent_loop(state.task))
-        finally:
-            loop.close()
+        result = await agent.agent_loop(state.task)
 
     except Exception as e:
         _agent_graph["nodes"][state.agent_id]["status"] = "error"
@@ -467,14 +461,25 @@ def create_agent(
         with _agent_llm_stats_lock:
             _agent_instances[state.agent_id] = agent
 
-        thread = threading.Thread(
-            target=_run_agent_in_thread,
-            args=(agent, state, inherited_messages),
-            daemon=True,
-            name=f"Agent-{name}-{state.agent_id}",
+        # Create async task for agent execution
+        # Get the current event loop, creating one if needed
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # If no event loop is running, we need to handle this differently
+            # This shouldn't happen in normal operation since tools are called from async context
+            return {
+                "success": False,
+                "error": "No event loop available. Agent creation must be called from async context.",
+                "agent_id": None,
+            }
+
+        # Create the async task
+        task = loop.create_task(
+            _run_agent_async(agent, state, inherited_messages),
+            name=f"Agent-{name}-{state.agent_id}",  # type: ignore[arg-type]
         )
-        thread.start()
-        _running_agents[state.agent_id] = thread
+        _running_agents[state.agent_id] = task  # type: ignore[assignment]
 
     except Exception as e:  # noqa: BLE001
         return {"success": False, "error": f"Failed to create agent: {e}", "agent_id": None}
@@ -714,6 +719,12 @@ def stop_agent(agent_id: str) -> dict[str, Any]:
                 agent_instance.state.request_stop()
             if hasattr(agent_instance, "cancel_current_execution"):
                 agent_instance.cancel_current_execution()
+
+        # Cancel the async task if it exists
+        if agent_id in _running_agents:
+            task = _running_agents[agent_id]
+            if not task.done():
+                task.cancel()
 
         agent_node["status"] = "stopping"
 

--- a/strix/tools/executor.py
+++ b/strix/tools/executor.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import os
 from typing import Any
@@ -321,15 +322,59 @@ async def process_tool_invocations(
 
     tracer, agent_id = _get_tracer_and_agent_id(agent_state)
 
-    for tool_inv in tool_invocations:
-        observation_xml, images, tool_should_finish = await _execute_single_tool(
-            tool_inv, agent_state, tracer, agent_id
-        )
-        observation_parts.append(observation_xml)
-        all_images.extend(images)
+    # Execute all tools concurrently for better performance
+    if len(tool_invocations) == 0:
+        return False
 
-        if tool_should_finish:
-            should_agent_finish = True
+    # Create tasks for all tool invocations
+    tasks = [
+        _execute_single_tool(tool_inv, agent_state, tracer, agent_id)
+        for tool_inv in tool_invocations
+    ]
+
+    # Execute all tools in parallel and collect results
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Process results in order, handling any exceptions
+    for i, result in enumerate(results):
+        # Check if result is an exception (from return_exceptions=True)
+        if isinstance(result, BaseException):
+            # Handle errors gracefully
+            tool_name = tool_invocations[i].get("toolName", "unknown")
+            error_msg = str(result)
+            if len(error_msg) > 500:
+                error_msg = error_msg[:500] + "... [truncated]"
+            
+            observation_xml = (
+                f"<tool_result>\n<tool_name>{tool_name}</tool_name>\n"
+                f"<result>Error: {error_msg}</result>\n</tool_result>"
+            )
+            observation_parts.append(observation_xml)
+            
+            # Log error to tracer if available
+            if tracer:
+                args = tool_invocations[i].get("args", {})
+                execution_id = tracer.log_tool_execution_start(agent_id, tool_name, args)
+                tracer.update_tool_execution(execution_id, "error", error_msg)
+            continue
+
+        # At this point, result is guaranteed to be a tuple from _execute_single_tool
+        # Type: tuple[str, list[dict[str, Any]], bool]
+        try:
+            observation_xml, images, tool_should_finish = result  # type: ignore[misc]
+            observation_parts.append(observation_xml)
+            all_images.extend(images)
+
+            if tool_should_finish:
+                should_agent_finish = True
+        except (ValueError, TypeError) as e:
+            # Unexpected result type - log as error
+            tool_name = tool_invocations[i].get("toolName", "unknown")
+            observation_xml = (
+                f"<tool_result>\n<tool_name>{tool_name}</tool_name>\n"
+                f"<result>Error: Unexpected result type: {type(result)}, error: {e}</result>\n</tool_result>"
+            )
+            observation_parts.append(observation_xml)
 
     if all_images:
         content = [{"type": "text", "text": "Tool Results:\n\n" + "\n\n".join(observation_parts)}]


### PR DESCRIPTION
## Summary
- Run child agents as `asyncio` tasks instead of daemon threads for correct async integration
- Add NovaRouter LLM gateway support (`novarouter/` model prefix, config, docs)
- Improve Docker socket discovery on macOS, optional OpenTelemetry imports, `.env` loading via `python-dotenv`
- Add Makefile `docker-build` targets and local Docker build docs

## Test plan
- [ ] `uv run pytest tests/tools/test_agents_graph_whitebox.py -v`
- [ ] `uv run ruff check strix/`
- [ ] Verify `create_agent` works from async tool executor path
- [ ] Smoke test with `STRIX_LLM=novarouter/...` if NovaRouter credentials available

## Risk
Medium — changes agent concurrency model and LLM routing.

## Rollout
Merge to `main`; no infra changes.

## Rollback
Revert merge commit.


Made with [Cursor](https://cursor.com)