### PR TITLE
Show "Send message to resume" on the left of the status bar

### DIFF
--- a/strix/interface/tui/app.py
+++ b/strix/interface/tui/app.py
@@ -1143,9 +1143,9 @@ class StrixTUIApp(App):  # type: ignore[misc]
             return (text, Text(), False)
 
         if status == "waiting":
-            keymap = Text()
-            keymap.append("Send message to resume", style="dim")
-            return (Text(" "), keymap, False)
+            text = Text()
+            text.append("Send message to resume", style="dim")
+            return (text, Text(), False)
 
         if status == "running":
             if self._agent_has_real_activity(agent_id):


### PR DESCRIPTION
When an agent is waiting, the prompt now appears in the left `status_text` slot instead of the right `keymap_indicator` slot.