### PR TITLE
Swallow sandbox container races in the stream consumer

### DIFF
--- a/strix/core/agents.py
+++ b/strix/core/agents.py
@@ -42,9 +42,13 @@ class AgentCoordinator:
         self.runtimes: dict[str, AgentRuntime] = {}
         self._lock = asyncio.Lock()
         self._snapshot_path: Path | None = None
+        self.is_shutting_down = False
 
     def set_snapshot_path(self, path: Path) -> None:
         self._snapshot_path = path
+
+    def mark_shutting_down(self) -> None:
+        self.is_shutting_down = True
 
     async def register(
         self,

--- a/strix/core/execution.py
+++ b/strix/core/execution.py
@@ -368,7 +368,13 @@ async def _run_cycle(  # noqa: PLR0912, PLR0915
                         agent_id,
                     )
                 except (ExecTransportError, docker_errors.NotFound):
-                    logger.warning("Ignoring sandbox container error for %s", agent_id)
+                    if not coordinator.is_shutting_down:
+                        raise
+                    logger.warning(
+                        "Ignoring sandbox container error during teardown for %s",
+                        agent_id,
+                        exc_info=True,
+                    )
             finally:
                 await coordinator.detach_stream(agent_id, stream)
         except Exception as exc:

--- a/strix/core/execution.py
+++ b/strix/core/execution.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 from agents import RunConfig, Runner
 from agents.exceptions import AgentsException, MaxTurnsExceeded, UserError
+from agents.sandbox.errors import ExecTransportError
+from docker import errors as docker_errors  # type: ignore[import-untyped, unused-ignore]
 from openai import APIError
 
 from strix.core.inputs import child_initial_input
@@ -320,7 +322,7 @@ async def _run_noninteractive_until_lifecycle(
         )
 
 
-async def _run_cycle(  # noqa: PLR0912
+async def _run_cycle(  # noqa: PLR0912, PLR0915
     agent: Any,
     coordinator: AgentCoordinator,
     agent_id: str,
@@ -356,6 +358,8 @@ async def _run_cycle(  # noqa: PLR0912
                                 event_sink(agent_id, event)
                             except Exception:
                                 logger.exception("stream event sink failed for %s", agent_id)
+                    if stream.run_loop_exception is not None:
+                        raise stream.run_loop_exception
                 except RuntimeError as stream_exc:
                     if "after shutdown" not in str(stream_exc):
                         raise
@@ -363,8 +367,8 @@ async def _run_cycle(  # noqa: PLR0912
                         "Ignoring LiteLLM end-of-stream shutdown race for %s",
                         agent_id,
                     )
-                if stream.run_loop_exception is not None:
-                    raise stream.run_loop_exception
+                except (ExecTransportError, docker_errors.NotFound):
+                    logger.warning("Ignoring sandbox container error for %s", agent_id)
             finally:
                 await coordinator.detach_stream(agent_id, stream)
         except Exception as exc:

--- a/strix/interface/tui/app.py
+++ b/strix/interface/tui/app.py
@@ -1715,6 +1715,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         self.exit()
 
     def _fire_sandbox_cleanup(self) -> None:
+        self.coordinator.mark_shutting_down()
         loop = self._scan_loop
         if loop is None or loop.is_closed():
             return


### PR DESCRIPTION
When the TUI quit path SIGKILL's the sandbox container (PR #548), the agent's in-flight SDK calls can race the cleanup and surface as either:

- `agents.sandbox.errors.ExecTransportError` — from `exec` calls into the now-gone container
- `docker.errors.NotFound` — from `container.reload()` / `inspect_container` / any container lookup

Both are expected during teardown. Catch them in `_run_cycle`'s stream consumer alongside the existing LiteLLM shutdown-race catch.

Also moves the `raise stream.run_loop_exception` line *inside* the try, so the stored exception path is covered too (the SDK stashes the exception on the stream object rather than re-raising it through `stream_events()`).
