### PR TITLE
fix: PyInstaller bundle is broken (missing agents SDK data + wrongly excluded gql); bump to 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "strix-agent"
-version = "1.0.0"
+version = "1.0.1"
 description = "Open-source AI Hackers for your apps"
 readme = "README.md"
 license = "Apache-2.0"

--- a/strix.spec
+++ b/strix.spec
@@ -32,6 +32,8 @@ datas += collect_data_files('tiktoken_ext')
 
 datas += collect_data_files('litellm')
 
+datas += collect_data_files('agents', includes=['**/*.md', '**/*.jinja', '**/*.json'])
+
 hiddenimports = [
     # Core dependencies
     'litellm',
@@ -188,9 +190,6 @@ excludes = [
     'pyte',
     'openhands_aci',
     'openhands-aci',
-    'gql',
-    'fastapi',
-    'uvicorn',
     'numpydoc',
 
     # Google Cloud / Vertex AI

--- a/uv.lock
+++ b/uv.lock
@@ -2035,7 +2035,7 @@ wheels = [
 
 [[package]]
 name = "strix-agent"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "caido-sdk-client" },


### PR DESCRIPTION
The v1.0.0 standalone binaries crash on startup with two errors:

1. `FileNotFoundError` reading `agents/sandbox/memory/prompts/memory_consolidation_prompt.md` — `strix.spec` didn't collect data files from the openai-agents SDK, so the bundled binary is missing the prompt markdown the SDK reads at import time.
2. `ModuleNotFoundError: No module named 'gql'` — `gql` was in the excludes list but `caido-sdk-client` needs it transitively. `fastapi`/`uvicorn` were similarly wrong excludes (also needed at runtime).

## Fixes

- `strix.spec`: add `collect_data_files('agents', includes=['**/*.md', '**/*.jinja', '**/*.json'])` so the SDK's prompt + jinja files end up in the bundle.
- `strix.spec`: drop `gql`, `fastapi`, `uvicorn` from excludes.
- `pyproject.toml` + `uv.lock`: bump to `1.0.1`.

## Verified locally

Rebuilt the binary on macOS arm64 with the same path CI uses (`uv sync --frozen` + `uv run pyinstaller strix.spec --noconfirm`):

- `./dist/strix --version` → `strix 1.0.0` (will be 1.0.1 once merged)
- `./dist/strix --help` → renders cleanly

## Scope

- Affects the standalone PyInstaller binaries on GitHub Releases.
- Does **not** affect the Docker image (`ghcr.io/usestrix/strix-sandbox:1.0.0`) — the image stays pinned.
- Does **not** affect the PyPI package (`strix-agent` ships Python source, not a frozen bundle).

Once merged, tag `v1.0.1` → CI rebuilds binaries → publish 1.0.1 to PyPI.