### PR TITLE
feat(skills): add MFA bypass and edge-case vulnerability skills

### DIFF
--- a/strix/skills/vulnerabilities/edge_cases.md
+++ b/strix/skills/vulnerabilities/edge_cases.md
@@ -1,0 +1,85 @@
+---
+name: edge_cases
+description: Boundary and distributed-systems edge cases — cache races/deception, partial failures, eventual consistency, boundary values, degraded-mode auth bypass
+---
+
+# Edge Cases (Caching Races, Partial Failures, Boundary Conditions)
+
+The `race_conditions` skill covers single-process concurrency; this one covers the broader class of bugs that appear at system *boundaries* — caches, service-to-service calls, replication lag, numeric/limit edges, and failure handling. They are high-impact (cross-user exposure, financial loss, authz bypass) and rarely surface in standard testing because they need adversarial timing, failure injection, or boundary-value analysis. CWE-362 and friends.
+
+## Attack Surface
+
+- **Caching layers**: CDN, reverse proxy, framework cache, browser — anywhere a response is stored and replayed.
+- **Multi-service transactions**: payment + order, user + profile, anything that writes to 2+ stores.
+- **Replicated/eventually-consistent stores**: read replicas, search indexes, distributed counters, caches of permissions.
+- **Numeric & limit fields**: quantity, price, balance, pagination cursors/offsets, quotas, time windows.
+- **Failure/degradation paths**: dependency-down fallbacks, circuit breakers, retry logic.
+
+## Reconnaissance
+
+- Fingerprint caching: inspect `Cache-Control`, `Age`, `Vary`, `X-Cache`, `CF-Cache-Status`, `ETag`. Note what is cached and the cache key.
+- Map every multi-step/transactional flow and where it can be interrupted (close the connection mid-request, kill the second leg).
+- Find replication/consistency windows: revoke a permission, then immediately read via a different path (search, list, replica-backed endpoint).
+- List numeric/cursor parameters and quota/time-window resets.
+
+## Key Vulnerabilities
+
+### Cache poisoning & deception
+- **Unkeyed input**: a header/param that influences the response but is not in the cache key — poison a shared cached entry for all users (test with `param_miner`-style header fuzzing, or vary `X-Forwarded-Host`, `X-Forwarded-Scheme`, etc.).
+- **`Vary` omission**: an authenticated, user-specific response cached without `Vary`/`Cache-Control: private` is served to other users — cross-user data exposure. Confirm: authenticate, fetch, then fetch the same URL unauthenticated/as another user and look for the first user's data.
+- **Web cache deception**: request `/<sensitive>/nonexistent.css` (or `;.css`, `%0a.css`) — if the origin serves the sensitive page but the CDN caches it as a static asset, it becomes publicly retrievable.
+- **Cache-key confusion**: path/normalization differences between proxy and origin (`//`, `/./`, case, `;`) that collide keys.
+
+### Partial-failure exploitation
+- Interrupt a multi-store write so one side commits and the other doesn't: payment captured but order not created (refund/duplicate-goods), credits deducted without delivery, or vice versa.
+- **Retry amplification**: a non-idempotent endpoint retried by the client/gateway produces duplicate side effects (double charge, double credit). Replay the same request/idempotency key and diff effects.
+- Orphaned resources left in a usable but unauthorized state after a half-rollback.
+
+### Eventual consistency windows
+- **Stale permission reads**: revoke access, then immediately read via a replica/cache/search endpoint that still returns the resource (TOCTOU across the consistency gap).
+- **Index lag**: deleted/revoked items still returned by search/list while the index catches up.
+- **Counter drift**: distributed counters (quota, rate limit, balance) that diverge under concurrency — overspend a quota by hammering during the window (overlaps `race_conditions`).
+
+### Boundary conditions
+- Integer overflow/underflow and sign flips in quantity/price/balance (`-1`, `0`, `2147483648`, `99999999999`, floats like `1e308`) — negative totals, free purchases, refunds-as-credit.
+- **Pagination/cursor authz**: manipulate `offset`/`cursor`/`page` (and decode opaque cursors) to cross a tenant/authorization boundary or read past your own data.
+- **Time boundaries**: quota/window resets at midnight/month-end/DST — fire at the boundary to double-spend a window.
+
+### Degraded-mode auth bypass
+- Force a dependency to appear down (slow it, block it, send malformed upstream input) and check whether the fallback path skips authentication/authorization, or whether an open circuit breaker routes around a security check.
+
+## Testing Methodology
+
+1. Fingerprint caching and identify shared vs per-user responses; test `Vary`/private omission and deception paths.
+2. Hunt unkeyed inputs that influence cached responses.
+3. For each transactional flow, inject a partial failure (drop the connection / kill the second leg) and inspect the resulting state.
+4. Replay non-idempotent requests and idempotency keys; diff side effects.
+5. Probe consistency windows: revoke/delete, then read via every alternate path immediately.
+6. Boundary-value sweep numeric and cursor/pagination params (scripted).
+7. Induce dependency failure and verify auth/authz still holds on the fallback path.
+
+## Validation
+
+1. Show the concrete impact: another user's data from a cached response, a negative/zero charge that completed, a resource accessed after revocation, or a quota exceeded.
+2. Make it reproducible — capture the exact timing/sequence/payload; for races and consistency windows, script the trigger.
+3. Use tester-owned accounts and harmless values; never move real funds or touch other tenants' real data.
+
+## False Positives
+
+- `X-Cache: MISS` everywhere / `Cache-Control: private` correctly set — no shared caching.
+- A "stale" read that is actually within a documented, bounded, and harmless window.
+- Numeric edges that are validated server-side (rejected with a clean error).
+- Idempotent endpoints where replay is a safe no-op.
+- Client-only cache effects with no server-side consequence.
+
+## Chaining & Impact
+
+Cross-user data exposure, financial manipulation (free/negative purchases, double credits), authorization bypass across tenants, and quota/limit evasion. Cache-poisoning a shared response can escalate a reflected issue into a stored, all-users one.
+
+## Pro Tips
+
+1. The fastest cross-user win is an authenticated response cached without `Vary`/`private` — always check it first.
+2. Decode opaque pagination cursors; they frequently embed IDs that cross authorization boundaries.
+3. To exploit partial failures, interrupt *between* the two writes — connection reset mid-request is your scalpel.
+4. Test permission revocation by reading immediately through a *different* endpoint than the one you'd expect; the lagging path is the bug.
+5. Script boundary and timing tests; these bugs live in windows too narrow for manual clicking.

