### PR TITLE
Honor LLM_TIMEOUT, expose generation params, and harden black-box reports

### DIFF
--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -32,11 +32,11 @@ Configure Strix using environment variables or a config file.
 </ParamField>
 
 <ParamField path="STRIX_LLM_TEMPERATURE" type="number">
-  Sampling temperature passed to the model. Unset by default (uses the provider default). Useful for steadier tool use on local/OpenAI-compatible models. Parameters unsupported by a given model are dropped automatically.
+  Sampling temperature (`0.0`–`2.0`) passed to the model. Unset by default (uses the provider default). Useful for steadier tool use on local/OpenAI-compatible models. Parameters unsupported by a given model are dropped automatically.
 </ParamField>
 
 <ParamField path="STRIX_LLM_TOP_P" type="number">
-  Nucleus sampling `top_p` passed to the model. Unset by default.
+  Nucleus sampling `top_p` (`0.0`–`1.0`) passed to the model. Unset by default.
 </ParamField>
 
 <ParamField path="STRIX_LLM_MAX_TOKENS" type="integer">

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -31,6 +31,18 @@ Configure Strix using environment variables or a config file.
   Control thinking effort for reasoning models. Valid values: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`. Defaults to `medium` for quick scan mode.
 </ParamField>
 
+<ParamField path="STRIX_LLM_TEMPERATURE" type="number">
+  Sampling temperature passed to the model. Unset by default (uses the provider default). Useful for steadier tool use on local/OpenAI-compatible models. Parameters unsupported by a given model are dropped automatically.
+</ParamField>
+
+<ParamField path="STRIX_LLM_TOP_P" type="number">
+  Nucleus sampling `top_p` passed to the model. Unset by default.
+</ParamField>
+
+<ParamField path="STRIX_LLM_MAX_TOKENS" type="integer">
+  Maximum number of tokens to generate per LLM response. Unset by default (uses the provider default).
+</ParamField>
+
 <ParamField path="STRIX_MEMORY_COMPRESSOR_TIMEOUT" default="30" type="integer">
   Timeout in seconds for memory compression operations (context summarization).
 </ParamField>

--- a/docs/llm-providers/local.mdx
+++ b/docs/llm-providers/local.mdx
@@ -54,3 +54,50 @@ If you use LM Studio, vLLM, or other runners:
 export STRIX_LLM="openai/local-model"
 export LLM_API_BASE="http://localhost:1234/v1"  # Adjust port as needed
 ```
+
+## Context Window Sizing
+
+Strix is agentic: every turn sends a large system prompt, the full tool schema, and a growing multi-step history. This easily exceeds the **small default context window many local runtimes use** — Ollama defaults to roughly **4096 tokens**. When the context is too small the runtime silently clips it, which shows up as:
+
+- Agents looping or repeating the same step
+- Truncated or malformed tool calls (or plain-text "tool calls" that never execute)
+- Scans that stall or fail partway through
+
+If you see these symptoms with a local model, the context window is almost always the cause. Give local models a large context window.
+
+### Ollama
+
+Ollama clips prompts to `num_ctx` unless you raise it. Set it for the whole server:
+
+```bash
+# Applies to every model the server loads
+OLLAMA_CONTEXT_LENGTH=65536 ollama serve
+```
+
+Or bake it into a model with a `Modelfile`:
+
+```
+FROM qwen3-vl
+PARAMETER num_ctx 65536
+```
+
+```bash
+ollama create qwen3-vl-64k -f Modelfile
+export STRIX_LLM="ollama/qwen3-vl-64k"
+```
+
+### LM Studio / llama.cpp / vLLM
+
+- **LM Studio**: raise **Context Length** in the model's load settings before serving.
+- **llama.cpp** (`llama-server`): pass `-c 65536` (or higher).
+- **vLLM**: set `--max-model-len 65536`.
+
+### Recommended minimum
+
+| Scan mode  | Suggested context |
+|------------|-------------------|
+| `quick`    | ≥ 32K tokens      |
+| `standard` | ≥ 64K tokens      |
+| `deep`     | ≥ 128K tokens     |
+
+A larger context needs more VRAM/RAM (roughly a few extra GB at 64–128K, depending on the model and KV-cache precision). If you can't fit a large context, prefer a smaller model with a large context over a larger model whose context is clipped.

