### PR TITLE
fix(reporting): drop fabricated code_locations in black-box scans

### DIFF
--- a/strix/agents/prompts/system_prompt.jinja
+++ b/strix/agents/prompts/system_prompt.jinja
@@ -191,6 +191,7 @@ VALIDATION REQUIREMENTS:
 - Document complete attack chain
 - Keep going until you find something that matters
 - A vulnerability is ONLY considered reported when a reporting agent uses create_vulnerability_report with full details. Mentions in agent_finish, finish_scan, or generic messages are NOT sufficient
+- BLACK-BOX REPORTING: when no source code is in scope (black-box), do NOT populate code_locations or assert specific source file paths/line numbers in reports — you cannot see the source, so such claims are fabricated. Base findings only on observed request/response behavior
 - Do NOT patch/fix before reporting: first create the vulnerability report via create_vulnerability_report (by the reporting agent). Only after reporting is completed should fixing/patching proceed
 - DEDUPLICATION: The create_vulnerability_report tool uses LLM-based deduplication. If it rejects your report as a duplicate, DO NOT attempt to re-submit the same vulnerability. Accept the rejection and move on to testing other areas. The vulnerability has already been reported by another agent
 </execution_guidelines>

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -217,6 +217,7 @@ async def run_strix_scan(
             "agent_id": root_id,
             "parent_id": None,
             "interactive": interactive,
+            "is_whitebox": is_whitebox,
             "spawn_child_agent": spawn_child_agent,
         }
 

--- a/strix/tools/reporting/tool.py
+++ b/strix/tools/reporting/tool.py
@@ -351,6 +351,11 @@ async def create_vulnerability_report(
     for the full rules around ``fix_before`` / ``fix_after``,
     multi-part fixes, and informational-vs-actionable entries.
 
+    **Black-box scans**: when no source code is in scope, do NOT populate
+    ``code_locations`` and do not assert specific source file paths or line
+    numbers — you cannot see the source, so such claims are fabricated. Any
+    ``code_locations`` supplied in a black-box scan are dropped automatically.
+
     **CVSS breakdown** is an object with all 8 metrics (each a single
     uppercase letter):
 
@@ -484,6 +489,14 @@ async def create_vulnerability_report(
             - Duplicating the same change across multiple locations.
     """
     inner = ctx.context if isinstance(ctx.context, dict) else {}
+    if not inner.get("is_whitebox") and code_locations:
+        # Black-box scan: no source tree is available, so any file paths /
+        # line numbers / snippets in code_locations can only be fabricated.
+        # Drop them so a hallucinated "Code Analysis" section can never reach
+        # the customer-facing report (#321).
+        logger.info("Black-box scan: dropping code_locations from report %r", title)
+        code_locations = None
+
     raw_agent_id = inner.get("agent_id")
     agent_id = raw_agent_id if isinstance(raw_agent_id, str) else None
     agent_name = None


### PR DESCRIPTION
## Problem

In a black-box scan (no source code in scope) `create_vulnerability_report` accepts `code_locations` unconditionally — validation only checks *format* (relative path, no `..`, positive line numbers), never whether a source tree exists. `render_vulnerability_md` then emits a `## Code Analysis` section verbatim. So the model can fabricate file paths, line numbers, and snippets into the customer-facing report (reported in #321).

The tool's run-context never carried any signal that no source was provided, so it had no way to gate this.

## Fix

- Thread the existing `is_whitebox` flag (already computed in `core/runner.py` from `local_code` targets) into the tool run-context. It propagates to every child agent automatically via `dict(parent_ctx)` in `core/execution.py`.
- In `create_vulnerability_report`, drop `code_locations` when the scan is black-box, so a hallucinated "Code Analysis" section can never reach the report.
- Add black-box guidance to the reporting tool docstring and the system prompt so the model doesn't assert source paths/line numbers it cannot see.

## Scope

Covers the deterministic, code-level half (issue Option A). Endpoint-existence verification (Option B) needs live HTTP from the host-side tool, which it doesn't have; that residual is addressed by the added prompt guidance, not deterministic code.

## Verification

`ruff` + `mypy` clean; gate logic unit-checked (black-box drops `code_locations`, white-box keeps them); dropping to `None` is a no-op in `_normalize_code_locations`.

Fixes #321