--- a/strix/skills/vulnerabilities/mfa_bypass.md
+++ b/strix/skills/vulnerabilities/mfa_bypass.md
@@ -1,0 +1,96 @@
+---
+name: mfa_bypass
+description: MFA/2FA bypass testing — pre-auth session gaps, OTP brute force/reuse, recovery downgrade, enrollment flaws, client-side gates
+---
+
+# MFA Bypass
+
+Multi-factor authentication is a baseline control, but it is frequently bolted onto an existing single-factor flow and leaks. The attacker's goal is to reach the authenticated state (or perform sensitive actions) without presenting the second factor. Treat the password step and the MFA step as two separate authorization checks and probe the seam between them. CWE-308.
+
+## Attack Surface
+
+- **Login flow**: the window between password verification and MFA completion — what session/token is issued, and what it can already do.
+- **OTP/TOTP verification endpoint**: rate limits, single-use enforcement, code lifetime, value space (6 digits = 1e6).
+- **Recovery & fallback**: backup codes, "lost device", SMS fallback, email magic links, support-driven reset.
+- **Enrollment / management**: adding, removing, or replacing a factor; whether the existing factor is re-verified first.
+- **Client-side trust**: MFA state encoded in a JWT claim, cookie, localStorage flag, or a hidden form field.
+- **Step-up / sensitive actions**: re-auth gates on password change, email change, payout, API key creation.
+
+## Reconnaissance
+
+- Map the full sequence with the proxy: `POST /login` -> response (cookies, tokens, `mfa_required` flag) -> `POST /verify-otp`. Capture every request/response.
+- Decode any JWT issued at the password step (`jwt_tool <token>` or base64) — look for `mfa: false`, `amr`, `acr`, `auth_level`, `2fa_passed` style claims.
+- Enumerate which endpoints accept the post-password / pre-MFA token (replay it against `/api/me`, `/api/account`, data endpoints).
+- Identify all factor types offered and every recovery path (often under `/account/security`).
+
+## Key Vulnerabilities
+
+### Pre-MFA session access (most common)
+The cookie/token issued after the password is already valid for some routes. Log in with valid creds, stop before submitting the OTP, and replay the session against sensitive endpoints. If `/api/*` data or state-changing actions work, MFA is decorative.
+
+### OTP brute force / missing rate limit
+6-digit codes have only 1,000,000 values and often live 5–10 minutes. Spray with a script (never by hand):
+- Fix the session, iterate `000000`–`999999` via `exec_command` Python with `aiohttp` concurrency, watch for a status/length/redirect change.
+- Test for limit resets: does requesting a new code reset the attempt counter? Does changing IP/`X-Forwarded-For` or rotating the session reset it?
+
+### OTP reuse / non-single-use / prediction
+- Submit the same valid code twice — is the second accept?
+- Does a code from an old request still validate? Are codes tied to the specific session/device?
+- Check for predictable or server-disclosed codes (leaked in a response body, header, or `Set-Cookie`).
+
+### Recovery & fallback downgrade
+- Force a method downgrade (strong TOTP -> SMS/email) and attack the weaker channel.
+- Backup codes: are they rate-limited? Single-use? Generated with weak entropy? Exposed in the enrollment response?
+- Account recovery that resets the password may drop MFA entirely — full bypass.
+
+### Enrollment flaws
+- Add a new attacker-controlled factor without re-verifying the current one — then authenticate with it.
+- Disable/remove MFA without step-up — combined with an account-takeover primitive (e.g. session fixation), this is a clean takeover.
+
+### Client-side / response-tamper gates
+- Flip the failing response: change `{"mfa":false}` / `"status":"PENDING"` to `true`/`"SUCCESS"` and see if the client proceeds with a usable session.
+- Tamper the JWT/cookie claim (`mfa:false`->`true`); test alg confusion / weak signing per the `authentication_jwt` skill.
+- Force-browse past the MFA page directly to the post-login landing route.
+
+## Bypass Techniques
+
+- Reuse the pre-MFA token directly on the API (skip the UI gate).
+- Race the verify endpoint (parallel valid+invalid submissions) — see `race_conditions`.
+- Null/empty/array OTP values (`otp=`, `otp[]=`, `otp=null`) to hit a comparison flaw.
+- Response/JWT tampering on the MFA-state field.
+- Recovery-flow pivot to escape the second factor entirely.
+
+## Testing Methodology
+
+1. Capture the complete login -> MFA -> landing flow in the proxy.
+2. Replay the pre-MFA session against sensitive/API endpoints (access without MFA?).
+3. Attack the OTP endpoint: brute force, reuse, lifetime, limit resets — all scripted.
+4. Walk every recovery/fallback path for downgrade and MFA-skip.
+5. Test enrollment add/remove without step-up re-verification.
+6. Tamper client-side MFA state (JSON flags, JWT claims, cookies) and force-browse.
+7. Check step-up enforcement on each sensitive action independently.
+
+## Validation
+
+1. Demonstrate a concrete authenticated action (read private data, change state) reached without a valid second factor.
+2. For brute force, show the request count and the success transition (with throttling absent).
+3. Keep PoCs minimal and on a tester-owned account; do not touch real user data.
+
+## False Positives
+
+- A pre-MFA token that only reaches public/`mfa_required` endpoints and nothing sensitive.
+- Rate limiting that is present but slow (still effective — note it, don't over-claim).
+- "Reuse" that actually issued a fresh equal-looking code.
+- Recovery flows that re-trigger MFA after reset.
+
+## Impact
+
+Full account takeover, authentication bypass, and defeat of the primary compensating control for credential theft/phishing. Often chains with leaked/guessable passwords into direct compromise.
+
+## Pro Tips
+
+1. The richest bug is almost always the pre-MFA token — test it against the API before anything fancy.
+2. Always script OTP work; manual attempts miss the missing-rate-limit window.
+3. Re-test limits after a new-code request and after session/IP rotation — counters often reset.
+4. Treat enrollment and recovery as separate attack surfaces from login; they bypass MFA more often than login itself.
+5. Pair with `authentication_jwt` whenever MFA state rides in a token.


### PR DESCRIPTION
## What

Adds the two vulnerability skills requested in #335 (the prior attempt #334 was closed):

- **`strix/skills/vulnerabilities/mfa_bypass.md`** (CWE-308) — pre-MFA session access, OTP brute force / reuse / lifetime, recovery & fallback downgrade, enrollment without step-up re-verification, and client-side/JWT MFA-state tampering.
- **`strix/skills/vulnerabilities/edge_cases.md`** (CWE-362) — cache poisoning/deception & `Vary` omission, partial-failure exploitation, eventual-consistency windows, boundary conditions (numeric/pagination/time), and degraded-mode auth bypass.

Both follow the existing skill template and tone (see `ssrf.md`): frontmatter + Attack Surface, Reconnaissance, Key Vulnerabilities, Testing Methodology, Validation, False Positives, Impact, Pro Tips. They're auto-discovered by the skills loader (verified: both load, frontmatter stripped, present in `get_all_skill_names()`).

Markdown-only; no code changes. Kept focused on the two skill files (no extra test harness) to match the existing `strix/skills/` convention.

Closes #335