### PR TITLE
fix: reasoning models reject tool_choice=required; bump to 1.0.2 (closes #503, #505)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "strix-agent"
-version = "1.0.1"
+version = "1.0.2"
 description = "Open-source AI Hackers for your apps"
 readme = "README.md"
 license = "Apache-2.0"

--- a/strix/agents/prompts/system_prompt.jinja
+++ b/strix/agents/prompts/system_prompt.jinja
@@ -43,6 +43,7 @@ AUTONOMOUS BEHAVIOR:
 - NEVER send an empty or blank message. If you have no content to output or need to wait (for user input, subagent results, or any other reason), you MUST call the wait_for_message tool (or another appropriate tool) instead of emitting an empty response.
 - If there is nothing to execute and no user query to answer any more: do NOT send filler/repetitive text — either call wait_for_message or finish your work (subagents: agent_finish; root: finish_scan)
 - While the agent loop is running, almost every output MUST be a tool call. Do NOT send plain text messages; act via tools. If idle, use wait_for_message; when done, use agent_finish (subagents) or finish_scan (root)
+- A text-only turn — even one — IMMEDIATELY ends the scan/run with no report written. The lifecycle tools (``finish_scan`` for root, ``agent_finish`` for subagents) are the ONLY valid way to terminate. If you find yourself wanting to say "Done!" or "Scan complete" without a tool call, call the lifecycle tool instead — the report and termination signal both flow through it.
 {% endif %}
 </communication_rules>
 

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -109,13 +109,19 @@ def build_scope_context(scan_config: dict[str, Any]) -> dict[str, Any]:
 def make_model_settings(
     reasoning_effort: ReasoningEffort | None,
 ) -> ModelSettings:
+    # Anthropic + DeepSeek thinking reject ``tool_choice="required"`` outright
+    # when reasoning is enabled; OpenAI o-series accepts both but doesn't need
+    # the safety net. When reasoning is on we let the model self-select tools
+    # and rely on the system prompt + the ``_finish_tool_use_behavior`` callback
+    # to keep the loop converging on a lifecycle tool.
+    use_reasoning = reasoning_effort is not None and reasoning_effort != "none"
     model_settings = ModelSettings(
         parallel_tool_calls=False,
-        tool_choice="required",
+        tool_choice=None if use_reasoning else "required",
         retry=DEFAULT_MODEL_RETRY,
         include_usage=True,
     )
-    if reasoning_effort is not None:
+    if use_reasoning:
         model_settings = model_settings.resolve(
             ModelSettings(reasoning=Reasoning(effort=reasoning_effort)),
         )

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -284,6 +284,8 @@ async def run_strix_scan(
                     scan_completed = bool(isinstance(parsed, dict) and parsed.get("scan_completed"))
                 except (ValueError, TypeError):
                     scan_completed = False
+            elif isinstance(final, dict):
+                scan_completed = bool(final.get("scan_completed"))
             if not scan_completed:
                 logger.error(
                     "Scan %s ended without calling finish_scan. The agent "

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -261,7 +261,7 @@ async def run_strix_scan(
         async with coordinator._lock:
             root_status = coordinator.statuses.get(root_id)
 
-        return await run_agent_loop(
+        result = await run_agent_loop(
             agent=root_agent,
             initial_input=initial_input,
             run_config=run_config,
@@ -275,6 +275,25 @@ async def run_strix_scan(
             event_sink=event_sink,
             hooks=hooks,
         )
+        if not interactive and result is not None:
+            final = getattr(result, "final_output", None)
+            scan_completed = False
+            if isinstance(final, str):
+                try:
+                    parsed = json.loads(final)
+                    scan_completed = bool(isinstance(parsed, dict) and parsed.get("scan_completed"))
+                except (ValueError, TypeError):
+                    scan_completed = False
+            if not scan_completed:
+                logger.error(
+                    "Scan %s ended without calling finish_scan. The agent "
+                    "emitted a text-only turn instead of a lifecycle tool call, "
+                    "so no executive report was written. Final output (first "
+                    "300 chars): %r",
+                    scan_id,
+                    str(final)[:300],
+                )
+        return result  # noqa: TRY300
     except BaseException:
         logger.exception("Strix scan %s failed", scan_id)
         if root_id is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -2035,7 +2035,7 @@ wheels = [
 
 [[package]]
 name = "strix-agent"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "caido-sdk-client" },


### PR DESCRIPTION
Fixes [#503](https://github.com/usestrix/strix/issues/503) and [#505](https://github.com/usestrix/strix/issues/505).

## Issue

Every scan against a reasoning-capable model fails immediately with provider-side 400s:

- Anthropic Claude with thinking: `"Thinking may not be enabled when tool_choice forces tool use"`
- DeepSeek V4 thinking: `"Thinking mode does not support this tool_choice"`

Affects `anthropic/claude-sonnet-4-6`, `anthropic/claude-opus-4-7`, DeepSeek V4 thinking, and any future reasoning-capable provider.

## Root cause

`strix/core/inputs.py:make_model_settings()` unconditionally sets `tool_choice="required"` AND attaches `Reasoning(effort=...)`. This combination is rejected provider-side. Quoting Anthropic's docs:

> *"Tool use with thinking only supports `tool_choice: {"type": "auto"}` (the default) or `tool_choice: {"type": "none"}`. Using `tool_choice: {"type": "any"}` … will result in an error because these options force tool use, which is incompatible with extended thinking."*

LiteLLM has declined to normalize this client-side ([BerriAI/litellm#8883](https://github.com/BerriAI/litellm/issues/8883)). LangChain and pydantic-ai both shipped client-side fixes for the same constraint ([langchain#35544](https://github.com/langchain-ai/langchain/pull/35544), [pydantic-ai#3611](https://github.com/pydantic/pydantic-ai/pull/3611)).

## Fixes

- **\`make_model_settings()\`** — drop \`tool_choice="required"\` when reasoning is enabled. Use SDK default (\`None\` → auto). Lifecycle-tool termination is still enforced by \`_finish_tool_use_behavior\` in the agent factory.
- **\`STRIX_REASONING_EFFORT="none"\` crash** — previously crashed with \`AttributeError: 'NoneType' object has no attribute 'get'\` because the literal string \`"none"\` was truthy and made it into LiteLLM's reasoning path. Now treated as "do not attach \`Reasoning(...)\`" — restores the documented escape hatch.
- **System prompt** — reinforced that text-only turns terminate the scan, since the SDK considers a text-only response the final output when \`tool_choice\` isn't forced. One new explicit line near existing strong language.
- **Runner defensive check** — when a non-interactive scan ends without \`finish_scan\` being called, log a clear error pointing at the text-ended turn. Replaces silent half-scans.

## Behavior matrix after the fix

| \`STRIX_REASONING_EFFORT\` | \`tool_choice\` | \`reasoning\` attached |
|---|---|---|
| (unset → default \`high\`) | \`None\` (auto) | yes |
| \`low\` / \`medium\` / \`high\` / \`xhigh\` | \`None\` (auto) | yes |
| \`"none"\` | \`"required"\` | **no** (literal \`"none"\` is now treated as off) |
| \`None\` (Python) | \`"required"\` | no |

## Provider impact

| Provider | Before | After |
|---|---|---|
| Anthropic Claude + thinking | 400 immediately | works |
| DeepSeek V4 thinking | 400 immediately | works |
| OpenAI o-series | works | works (loses \`required\` safety net, but follows instructions reliably) |
| OpenAI gpt-5.x non-reasoning | works | works |
| Any model with reasoning off | works | works (unchanged) |

## Version

Bumped to **1.0.2**. After merge → tag \`v1.0.2\` → CI binaries + PyPI publish.

Docker image stays at \`:1.0.0\` (unaffected).