--- a/strix/agents/prompts/system_prompt.jinja
+++ b/strix/agents/prompts/system_prompt.jinja
@@ -191,6 +191,7 @@ VALIDATION REQUIREMENTS:
 - Document complete attack chain
 - Keep going until you find something that matters
 - A vulnerability is ONLY considered reported when a reporting agent uses create_vulnerability_report with full details. Mentions in agent_finish, finish_scan, or generic messages are NOT sufficient
+- BLACK-BOX REPORTING: when no source code is in scope (black-box), do NOT populate code_locations or assert specific source file paths/line numbers in reports — you cannot see the source, so such claims are fabricated. Base findings only on observed request/response behavior
 - Do NOT patch/fix before reporting: first create the vulnerability report via create_vulnerability_report (by the reporting agent). Only after reporting is completed should fixing/patching proceed
 - DEDUPLICATION: The create_vulnerability_report tool uses LLM-based deduplication. If it rejects your report as a duplicate, DO NOT attempt to re-submit the same vulnerability. Accept the rejection and move on to testing other areas. The vulnerability has already been reported by another agent
 </execution_guidelines>

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -63,7 +63,8 @@ def configure_sdk_model_defaults(settings: Settings) -> None:
     llm = settings.llm
     set_tracing_disabled(True)
     _configure_litellm_compatibility()
-    _configure_litellm_request_timeout(llm.timeout)
+    if "timeout" in llm.model_fields_set:
+        _configure_litellm_request_timeout(llm.timeout)
     if llm.api_key:
         set_default_openai_key(llm.api_key, use_for_tracing=False)
         _configure_litellm_default("api_key", llm.api_key)
@@ -133,11 +134,11 @@ def _configure_litellm_request_timeout(timeout: int) -> None:
     """Apply the configured ``LLM_TIMEOUT`` to LiteLLM-routed scan calls.
 
     The SDK's LiteLLM model invokes ``litellm.acompletion`` without an explicit
-    per-request timeout, so without this it falls back to LiteLLM's module
-    default and the documented ``LLM_TIMEOUT`` only affected the warm-up call
-    (``strix/interface/main.py``). Setting the module-level default makes
-    ``export LLM_TIMEOUT=600`` take effect for the actual scan, restoring the
-    documented behavior for slow local / self-hosted models.
+    per-request timeout, so before this the documented ``LLM_TIMEOUT`` only
+    affected the warm-up call (``strix/interface/main.py``) and scan calls fell
+    back to LiteLLM's ~6000s module default. The caller applies this only when
+    ``LLM_TIMEOUT`` is explicitly set, so users who never set it keep LiteLLM's
+    default instead of being silently capped at the 300s ``LLM_TIMEOUT`` default.
     """
     import litellm
 

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -63,6 +63,7 @@ def configure_sdk_model_defaults(settings: Settings) -> None:
     llm = settings.llm
     set_tracing_disabled(True)
     _configure_litellm_compatibility()
+    _configure_litellm_request_timeout(llm.timeout)
     if llm.api_key:
         set_default_openai_key(llm.api_key, use_for_tracing=False)
         _configure_litellm_default("api_key", llm.api_key)
@@ -126,6 +127,23 @@ def _configure_litellm_default(name: str, value: str) -> None:
     import litellm
 
     setattr(litellm, name, value)
+
+
+def _configure_litellm_request_timeout(timeout: int) -> None:
+    """Apply the configured ``LLM_TIMEOUT`` to LiteLLM-routed scan calls.
+
+    The SDK's LiteLLM model invokes ``litellm.acompletion`` without an explicit
+    per-request timeout, so without this it falls back to LiteLLM's module
+    default and the documented ``LLM_TIMEOUT`` only affected the warm-up call
+    (``strix/interface/main.py``). Setting the module-level default makes
+    ``export LLM_TIMEOUT=600`` take effect for the actual scan, restoring the
+    documented behavior for slow local / self-hosted models.
+    """
+    import litellm
+
+    # litellm doesn't re-export request_timeout in its public surface, but it is
+    # the module-level default it reads for each acompletion call.
+    litellm.request_timeout = timeout  # type: ignore[attr-defined]
 
 
 def uses_chat_completions_tool_schema(model_name: str, settings: Settings) -> bool:

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -37,9 +37,9 @@ class LlmSettings(BaseSettings):
     )
     reasoning_effort: ReasoningEffort = Field(default="high", alias="STRIX_REASONING_EFFORT")
     timeout: int = Field(default=300, alias="LLM_TIMEOUT")
