### PR TITLE
Simplify LLM configuration layer (closes #504)

### DIFF
--- a/strix/agents/factory.py
+++ b/strix/agents/factory.py
@@ -395,7 +395,6 @@ def build_strix_agent(
         instructions=instructions,
         tools=tools,
         tool_use_behavior=_finish_tool_use_behavior,
-        reset_tool_choice=interactive,
         model=None,
         capabilities=[
             Filesystem(

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -61,7 +61,7 @@ def configure_sdk_model_defaults(settings: Settings) -> None:
 def _mirror_api_key_to_provider_env(model_name: str | None, api_key: str) -> None:
     if not model_name:
         return
-    name = model_name.strip()
+    name = normalize_model_name(model_name)
     for prefix in ("litellm/", "any-llm/"):
         if name.lower().startswith(prefix):
             name = name[len(prefix) :]

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -61,17 +61,20 @@ def configure_sdk_model_defaults(settings: Settings) -> None:
 def _mirror_api_key_to_provider_env(model_name: str | None, api_key: str) -> None:
     if not model_name:
         return
+    import litellm
+
     name = normalize_model_name(model_name)
     for prefix in ("litellm/", "any-llm/"):
         if name.lower().startswith(prefix):
             name = name[len(prefix) :]
             break
-    if "/" not in name:
+    try:
+        report = litellm.validate_environment(model=name.lower())
+    except Exception:  # noqa: BLE001
         return
-    provider = name.split("/", 1)[0].strip().upper()
-    if not provider:
-        return
-    os.environ.setdefault(f"{provider}_API_KEY", api_key)
+    for env_key in report.get("missing_keys") or []:
+        if env_key.endswith("_API_KEY"):
+            os.environ.setdefault(env_key, api_key)
 
 
 def _configure_litellm_compatibility() -> None:

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -117,7 +117,17 @@ def uses_chat_completions_tool_schema(model_name: str, settings: Settings) -> bo
     model = model_name.strip().lower()
     if "/" in model and not model.startswith("openai/"):
         return True
-    return bool(settings.llm.api_base)
+    if settings.llm.api_base:
+        return True
+    return not _supports_responses_custom_tools(model_name)
+
+
+def _supports_responses_custom_tools(model_name: str) -> bool:
+    import litellm
+
+    name = model_name.strip().lower().removeprefix("openai/")
+    entry = litellm.model_cost.get(name) or {}
+    return bool(entry.get("supports_reasoning"))
 
 
 def is_known_openai_bare_model(model_name: str) -> bool:

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -49,12 +49,29 @@ def configure_sdk_model_defaults(settings: Settings) -> None:
     if llm.api_key:
         set_default_openai_key(llm.api_key, use_for_tracing=False)
         _configure_litellm_default("api_key", llm.api_key)
+        _mirror_api_key_to_provider_env(llm.model, llm.api_key)
     if llm.api_base:
         os.environ["OPENAI_BASE_URL"] = llm.api_base
         _configure_litellm_default("api_base", llm.api_base)
         set_default_openai_api("chat_completions")
     else:
         set_default_openai_api("responses")
+
+
+def _mirror_api_key_to_provider_env(model_name: str | None, api_key: str) -> None:
+    if not model_name:
+        return
+    name = model_name.strip()
+    for prefix in ("litellm/", "any-llm/"):
+        if name.lower().startswith(prefix):
+            name = name[len(prefix) :]
+            break
+    if "/" not in name:
+        return
+    provider = name.split("/", 1)[0].strip().upper()
+    if not provider:
+        return
+    os.environ.setdefault(f"{provider}_API_KEY", api_key)
 
 
 def _configure_litellm_compatibility() -> None:

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -121,7 +121,7 @@ def uses_chat_completions_tool_schema(model_name: str, settings: Settings) -> bo
     return bool(settings.llm.api_base)
 
 
-def model_supports_reasoning(model_name: str) -> bool:
+def _model_cost_entry(model_name: str) -> dict[str, object] | None:
     import litellm
 
     name = model_name.strip().lower()
@@ -132,4 +132,13 @@ def model_supports_reasoning(model_name: str) -> bool:
     entry = litellm.model_cost.get(name)
     if entry is None and "/" in name:
         entry = litellm.model_cost.get(name.rsplit("/", 1)[1])
+    return entry
+
+
+def model_supports_reasoning(model_name: str) -> bool:
+    entry = _model_cost_entry(model_name)
     return bool(entry and entry.get("supports_reasoning"))
+
+
+def model_known_to_registry(model_name: str) -> bool:
+    return _model_cost_entry(model_name) is not None

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -95,11 +95,13 @@ def _mirror_api_key_to_provider_env(model_name: str | None, api_key: str) -> Non
 
 
 def _configure_litellm_compatibility() -> None:
-    """Enable LiteLLM's permissive param-handling mode."""
+    """Enable LiteLLM's permissive param handling and disable its callbacks."""
     import litellm
 
     litellm.drop_params = True
     litellm.modify_params = True
+    litellm.turn_off_message_logging = True
+    litellm.disable_streaming_logging = True
 
 
 def _configure_litellm_default(name: str, value: str) -> None:
@@ -115,3 +117,13 @@ def uses_chat_completions_tool_schema(model_name: str, settings: Settings) -> bo
     if "/" in model and not model.startswith("openai/"):
         return True
     return bool(settings.llm.api_base)
+
+
+def is_known_openai_bare_model(model_name: str) -> bool:
+    import litellm
+
+    name = model_name.strip().lower()
+    if not name or "/" in name:
+        return False
+    entry = litellm.model_cost.get(name)
+    return bool(entry and entry.get("litellm_provider") == "openai")

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -6,6 +6,7 @@ import os
 from typing import TYPE_CHECKING
 
 from agents import set_default_openai_api, set_default_openai_key, set_tracing_disabled
+from agents.models.multi_provider import MultiProvider
 from agents.retry import (
     ModelRetryBackoffSettings,
     ModelRetrySettings,
@@ -14,10 +15,31 @@ from agents.retry import (
 
 
 if TYPE_CHECKING:
+    from agents.models.interface import ModelProvider
+
     from strix.config.settings import Settings
 
 
-_SDK_PREFIXES = {"any-llm", "litellm", "openai"}
+class StrixProvider(MultiProvider):
+    """Route any non-OpenAI prefix through LiteLLM with the prefix preserved,
+    so users type ``deepseek/deepseek-chat`` rather than
+    ``litellm/deepseek/deepseek-chat``.
+    """
+
+    def _resolve_prefixed_model(
+        self,
+        *,
+        original_model_name: str,
+        prefix: str,
+        stripped_model_name: str | None,
+    ) -> tuple[ModelProvider, str | None]:
+        if prefix in {"openai", "litellm", "any-llm"}:
+            return super()._resolve_prefixed_model(
+                original_model_name=original_model_name,
+                prefix=prefix,
+                stripped_model_name=stripped_model_name,
+            )
+        return self._get_fallback_provider("litellm"), original_model_name
 
 
 DEFAULT_MODEL_RETRY = ModelRetrySettings(
@@ -99,16 +121,13 @@ def normalize_model_name(model_name: str) -> str:
         return model
 
     if "/" in model:
-        prefix = model.split("/", 1)[0].lower()
-        if prefix in _SDK_PREFIXES:
-            return model
-        return f"litellm/{model}"
+        return model
 
     lower = model.lower()
     if lower.startswith("claude"):
-        return f"litellm/anthropic/{model}"
+        return f"anthropic/{model}"
     if lower.startswith("gemini"):
-        return f"litellm/gemini/{model}"
+        return f"gemini/{model}"
 
     return model
 
@@ -116,7 +135,7 @@ def normalize_model_name(model_name: str) -> str:
 def uses_chat_completions_tool_schema(model_name: str, settings: Settings) -> bool:
     """Return whether the resolved SDK route can only receive JSON function tools."""
     model = model_name.strip().lower()
-    if model.startswith(("litellm/", "any-llm/")):
+    if "/" in model and not model.startswith("openai/"):
         return True
     return bool(settings.llm.api_base)
 

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -59,12 +59,7 @@ DEFAULT_MODEL_RETRY = ModelRetrySettings(
 
 
 def configure_sdk_model_defaults(settings: Settings) -> None:
-    """Apply Strix config to SDK-native defaults.
-
-    OpenAI-compatible base URLs are handled by the SDK OpenAI provider.
-    Non-OpenAI providers should use the SDK's native ``litellm/`` or
-    ``any-llm/`` routing, produced by :func:`normalize_model_name`.
-    """
+    """Apply Strix config to SDK-native defaults."""
     llm = settings.llm
     set_tracing_disabled(True)
     _configure_litellm_compatibility()
@@ -85,7 +80,7 @@ def _mirror_api_key_to_provider_env(model_name: str | None, api_key: str) -> Non
         return
     import litellm
 
-    name = normalize_model_name(model_name)
+    name = model_name.strip()
     for prefix in ("litellm/", "any-llm/"):
         if name.lower().startswith(prefix):
             name = name[len(prefix) :]
@@ -114,50 +109,9 @@ def _configure_litellm_default(name: str, value: str) -> None:
     setattr(litellm, name, value)
 
 
-def normalize_model_name(model_name: str) -> str:
-    """Normalize friendly Strix model names to SDK-native model ids."""
-    model = model_name.strip()
-    if not model:
-        return model
-
-    if "/" in model:
-        return model
-
-    lower = model.lower()
-    if lower.startswith("claude"):
-        return f"anthropic/{model}"
-    if lower.startswith("gemini"):
-        return f"gemini/{model}"
-
-    return model
-
-
 def uses_chat_completions_tool_schema(model_name: str, settings: Settings) -> bool:
     """Return whether the resolved SDK route can only receive JSON function tools."""
     model = model_name.strip().lower()
     if "/" in model and not model.startswith("openai/"):
         return True
     return bool(settings.llm.api_base)
-
-
-def _model_cost_entry(model_name: str) -> dict[str, object] | None:
-    import litellm
-
-    name = model_name.strip().lower()
-    for prefix in ("litellm/", "any-llm/"):
-        if name.startswith(prefix):
-            name = name[len(prefix) :]
-            break
-    entry = litellm.model_cost.get(name)
-    if entry is None and "/" in name:
-        entry = litellm.model_cost.get(name.rsplit("/", 1)[1])
-    return entry
-
-
-def model_supports_reasoning(model_name: str) -> bool:
-    entry = _model_cost_entry(model_name)
-    return bool(entry and entry.get("supports_reasoning"))
-
-
-def model_known_to_registry(model_name: str) -> bool:
-    return _model_cost_entry(model_name) is not None

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -102,6 +102,7 @@ def _configure_litellm_compatibility() -> None:
     litellm.modify_params = True
     litellm.turn_off_message_logging = True
     litellm.disable_streaming_logging = True
+    litellm.suppress_debug_info = True
 
 
 def _configure_litellm_default(name: str, value: str) -> None:

--- a/strix/core/execution.py
+++ b/strix/core/execution.py
@@ -349,12 +349,20 @@ async def _run_cycle(  # noqa: PLR0912
             )
             await coordinator.attach_stream(agent_id, stream)
             try:
-                async for event in stream.stream_events():
-                    if event_sink is not None:
-                        try:
-                            event_sink(agent_id, event)
-                        except Exception:
-                            logger.exception("stream event sink failed for %s", agent_id)
+                try:
+                    async for event in stream.stream_events():
+                        if event_sink is not None:
+                            try:
+                                event_sink(agent_id, event)
+                            except Exception:
+                                logger.exception("stream event sink failed for %s", agent_id)
+                except RuntimeError as stream_exc:
+                    if "after shutdown" not in str(stream_exc):
+                        raise
+                    logger.warning(
+                        "Ignoring LiteLLM end-of-stream shutdown race for %s",
+                        agent_id,
+                    )
                 if stream.run_loop_exception is not None:
                     raise stream.run_loop_exception
             finally:

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any
 from agents.model_settings import ModelSettings
 from openai.types.shared import Reasoning
 
-from strix.config.models import DEFAULT_MODEL_RETRY, model_supports_reasoning
+from strix.config.models import (
+    DEFAULT_MODEL_RETRY,
+    model_known_to_registry,
+    model_supports_reasoning,
+)
 
 
 if TYPE_CHECKING:
@@ -111,23 +115,25 @@ def make_model_settings(
     *,
     model_name: str,
 ) -> ModelSettings:
-    # Anthropic + DeepSeek thinking reject ``tool_choice="required"`` outright
-    # when reasoning is enabled; OpenAI o-series accepts both but doesn't need
-    # the safety net. When reasoning is on we let the model self-select tools
-    # and rely on the system prompt + the ``_finish_tool_use_behavior`` callback
-    # to keep the loop converging on a lifecycle tool.
-    use_reasoning = (
-        reasoning_effort is not None
-        and reasoning_effort != "none"
-        and model_supports_reasoning(model_name)
+    # Anthropic + DeepSeek thinking reject ``tool_choice="required"`` outright;
+    # when reasoning is enabled we let the model self-select tools and rely on
+    # the system prompt + the ``_finish_tool_use_behavior`` callback to keep
+    # the loop converging. When the user opted into reasoning but the model
+    # is unknown to LiteLLM's registry (e.g. a private DeepSeek SKU, a fresh
+    # release the registry hasn't picked up), drop ``tool_choice`` too —
+    # server-side thinking-mode endpoints reject it and we can't confirm.
+    user_wants_reasoning = reasoning_effort is not None and reasoning_effort != "none"
+    confirmed_reasoning = model_supports_reasoning(model_name)
+    drop_tool_choice = user_wants_reasoning and (
+        confirmed_reasoning or not model_known_to_registry(model_name)
     )
     model_settings = ModelSettings(
         parallel_tool_calls=False,
-        tool_choice=None if use_reasoning else "required",
+        tool_choice=None if drop_tool_choice else "required",
         retry=DEFAULT_MODEL_RETRY,
         include_usage=True,
     )
-    if use_reasoning:
+    if user_wants_reasoning and confirmed_reasoning:
         model_settings = model_settings.resolve(
             ModelSettings(reasoning=Reasoning(effort=reasoning_effort)),
         )

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -8,11 +8,7 @@ from typing import TYPE_CHECKING, Any
 from agents.model_settings import ModelSettings
 from openai.types.shared import Reasoning
 
-from strix.config.models import (
-    DEFAULT_MODEL_RETRY,
-    model_known_to_registry,
-    model_supports_reasoning,
-)
+from strix.config.models import DEFAULT_MODEL_RETRY
 
 
 if TYPE_CHECKING:
@@ -110,30 +106,13 @@ def build_scope_context(scan_config: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def make_model_settings(
-    reasoning_effort: ReasoningEffort | None,
-    *,
-    model_name: str,
-) -> ModelSettings:
-    # Anthropic + DeepSeek thinking reject ``tool_choice="required"`` outright;
-    # when reasoning is enabled we let the model self-select tools and rely on
-    # the system prompt + the ``_finish_tool_use_behavior`` callback to keep
-    # the loop converging. When the user opted into reasoning but the model
-    # is unknown to LiteLLM's registry (e.g. a private DeepSeek SKU, a fresh
-    # release the registry hasn't picked up), drop ``tool_choice`` too —
-    # server-side thinking-mode endpoints reject it and we can't confirm.
-    user_wants_reasoning = reasoning_effort is not None and reasoning_effort != "none"
-    confirmed_reasoning = model_supports_reasoning(model_name)
-    drop_tool_choice = user_wants_reasoning and (
-        confirmed_reasoning or not model_known_to_registry(model_name)
-    )
+def make_model_settings(reasoning_effort: ReasoningEffort | None) -> ModelSettings:
     model_settings = ModelSettings(
         parallel_tool_calls=False,
-        tool_choice=None if drop_tool_choice else "required",
         retry=DEFAULT_MODEL_RETRY,
         include_usage=True,
     )
-    if user_wants_reasoning and confirmed_reasoning:
+    if reasoning_effort is not None and reasoning_effort != "none":
         model_settings = model_settings.resolve(
             ModelSettings(reasoning=Reasoning(effort=reasoning_effort)),
         )

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -17,7 +17,6 @@ from strix.config import load_settings
 from strix.config.models import (
     StrixProvider,
     configure_sdk_model_defaults,
-    normalize_model_name,
     uses_chat_completions_tool_schema,
 )
 from strix.core.agents import AgentCoordinator
@@ -91,7 +90,7 @@ async def run_strix_scan(
 
     settings = load_settings()
     configure_sdk_model_defaults(settings)
-    resolved_model = normalize_model_name(model or settings.llm.model or "")
+    resolved_model = (model or settings.llm.model or "").strip()
     if not resolved_model:
         raise RuntimeError(
             "No LLM model configured. Set STRIX_LLM env or pass model= to run_strix_scan().",
@@ -154,10 +153,7 @@ async def run_strix_scan(
         is_whitebox = any(t.get("type") == "local_code" for t in targets)
         skills = list(scan_config.get("skills") or [])
         root_task = build_root_task(scan_config)
-        model_settings = make_model_settings(
-            settings.llm.reasoning_effort,
-            model_name=resolved_model,
-        )
+        model_settings = make_model_settings(settings.llm.reasoning_effort)
         run_config = RunConfig(
             model=resolved_model,
             model_provider=StrixProvider(),

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -15,6 +15,7 @@ from agents.sandbox import SandboxRunConfig
 from strix.agents.factory import build_strix_agent, make_child_factory
 from strix.config import load_settings
 from strix.config.models import (
+    StrixProvider,
     configure_sdk_model_defaults,
     normalize_model_name,
     uses_chat_completions_tool_schema,
@@ -159,6 +160,7 @@ async def run_strix_scan(
         )
         run_config = RunConfig(
             model=resolved_model,
+            model_provider=StrixProvider(),
             model_settings=model_settings,
             sandbox=SandboxRunConfig(client=bundle["client"], session=bundle["session"]),
             trace_include_sensitive_data=False,

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
-from agents.models.multi_provider import MultiProvider
 from docker.errors import DockerException
 from rich.console import Console
 from rich.panel import Panel
@@ -24,7 +23,7 @@ from strix.config import (
     load_settings,
     persist_current,
 )
-from strix.config.models import configure_sdk_model_defaults, normalize_model_name
+from strix.config.models import StrixProvider, configure_sdk_model_defaults, normalize_model_name
 from strix.core.paths import run_dir_for, runtime_state_dir
 from strix.interface.cli import run_cli
 from strix.interface.tui import run_tui
@@ -99,7 +98,8 @@ def validate_environment() -> None:
                 error_text.append("• ", style="white")
                 error_text.append("STRIX_LLM", style="bold cyan")
                 error_text.append(
-                    " - Model name to use (e.g., 'gpt-5.4' or 'claude-sonnet-4-6')\n",
+                    " - Model name to use (e.g., 'openai/gpt-5.4' or "
+                    "'anthropic/claude-opus-4-7')\n",
                     style="white",
                 )
 
@@ -138,7 +138,7 @@ def validate_environment() -> None:
                     )
 
         error_text.append("\nExample setup:\n", style="white")
-        error_text.append("export STRIX_LLM='gpt-5.4'\n", style="dim white")
+        error_text.append("export STRIX_LLM='openai/gpt-5.4'\n", style="dim white")
 
         if missing_optional_vars:
             for var in missing_optional_vars:
@@ -216,7 +216,7 @@ async def warm_up_llm() -> None:
         configure_sdk_model_defaults(settings)
         llm = settings.llm
 
-        model = MultiProvider().get_model(normalize_model_name(llm.model or ""))
+        model = StrixProvider().get_model(normalize_model_name(llm.model or ""))
         await asyncio.wait_for(
             model.get_response(
                 system_instructions="You are a helpful assistant.",
@@ -256,8 +256,8 @@ async def warm_up_llm() -> None:
                 f"\n\nHint: '{raw_model}' has no provider prefix, so the SDK "
                 f"routed it through OpenAI by default. For non-OpenAI providers "
                 f"use the '<provider>/<model>' form, e.g. "
-                f"'deepseek/deepseek-chat', 'groq/llama-3.1-70b', "
-                f"'anthropic/claude-3-5-sonnet'.",
+                f"'anthropic/claude-opus-4-7', 'deepseek/deepseek-reasoner', "
+                f"'openai/gpt-5.4'.",
                 style="yellow",
             )
 

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -22,7 +22,11 @@ from strix.config import (
     load_settings,
     persist_current,
 )
-from strix.config.models import StrixProvider, configure_sdk_model_defaults
+from strix.config.models import (
+    StrixProvider,
+    configure_sdk_model_defaults,
+    is_known_openai_bare_model,
+)
 from strix.core.paths import run_dir_for, runtime_state_dir
 from strix.interface.cli import run_cli
 from strix.interface.tui import run_tui
@@ -215,7 +219,39 @@ async def warm_up_llm() -> None:
         configure_sdk_model_defaults(settings)
         llm = settings.llm
 
-        model = StrixProvider().get_model((llm.model or "").strip())
+        raw_model = (llm.model or "").strip()
+        if (
+            raw_model
+            and "/" not in raw_model
+            and not is_known_openai_bare_model(raw_model)
+            and not llm.api_base
+        ):
+            warn_text = Text()
+            warn_text.append("UNKNOWN MODEL NAME", style="bold yellow")
+            warn_text.append("\n\n", style="white")
+            warn_text.append(f"'{raw_model}'", style="bold cyan")
+            warn_text.append(
+                " is not a known OpenAI model. Bare names route to OpenAI by default.\n"
+                "If you meant a non-OpenAI provider, use the '",
+                style="white",
+            )
+            warn_text.append("<provider>/<model>", style="bold cyan")
+            warn_text.append(
+                "' form, e.g. 'anthropic/claude-opus-4-7', 'deepseek/deepseek-v4-pro'.",
+                style="white",
+            )
+            console.print(
+                Panel(
+                    warn_text,
+                    title="[bold white]STRIX",
+                    title_align="left",
+                    border_style="yellow",
+                    padding=(1, 2),
+                ),
+            )
+            sys.exit(1)
+
+        model = StrixProvider().get_model(raw_model)
         await asyncio.wait_for(
             model.get_response(
                 system_instructions="You are a helpful assistant.",

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -5,7 +5,6 @@ Strix Agent Interface
 
 import argparse
 import asyncio
-import contextlib
 import shutil
 import sys
 from datetime import UTC, datetime
@@ -23,7 +22,7 @@ from strix.config import (
     load_settings,
     persist_current,
 )
-from strix.config.models import StrixProvider, configure_sdk_model_defaults, normalize_model_name
+from strix.config.models import StrixProvider, configure_sdk_model_defaults
 from strix.core.paths import run_dir_for, runtime_state_dir
 from strix.interface.cli import run_cli
 from strix.interface.tui import run_tui
@@ -216,7 +215,7 @@ async def warm_up_llm() -> None:
         configure_sdk_model_defaults(settings)
         llm = settings.llm
 
-        model = StrixProvider().get_model(normalize_model_name(llm.model or ""))
+        model = StrixProvider().get_model((llm.model or "").strip())
         await asyncio.wait_for(
             model.get_response(
                 system_instructions="You are a helpful assistant.",
@@ -232,7 +231,7 @@ async def warm_up_llm() -> None:
             ),
             timeout=llm.timeout,
         )
-        logger.info("LLM warm-up succeeded for model %s", normalize_model_name(llm.model or ""))
+        logger.info("LLM warm-up succeeded for model %s", (llm.model or "").strip())
 
     except Exception as e:
         logger.exception("LLM warm-up failed")
@@ -242,24 +241,6 @@ async def warm_up_llm() -> None:
         error_text.append("Could not establish connection to the language model.\n", style="white")
         error_text.append("Please check your configuration and try again.\n", style="white")
         error_text.append(f"\nError: {e}", style="dim white")
-
-        raw_model = ""
-        resolved = ""
-        with contextlib.suppress(Exception):
-            raw_model = (load_settings().llm.model or "").strip()
-            resolved = normalize_model_name(raw_model)
-        err_lc = str(e).lower()
-        unprefixed = bool(resolved) and "/" not in resolved
-        looks_openai = "platform.openai.com" in err_lc or "openai" in err_lc
-        if unprefixed and looks_openai:
-            error_text.append(
-                f"\n\nHint: '{raw_model}' has no provider prefix, so the SDK "
-                f"routed it through OpenAI by default. For non-OpenAI providers "
-                f"use the '<provider>/<model>' form, e.g. "
-                f"'anthropic/claude-opus-4-7', 'deepseek/deepseek-reasoner', "
-                f"'openai/gpt-5.4'.",
-                style="yellow",
-            )
 
         panel = Panel(
             error_text,

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -5,6 +5,7 @@ Strix Agent Interface
 
 import argparse
 import asyncio
+import contextlib
 import shutil
 import sys
 from datetime import UTC, datetime
@@ -241,6 +242,24 @@ async def warm_up_llm() -> None:
         error_text.append("Could not establish connection to the language model.\n", style="white")
         error_text.append("Please check your configuration and try again.\n", style="white")
         error_text.append(f"\nError: {e}", style="dim white")
+
+        raw_model = ""
+        resolved = ""
+        with contextlib.suppress(Exception):
+            raw_model = (load_settings().llm.model or "").strip()
+            resolved = normalize_model_name(raw_model)
+        err_lc = str(e).lower()
+        unprefixed = bool(resolved) and "/" not in resolved
+        looks_openai = "platform.openai.com" in err_lc or "openai" in err_lc
+        if unprefixed and looks_openai:
+            error_text.append(
+                f"\n\nHint: '{raw_model}' has no provider prefix, so the SDK "
+                f"routed it through OpenAI by default. For non-OpenAI providers "
+                f"use the '<provider>/<model>' form, e.g. "
+                f"'deepseek/deepseek-chat', 'groq/llama-3.1-70b', "
+                f"'anthropic/claude-3-5-sonnet'.",
+                style="yellow",
+            )
 
         panel = Panel(
             error_text,

--- a/strix/report/dedupe.py
+++ b/strix/report/dedupe.py
@@ -8,14 +8,13 @@ from typing import TYPE_CHECKING, Any
 
 from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
-from agents.models.multi_provider import MultiProvider
 from openai.types.responses import ResponseOutputMessage
 
 from strix.config import load_settings
 from strix.config.models import (
     DEFAULT_MODEL_RETRY,
+    StrixProvider,
     configure_sdk_model_defaults,
-    normalize_model_name,
 )
 from strix.report.state import get_global_report_state
 
@@ -188,8 +187,8 @@ async def check_duplicate(
         )
 
         configure_sdk_model_defaults(settings)
-        resolved_model = normalize_model_name(model_name)
-        model = MultiProvider().get_model(resolved_model)
+        resolved_model = model_name.strip()
+        model = StrixProvider().get_model(resolved_model)
         response = await model.get_response(
             system_instructions=DEDUPE_SYSTEM_PROMPT,
             input=user_msg,

--- a/uv.lock
+++ b/uv.lock
@@ -956,7 +956,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.7"
+version = "1.88.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -972,9 +972,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/2b/b58bf6bbcbc3d0e55d0a84fdf9128e5b1436517f46fce89b1cd8948ebb81/litellm-1.83.7.tar.gz", hash = "sha256:e2f2cb99df2e2b2eab63f1354faa45c88dd7c8d40c18eb648afb1b349c689633", size = 17791694, upload-time = "2026-04-13T17:35:01.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/8c/6cfce5d15554e076b8438a955436e9e6e2a2bd39c76539656c1c3861c369/litellm-1.88.0.tar.gz", hash = "sha256:4ff794493e40bd86c6f13e91dcb3e1aad697403fd46a96902196d93356ba48f4", size = 13886026, upload-time = "2026-06-06T23:25:17.93Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/80/caeb4cdcad96451ba83ad3ba2a9da08b1e1a915fa845c489f56ea044488b/litellm-1.83.7-py3-none-any.whl", hash = "sha256:5784a1d9a9a4a8acd6ca1e347003a5e2e1b3c749b4d41e7da4904577adade111", size = 16069807, upload-time = "2026-04-13T17:34:58.36Z" },
+    { url = "https://files.pythonhosted.org/packages/da/71/deb6637475253b83eb4577c058863eec4b4ddaef2d08dcd93981b1aa4209/litellm-1.88.0-py3-none-any.whl", hash = "sha256:abd3037e0bf5703f833f5565c87bdfd93578d3de46cbcb36dfa108c3ef58021c", size = 15276203, upload-time = "2026-06-06T23:25:07.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #504.

Strips the LLM-config layer to a thin shim over the OpenAI Agents SDK + LiteLLM. No hand-rolled provider tables, no shorthand expansion, no per-provider gating.

## What changes

- **One key, any provider.** `LLM_API_KEY` is mirrored into the provider-specific env var (`DEEPSEEK_API_KEY`, `ANTHROPIC_API_KEY`, `TOGETHERAI_API_KEY`, ...) via `litellm.validate_environment`. No local provider→env-var map.
- **No `litellm/` prefix in user config.** `StrixProvider` (a 5-line `MultiProvider` subclass) routes any non-OpenAI prefix through LiteLLM. Users type `deepseek/deepseek-v4-pro`. Old `litellm/...` configs still work.
- **No `tool_choice="required"`.** Modern thinking models (Anthropic extended thinking, DeepSeek `/beta`, Bedrock newer Claude) reject it; convergence relies on `_finish_tool_use_behavior` + `_append_noninteractive_tool_required_message` (already in place).
- **No bare-name shorthand expansion.** Users supply `<provider>/<model>`. Bare unknown names route to the SDK's OpenAI default; pre-warm-up panel warns when the bare name isn't a known OpenAI model and exits before the doomed call.

## Side stability fixes

- Catch the LiteLLM end-of-stream `RuntimeError: cannot schedule new futures after shutdown` race (background `success_handler.submit` losing to atexit during interpreter teardown — stream content was already delivered).
- Silence LiteLLM stdout banners via `suppress_debug_info`, `disable_streaming_logging`, `turn_off_message_logging`.
- Dedupe pass also routes via `StrixProvider` (was stock `MultiProvider`, broke non-OpenAI configs).
- Bump litellm 1.83.7 → 1.88.0.