### PR TITLE
Stop finish_scan from discarding partial reports (closes #294)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev-install format lint type-check security check-all clean pre-commit setup-dev dev
+.PHONY: help install dev-install format lint type-check security test check-all clean pre-commit setup-dev dev
 
 help:
 	@echo "Available commands:"
@@ -11,6 +11,7 @@ help:
 	@echo "  lint          - Lint code with ruff"
 	@echo "  type-check    - Run type checking with mypy and pyright"
 	@echo "  security      - Run security checks with bandit"
+	@echo "  test          - Run tests with pytest"
 	@echo "  check-all     - Run all code quality checks"
 	@echo ""
 	@echo "Development:"
@@ -50,7 +51,12 @@ security:
 	uv run bandit -r strix/ -c pyproject.toml
 	@echo "✅ Security checks complete!"
 
-check-all: format lint type-check security
+test:
+	@echo "🧪 Running tests with pytest..."
+	uv run pytest
+	@echo "✅ Tests complete!"
+
+check-all: format lint type-check security test
 	@echo "✅ All code quality checks passed!"
 
 pre-commit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
   "pyright>=1.1.401",
   "bandit>=1.8.3",
   "pre-commit>=4.2.0",
+  "pytest>=8.0.0",
   "pyinstaller>=6.17.0; python_version >= '3.12' and python_version < '3.15'",
 ]
 