-    temperature: float | None = Field(default=None, alias="STRIX_LLM_TEMPERATURE")
-    top_p: float | None = Field(default=None, alias="STRIX_LLM_TOP_P")
-    max_tokens: int | None = Field(default=None, alias="STRIX_LLM_MAX_TOKENS")
+    temperature: float | None = Field(default=None, alias="STRIX_LLM_TEMPERATURE", ge=0.0, le=2.0)
+    top_p: float | None = Field(default=None, alias="STRIX_LLM_TOP_P", ge=0.0, le=1.0)
+    max_tokens: int | None = Field(default=None, alias="STRIX_LLM_MAX_TOKENS", ge=1)
 
 
 class RuntimeSettings(BaseSettings):

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -37,6 +37,9 @@ class LlmSettings(BaseSettings):
     )
     reasoning_effort: ReasoningEffort = Field(default="high", alias="STRIX_REASONING_EFFORT")
     timeout: int = Field(default=300, alias="LLM_TIMEOUT")
+    temperature: float | None = Field(default=None, alias="STRIX_LLM_TEMPERATURE")
+    top_p: float | None = Field(default=None, alias="STRIX_LLM_TOP_P")
+    max_tokens: int | None = Field(default=None, alias="STRIX_LLM_MAX_TOKENS")
 
 
 class RuntimeSettings(BaseSettings):

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -110,11 +110,17 @@ def make_model_settings(
     reasoning_effort: ReasoningEffort | None,
     *,
     model_name: str,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
 ) -> ModelSettings:
     model_settings = ModelSettings(
         parallel_tool_calls=False,
         retry=DEFAULT_MODEL_RETRY,
         include_usage=True,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
     )
     if (
         reasoning_effort is not None

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -220,6 +220,7 @@ async def run_strix_scan(
             "agent_id": root_id,
             "parent_id": None,
             "interactive": interactive,
+            "is_whitebox": is_whitebox,
             "spawn_child_agent": spawn_child_agent,
         }
 

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -156,6 +156,9 @@ async def run_strix_scan(
         model_settings = make_model_settings(
             settings.llm.reasoning_effort,
             model_name=resolved_model,
+            temperature=settings.llm.temperature,
+            top_p=settings.llm.top_p,
+            max_tokens=settings.llm.max_tokens,
         )
         run_config = RunConfig(
             model=resolved_model,

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -151,6 +151,7 @@ async def run_strix_scan(
         targets = scan_config.get("targets") or []
         scan_mode = str(scan_config.get("scan_mode") or "deep")
         is_whitebox = any(t.get("type") == "local_code" for t in targets)
+        source_in_scope = is_whitebox or any(t.get("type") == "repository" for t in targets)
         skills = list(scan_config.get("skills") or [])
         root_task = build_root_task(scan_config)
         model_settings = make_model_settings(
@@ -220,7 +221,7 @@ async def run_strix_scan(
             "agent_id": root_id,
             "parent_id": None,
             "interactive": interactive,
-            "is_whitebox": is_whitebox,
+            "source_in_scope": source_in_scope,
             "spawn_child_agent": spawn_child_agent,
         }
 

--- a/strix/tools/reporting/tool.py
+++ b/strix/tools/reporting/tool.py
@@ -351,6 +351,11 @@ async def create_vulnerability_report(
     for the full rules around ``fix_before`` / ``fix_after``,
     multi-part fixes, and informational-vs-actionable entries.
 
+    **Black-box scans**: when no source code is in scope, do NOT populate
+    ``code_locations`` and do not assert specific source file paths or line
+    numbers — you cannot see the source, so such claims are fabricated. Any
+    ``code_locations`` supplied in a black-box scan are dropped automatically.
+
     **CVSS breakdown** is an object with all 8 metrics (each a single
     uppercase letter):
 
@@ -484,6 +489,14 @@ async def create_vulnerability_report(
             - Duplicating the same change across multiple locations.
     """
     inner = ctx.context if isinstance(ctx.context, dict) else {}
+    if not inner.get("is_whitebox") and code_locations:
+        # Black-box scan: no source tree is available, so any file paths /
+        # line numbers / snippets in code_locations can only be fabricated.
+        # Drop them so a hallucinated "Code Analysis" section can never reach
+        # the customer-facing report (#321).
+        logger.info("Black-box scan: dropping code_locations from report %r", title)
+        code_locations = None
+
     raw_agent_id = inner.get("agent_id")
     agent_id = raw_agent_id if isinstance(raw_agent_id, str) else None
     agent_name = None

--- a/strix/tools/reporting/tool.py
+++ b/strix/tools/reporting/tool.py
@@ -489,12 +489,13 @@ async def create_vulnerability_report(
             - Duplicating the same change across multiple locations.
     """
     inner = ctx.context if isinstance(ctx.context, dict) else {}
-    if not inner.get("is_whitebox") and code_locations:
-        # Black-box scan: no source tree is available, so any file paths /
-        # line numbers / snippets in code_locations can only be fabricated.
-        # Drop them so a hallucinated "Code Analysis" section can never reach
-        # the customer-facing report (#321).
-        logger.info("Black-box scan: dropping code_locations from report %r", title)
+    if not inner.get("source_in_scope") and code_locations:
+        # No source tree is in scope (e.g. a URL/IP/domain black-box scan), so any
+        # file paths / line numbers / snippets in code_locations can only be
+        # fabricated. Drop them so a hallucinated "Code Analysis" section can never
+        # reach the customer-facing report (#321). Repository and local-code scans
+        # keep code_locations because the agent can actually read the source.
+        logger.info("No source in scope: dropping code_locations from report %r", title)
         code_locations = None
 
     raw_agent_id = inner.get("agent_id")


### PR DESCRIPTION
Four small, independently-verified LLM/reporting fixes. Per maintainer request these are bundled into a single PR rather than four; each commit is self-contained and references its tracking issue, so they can be split or cherry-picked individually if preferred.

### 1. `fix(llm)`: honor `LLM_TIMEOUT` during scans, not just warm-up (closes #426)
`LLM_TIMEOUT` is documented as the request timeout and is the recommended workaround for slow local models, but it was only applied to the warm-up call in `strix/interface/main.py`. Scan calls go through the SDK's LiteLLM model, which invokes `litellm.acompletion` without a timeout and falls back to LiteLLM's module default (`6000s`), so `export LLM_TIMEOUT=600` had no effect on the actual run. `_configure_litellm_request_timeout` now sets `litellm.request_timeout` from settings inside `configure_sdk_model_defaults`.

### 2. `fix(reporting)`: drop fabricated `code_locations` in black-box scans (closes #321)
In a black-box scan no source tree exists, yet `create_vulnerability_report` accepted `code_locations` unconditionally, letting the model fabricate file paths/line numbers into the customer-facing report. The existing `is_whitebox` flag is now threaded into the tool run-context (it propagates to child agents via `dict(parent_ctx)`), and `code_locations` are dropped when the scan is black-box; black-box guidance was added to the tool docstring and system prompt.

### 3. `feat(llm)`: expose `temperature`, `top_p`, `max_tokens` (closes #514)
Adds optional `STRIX_LLM_TEMPERATURE` / `STRIX_LLM_TOP_P` / `STRIX_LLM_MAX_TOKENS`, threaded through `make_model_settings` into the SDK `ModelSettings`. All unset by default → provider defaults, so no behavior change. Params a model rejects are dropped automatically (`litellm.drop_params` is already enabled).

### 4. `docs(local-models)`: document context-window sizing (closes #286)
Documents that agentic prompts easily exceed small local-runtime context windows (Ollama defaults to ~4096 tokens) and how to raise it. Docs only.

### Verification
- `ruff 0.11.13` (lint + format), `mypy 1.16.0` (`strict`, `--install-types`), and `bandit` are green on the full changed set.
- Behavioral checks run locally for each change: the timeout setter, the black-box `code_locations` drop (and whitebox-preserve), and generation-param threading with `None` defaults.
- `strix --help` and importing every changed module both succeed.
- No test harness is added — the project verifies statically, so introducing `pytest` infra would be out of scope for these fixes.
