### PR TITLE
feat(llm): expose temperature, top_p, and max_tokens settings

### DIFF
--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -31,6 +31,18 @@ Configure Strix using environment variables or a config file.
   Control thinking effort for reasoning models. Valid values: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`. Defaults to `medium` for quick scan mode.
 </ParamField>
 
+<ParamField path="STRIX_LLM_TEMPERATURE" type="number">
+  Sampling temperature passed to the model. Unset by default (uses the provider default). Useful for steadier tool use on local/OpenAI-compatible models. Parameters unsupported by a given model are dropped automatically.
+</ParamField>
+
+<ParamField path="STRIX_LLM_TOP_P" type="number">
+  Nucleus sampling `top_p` passed to the model. Unset by default.
+</ParamField>
+
+<ParamField path="STRIX_LLM_MAX_TOKENS" type="integer">
+  Maximum number of tokens to generate per LLM response. Unset by default (uses the provider default).
+</ParamField>
+
 <ParamField path="STRIX_MEMORY_COMPRESSOR_TIMEOUT" default="30" type="integer">
   Timeout in seconds for memory compression operations (context summarization).
 </ParamField>

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -37,6 +37,9 @@ class LlmSettings(BaseSettings):
     )
     reasoning_effort: ReasoningEffort = Field(default="high", alias="STRIX_REASONING_EFFORT")
     timeout: int = Field(default=300, alias="LLM_TIMEOUT")
+    temperature: float | None = Field(default=None, alias="STRIX_LLM_TEMPERATURE")
+    top_p: float | None = Field(default=None, alias="STRIX_LLM_TOP_P")
+    max_tokens: int | None = Field(default=None, alias="STRIX_LLM_MAX_TOKENS")
 
 
 class RuntimeSettings(BaseSettings):

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -110,11 +110,17 @@ def make_model_settings(
     reasoning_effort: ReasoningEffort | None,
     *,
     model_name: str,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
 ) -> ModelSettings:
     model_settings = ModelSettings(
         parallel_tool_calls=False,
         retry=DEFAULT_MODEL_RETRY,
         include_usage=True,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
     )
     if (
         reasoning_effort is not None

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -156,6 +156,9 @@ async def run_strix_scan(
         model_settings = make_model_settings(
             settings.llm.reasoning_effort,
             model_name=resolved_model,
+            temperature=settings.llm.temperature,
+            top_p=settings.llm.top_p,
+            max_tokens=settings.llm.max_tokens,
         )
         run_config = RunConfig(
             model=resolved_model,


### PR DESCRIPTION
## What

Adds optional LLM generation parameters so users can steer model behavior (requested in #514):

- `STRIX_LLM_TEMPERATURE`
- `STRIX_LLM_TOP_P`
- `STRIX_LLM_MAX_TOKENS`

All are **unset by default**, so the provider default is used and there is no behavior change for existing users. They're threaded through `make_model_settings` into the SDK `ModelSettings` used for the scan. Parameters a given model doesn't accept are dropped automatically (`litellm.drop_params` is already enabled), so reasoning models that reject `temperature`/`top_p` are unaffected.

## Why

Local / OpenAI-compatible models often need a lower temperature for reliable, deterministic tool calling — a recurring pain point for local-model users. This gives them a supported knob without code changes.

## Verification

- Defaults: `make_model_settings(...)` leaves `temperature/top_p/max_tokens` as `None`.
- Explicit values flow into `ModelSettings` (`temperature=0.2`, `top_p=0.9`, `max_tokens=4096`).
- Env aliases parse via `LlmSettings`.
- `ruff` + `mypy` clean; docs updated.

Closes #514