### PR TITLE
fix(llm): honor LLM_TIMEOUT during scans, not just warm-up

### DIFF
--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -63,6 +63,7 @@ def configure_sdk_model_defaults(settings: Settings) -> None:
     llm = settings.llm
     set_tracing_disabled(True)
     _configure_litellm_compatibility()
+    _configure_litellm_request_timeout(llm.timeout)
     if llm.api_key:
         set_default_openai_key(llm.api_key, use_for_tracing=False)
         _configure_litellm_default("api_key", llm.api_key)
@@ -126,6 +127,21 @@ def _configure_litellm_default(name: str, value: str) -> None:
     import litellm
 
     setattr(litellm, name, value)
+
+
+def _configure_litellm_request_timeout(timeout: int) -> None:
+    """Apply the configured ``LLM_TIMEOUT`` to LiteLLM-routed scan calls.
+
+    The SDK's LiteLLM model invokes ``litellm.acompletion`` without an explicit
+    per-request timeout, so without this it falls back to LiteLLM's module
+    default and the documented ``LLM_TIMEOUT`` only affected the warm-up call
+    (``strix/interface/main.py``). Setting the module-level default makes
+    ``export LLM_TIMEOUT=600`` take effect for the actual scan, restoring the
+    documented behavior for slow local / self-hosted models.
+    """
+    import litellm
+
+    litellm.request_timeout = timeout
 
 
 def uses_chat_completions_tool_schema(model_name: str, settings: Settings) -> bool:


### PR DESCRIPTION
## Problem

`LLM_TIMEOUT` is documented in `docs/advanced/configuration.mdx` as the request timeout for LLM calls (default 300s) and is explicitly offered as the workaround for slow local models (`export LLM_TIMEOUT="600"`). But it has no effect on actual scans.

`settings.llm.timeout` is only consumed at `strix/interface/main.py` for the **warm-up** call. The scan itself runs through the SDK's LiteLLM model, which calls `litellm.acompletion(...)` **without** a timeout, falling back to LiteLLM's module default (`litellm.request_timeout`, currently 6000s). So raising `LLM_TIMEOUT` does nothing for the run — the documented escape hatch for slow/self-hosted models is silently ineffective (reported in #426).

## Fix

Set `litellm.request_timeout` from `settings.llm.timeout` in `configure_sdk_model_defaults`, so the documented setting actually governs LiteLLM-routed scan calls.

## Scope / verification

- Covers LiteLLM-routed models (local/Ollama/most providers), which is exactly where slow-model timeouts bite and where the docs point users.
- Verified locally: with `LLM_TIMEOUT=600`, `configure_sdk_model_defaults()` sets `litellm.request_timeout == 600` (was 6000 default). `ruff` + `mypy` clean.

Fixes #426