@@ -228,6 +229,9 @@ ignore = [
 "strix/interface/tui/app.py" = ["BLE001", "PLC0415", "PLR0912", "PLR0915", "SIM105"]
 "strix/interface/main.py" = ["BLE001", "PLC0415", "PLR0912", "PLR0915"]
 "strix/interface/tui/renderers/agent_message_renderer.py" = ["PLC0415"]
+# Tests are not part of the importable package and reach into module-private
+# helpers under test on purpose.
+"tests/**/*.py" = ["INP001", "ARG001"]
 
 [tool.ruff.lint.isort]
 force-single-line = false
@@ -319,3 +323,8 @@ known_third_party = ["pydantic", "litellm"]
 exclude_dirs = ["docs", "build", "dist"]
 skips = ["B101", "B601", "B404", "B603", "B607"]  # Skip assert, shell injection, subprocess import and partial path checks
 severity = "medium"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+addopts = "-q"

--- a/strix/tools/finish/tool.py
+++ b/strix/tools/finish/tool.py
@@ -14,6 +14,8 @@ from strix.core.agents import coordinator_from_context
 
 logger = logging.getLogger(__name__)
 
+_NOT_PROVIDED = "[Not provided by model]"
+
 
 def _do_finish(
     *,
@@ -32,17 +34,17 @@ def _do_finish(
             ),
         }
 
-    errors: list[str] = []
-    if not executive_summary.strip():
-        errors.append("Executive summary cannot be empty")
-    if not methodology.strip():
-        errors.append("Methodology cannot be empty")
-    if not technical_analysis.strip():
-        errors.append("Technical analysis cannot be empty")
-    if not recommendations.strip():
-        errors.append("Recommendations cannot be empty")
-    if errors:
-        return {"success": False, "error": "Validation failed", "errors": errors}
+    # Save a partial report instead of rejecting it: vulnerabilities are persisted
+    # incrementally as they are found, so refusing the whole report over one empty
+    # narrative field silently discards the executive summary when the model leaves
+    # a section blank (issue #294).
+    sections = {
+        "executive_summary": executive_summary.strip() or _NOT_PROVIDED,
+        "methodology": methodology.strip() or _NOT_PROVIDED,
+        "technical_analysis": technical_analysis.strip() or _NOT_PROVIDED,
+        "recommendations": recommendations.strip() or _NOT_PROVIDED,
+    }
+    missing = [name for name, value in sections.items() if value is _NOT_PROVIDED]
 
     try:
         from strix.report.state import get_global_report_state
@@ -57,10 +59,10 @@ def _do_finish(
                 "warning": "Results could not be persisted - report state unavailable",
             }
         report_state.update_scan_final_fields(
-            executive_summary=executive_summary.strip(),
-            methodology=methodology.strip(),
-            technical_analysis=technical_analysis.strip(),
-            recommendations=recommendations.strip(),
+            executive_summary=sections["executive_summary"],
+            methodology=sections["methodology"],
+            technical_analysis=sections["technical_analysis"],
+            recommendations=sections["recommendations"],
         )
         vuln_count = len(report_state.vulnerability_reports)
     except (ImportError, AttributeError) as e:
@@ -71,12 +73,17 @@ def _do_finish(
             "finish_scan: completed scan with %d vulnerability report(s)",
             vuln_count,
         )
-        return {
+        result: dict[str, Any] = {
             "success": True,
             "scan_completed": True,
             "message": "Scan completed successfully",
             "vulnerabilities_found": vuln_count,
         }
+        if missing:
+            result["warning"] = (
+                "Saved report with placeholder text for empty section(s): " + ", ".join(missing)
+            )
+        return result
 
 
 @function_tool(timeout=60)

--- a/tests/tools/finish/test_finish_tool.py
+++ b/tests/tools/finish/test_finish_tool.py
@@ -1,0 +1,97 @@
+"""Regression tests for finish_scan partial-report persistence (issue #294)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from strix.report.state import ReportState, set_global_report_state
+from strix.telemetry import posthog, scarf
+from strix.tools.finish.tool import _NOT_PROVIDED, _do_finish
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _noop(*args: object, **kwargs: object) -> None:
+    return None
+
+
+@pytest.fixture
+def state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ReportState:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(posthog, "end", _noop)
+    monkeypatch.setattr(scarf, "end", _noop)
+    rs = ReportState(run_name="test-run")
+    set_global_report_state(rs)
+    return rs
+
+
+def test_partial_report_is_saved_with_placeholder(state: ReportState) -> None:
+    result = _do_finish(
+        parent_id=None,
+        executive_summary="Critical exposure found.",
+        methodology="",
+        technical_analysis="SQLi via id parameter.",
+        recommendations="Parameterize queries.",
+    )
+
+    assert result["success"] is True
+    assert result["scan_completed"] is True
+    assert "methodology" in result["warning"]
+
+    assert state.scan_results is not None
+    assert state.scan_results["methodology"] == _NOT_PROVIDED
+    assert state.scan_results["executive_summary"] == "Critical exposure found."
+
+    report_path = state.get_run_dir() / "penetration_test_report.md"
+    assert report_path.exists()
+    assert _NOT_PROVIDED in report_path.read_text(encoding="utf-8")
+
+
+def test_complete_report_has_no_warning(state: ReportState) -> None:
+    result = _do_finish(
+        parent_id=None,
+        executive_summary="Summary.",
+        methodology="OWASP WSTG.",
+        technical_analysis="Findings.",
+        recommendations="Remediation.",
+    )
+
+    assert result["success"] is True
+    assert "warning" not in result
+    assert state.scan_results is not None
+    assert state.scan_results["methodology"] == "OWASP WSTG."
+
+
+def test_all_empty_sections_still_complete(state: ReportState) -> None:
+    result = _do_finish(
+        parent_id=None,
+        executive_summary="   ",
+        methodology="",
+        technical_analysis="",
+        recommendations="",
+    )
+
+    assert result["success"] is True
+    assert result["scan_completed"] is True
+    assert state.scan_results is not None
+    assert all(
+        state.scan_results[field] == _NOT_PROVIDED
+        for field in ("executive_summary", "methodology", "technical_analysis", "recommendations")
+    )
+
+
+def test_subagent_cannot_finish() -> None:
+    result = _do_finish(
+        parent_id="parent-1",
+        executive_summary="x",
+        methodology="x",
+        technical_analysis="x",
+        recommendations="x",
+    )
+
+    assert result["success"] is False
+    assert "agent_finish" in result["error"]

--- a/uv.lock
+++ b/uv.lock
@@ -776,6 +776,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1348,6 +1357,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1631,6 +1649,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -2056,6 +2090,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pyinstaller", marker = "python_full_version < '3.15'" },
     { name = "pyright" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -2079,6 +2114,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pyinstaller", marker = "python_full_version >= '3.12' and python_full_version < '3.15'", specifier = ">=6.17.0" },
     { name = "pyright", specifier = ">=1.1.401" },
+    { name = "pytest", specifier = ">=8.0.0" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]
 


### PR DESCRIPTION
## Problem

Fixes #294.

`finish_scan` → `_do_finish` rejected the **entire** executive report with a validation error whenever the model left any of the four narrative sections (`executive_summary` / `methodology` / `technical_analysis` / `recommendations`) empty, returning without persisting anything.

Vulnerabilities are saved incrementally via `ReportState.add_vulnerability_report`, but the executive report is only written by `update_scan_final_fields` on a fully-populated call. So a single blank section silently dropped the whole customer-facing report — the run finished with no `penetration_test_report.md`, matching the symptom multiple users reported in #294 ("Creating report…" then nothing on disk).

## Fix

Replace the all-or-nothing validation in `_do_finish` with a graceful fallback:

- empty sections are filled with a `"[Not provided by model]"` placeholder,
- the report is persisted via `update_scan_final_fields`,
- the missing section names are returned as a non-fatal `warning` in the tool result.

Incremental vulnerability saving and the exit-path flush (`report_state.cleanup()` in `main.py`'s `finally`) are unchanged.

## Tests

The repo had no test suite, so this bootstraps a minimal pytest setup:

- `tests/tools/finish/test_finish_tool.py` — regression coverage for partial, complete, all-empty, and subagent-guard paths; asserts `penetration_test_report.md` is written with the placeholder. Hermetic (tmp run dir, telemetry stubbed).
- `pytest` dev dependency + `[tool.pytest.ini_options]`.
- `make test` target wired into `make check-all`.

## Verification

- `pytest`: 4 passed
- `ruff check` + `ruff format --check` (v0.11.13): clean on changed files
- `mypy --strict`: clean (source + tests)
- `bandit`: clean

The pre-existing `pyright` findings in `finish_scan`'s SDK-untyped `ctx.context` handling and the `TRY004` in `report/writer.py` are unrelated to this change (identical on `main`).
