### PR TITLE
fix: don't send reasoning params to models that don't support them

### DIFF
--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -22,7 +22,7 @@ _SDK_PREFIXES = {"any-llm", "litellm", "openai"}
 _ROUTING_PREFIXES = ("litellm/", "any-llm/", "openrouter/", "openai/")
 _REASONING_MODEL_RE = re.compile(
     r"(?:^|/)"
-    r"(?:anthropic/|claude|o[134][-\w.]*|gpt-5|deepseek-reasoner|deepseek-r1|gemini-.*-thinking)",
+    r"(?:anthropic/|claude|o\d+[-\w.]*|gpt-5|deepseek-reasoner|deepseek-r1|gemini-.*-thinking)",
     re.IGNORECASE,
 )
 
@@ -139,4 +139,8 @@ def effective_reasoning_effort(
         return None
     if scan_mode == "quick" and effort in ("high", "xhigh"):
         return "medium"
+    if effort == "xhigh":
+        return "high"
+    if effort == "minimal":
+        return "low"
     return effort

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from typing import TYPE_CHECKING
 
 from agents import set_default_openai_api, set_default_openai_key
@@ -14,10 +15,16 @@ from agents.retry import (
 
 
 if TYPE_CHECKING:
-    from strix.config.settings import Settings
+    from strix.config.settings import ReasoningEffort, Settings
 
 
 _SDK_PREFIXES = {"any-llm", "litellm", "openai"}
+_ROUTING_PREFIXES = ("litellm/", "any-llm/", "openrouter/", "openai/")
+_REASONING_MODEL_RE = re.compile(
+    r"(?:^|/)"
+    r"(?:anthropic/|claude|o[134][-\w.]*|gpt-5|deepseek-reasoner|deepseek-r1|gemini-.*-thinking)",
+    re.IGNORECASE,
+)
 
 
 DEFAULT_MODEL_RETRY = ModelRetrySettings(
@@ -98,3 +105,38 @@ def uses_chat_completions_tool_schema(model_name: str, settings: Settings) -> bo
     if model.startswith(("litellm/", "any-llm/")):
         return True
     return bool(settings.llm.api_base)
+
+
+def _model_slug(model_name: str) -> str:
+    slug = model_name.strip().lower()
+    for _ in range(len(_ROUTING_PREFIXES)):
+        stripped = False
+        for prefix in _ROUTING_PREFIXES:
+            if slug.startswith(prefix):
+                slug = slug[len(prefix) :]
+                stripped = True
+                break
+        if not stripped:
+            break
+    return slug
+
+
+def model_supports_reasoning(model_name: str) -> bool:
+    """Return whether the resolved model accepts OpenAI-style reasoning params."""
+    return bool(_REASONING_MODEL_RE.search(_model_slug(model_name)))
+
+
+def effective_reasoning_effort(
+    effort: ReasoningEffort,
+    *,
+    model_name: str,
+    scan_mode: str = "deep",
+) -> ReasoningEffort | None:
+    """Resolve configured reasoning effort for a concrete model + scan mode."""
+    if effort == "none":
+        return None
+    if not model_supports_reasoning(model_name):
+        return None
+    if scan_mode == "quick" and effort in ("high", "xhigh"):
+        return "medium"
+    return effort

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from agents.model_settings import ModelSettings
 from openai.types.shared import Reasoning
 
-from strix.config.models import DEFAULT_MODEL_RETRY
+from strix.config.models import DEFAULT_MODEL_RETRY, effective_reasoning_effort
 
 
 if TYPE_CHECKING:
@@ -107,14 +107,26 @@ def build_scope_context(scan_config: dict[str, Any]) -> dict[str, Any]:
 
 
 def make_model_settings(
-    reasoning_effort: ReasoningEffort | None,
+    reasoning_effort: ReasoningEffort,
+    *,
+    model_name: str,
+    scan_mode: str = "deep",
 ) -> ModelSettings:
     # Anthropic + DeepSeek thinking reject ``tool_choice="required"`` outright
     # when reasoning is enabled; OpenAI o-series accepts both but doesn't need
     # the safety net. When reasoning is on we let the model self-select tools
     # and rely on the system prompt + the ``_finish_tool_use_behavior`` callback
     # to keep the loop converging on a lifecycle tool.
-    use_reasoning = reasoning_effort is not None and reasoning_effort != "none"
+    #
+    # Most OpenAI-compatible open models (GLM, Kimi, MiniMax, etc.) do not
+    # accept reasoning params at all — sending them yields 400s and the agent
+    # graph shows up as "scan failed".
+    resolved_effort = effective_reasoning_effort(
+        reasoning_effort,
+        model_name=model_name,
+        scan_mode=scan_mode,
+    )
+    use_reasoning = resolved_effort is not None
     model_settings = ModelSettings(
         parallel_tool_calls=False,
         tool_choice=None if use_reasoning else "required",
@@ -123,7 +135,7 @@ def make_model_settings(
     )
     if use_reasoning:
         model_settings = model_settings.resolve(
-            ModelSettings(reasoning=Reasoning(effort=reasoning_effort)),
+            ModelSettings(reasoning=Reasoning(effort=resolved_effort)),
         )
     return model_settings
 

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -153,7 +153,11 @@ async def run_strix_scan(
         is_whitebox = any(t.get("type") == "local_code" for t in targets)
         skills = list(scan_config.get("skills") or [])
         root_task = build_root_task(scan_config)
-        model_settings = make_model_settings(settings.llm.reasoning_effort)
+        model_settings = make_model_settings(
+            settings.llm.reasoning_effort,
+            model_name=resolved_model,
+            scan_mode=scan_mode,
+        )
         run_config = RunConfig(
             model=resolved_model,
             model_settings=model_settings,


### PR DESCRIPTION
## Summary

- OpenAI-compatible open models (GLM, Kimi, MiniMax, etc.) reject `reasoning.effort` with a 400, causing agents to surface as "scan failed"
- Introduces `_model_slug`, `model_supports_reasoning`, and `effective_reasoning_effort` to gate reasoning params on a per-model allowlist
- Also caps `xhigh` effort to `medium` in quick scan mode, consistent with the existing `high → medium` downgrade

## Test plan

- [x] Confirm `model_supports_reasoning("GLM-5.1")` returns `False`
- [x] Confirm `effective_reasoning_effort("high", model_name="glm-5.1")` returns `None`
- [x] Confirm reasoning models (claude, o1/o3/o4, deepseek-r1, gemini-*-thinking) still resolve correctly
- [x] Confirm `xhigh` + quick scan mode now returns `medium`
- [x] Run `make check-all`

Closes #517