### PR TITLE
Strip all images from session on vision-rejection, not just the latest

### DIFF
--- a/strix/core/execution.py
+++ b/strix/core/execution.py
@@ -16,7 +16,7 @@ from docker import errors as docker_errors  # type: ignore[import-untyped, unuse
 from openai import APIError
 
 from strix.core.inputs import child_initial_input
-from strix.core.sessions import open_agent_session, strip_latest_image_from_session
+from strix.core.sessions import open_agent_session, strip_all_images_from_session
 
 
 if TYPE_CHECKING:
@@ -384,7 +384,7 @@ async def _run_cycle(  # noqa: PLR0912, PLR0915
                 and getattr(exc, "status_code", None) in _INPUT_REJECTION_CODES
             ):
                 try:
-                    stripped = await strip_latest_image_from_session(session)
+                    stripped = await strip_all_images_from_session(session)
                 except Exception:
                     logger.exception("image-strip recovery failed for %s", agent_id)
                     stripped = False

--- a/strix/core/execution.py
+++ b/strix/core/execution.py
@@ -391,7 +391,7 @@ async def _run_cycle(  # noqa: PLR0912, PLR0915
                 if stripped:
                     image_strips += 1
                     logger.info(
-                        "Stripped latest image from %s session after rejection; retrying (%d)",
+                        "Stripped images from %s session after rejection; retrying (%d)",
                         agent_id,
                         image_strips,
                     )

--- a/strix/core/sessions.py
+++ b/strix/core/sessions.py
@@ -54,12 +54,12 @@ async def strip_all_images_from_session(session: Session) -> bool:
     if not changed:
         return False
 
-    original = cast("list[TResponseInputItem]", list(items))
+    rebuilt_items = cast("list[TResponseInputItem]", rebuilt)
     await session.clear_session()
     try:
-        await session.add_items(cast("list[TResponseInputItem]", rebuilt))
+        await session.add_items(rebuilt_items)
     except Exception:
         with contextlib.suppress(Exception):
-            await session.add_items(original)
+            await session.add_items(rebuilt_items)
         raise
     return True

--- a/strix/core/sessions.py
+++ b/strix/core/sessions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from agents.memory import SQLiteSession
 
@@ -22,29 +22,37 @@ def open_agent_session(agent_id: str, path: Path) -> SQLiteSession:
 _IMAGE_REJECTED_TEXT = "[image rejected by the model]"
 
 
-async def strip_latest_image_from_session(session: Session) -> bool:
+async def strip_all_images_from_session(session: Session) -> bool:
     items = await session.get_items()
     if not items:
         return False
-    latest = items[-1]
-    if not isinstance(latest, dict) or latest.get("type") != "function_call_output":
-        return False
-    output = latest.get("output")
-    if not isinstance(output, list):
-        return False
-    if not any(isinstance(b, dict) and b.get("type") == "input_image" for b in output):
-        return False
-    await session.pop_item()
-    await session.add_items(
-        cast(
-            "list[TResponseInputItem]",
-            [
+
+    rebuilt: list[Any] = []
+    changed = False
+    for item in items:
+        item_dict = cast("dict[str, Any]", item) if isinstance(item, dict) else None
+        if (
+            item_dict is not None
+            and item_dict.get("type") == "function_call_output"
+            and isinstance(item_dict.get("output"), list)
+            and any(
+                isinstance(b, dict) and b.get("type") == "input_image" for b in item_dict["output"]
+            )
+        ):
+            rebuilt.append(
                 {
                     "type": "function_call_output",
-                    "call_id": latest.get("call_id"),
+                    "call_id": item_dict.get("call_id"),
                     "output": [{"type": "input_text", "text": _IMAGE_REJECTED_TEXT}],
                 },
-            ],
-        ),
-    )
+            )
+            changed = True
+        else:
+            rebuilt.append(item)
+
+    if not changed:
+        return False
+
+    await session.clear_session()
+    await session.add_items(cast("list[TResponseInputItem]", rebuilt))
     return True

--- a/strix/core/sessions.py
+++ b/strix/core/sessions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING, Any, cast
 
 from agents.memory import SQLiteSession
@@ -53,6 +54,12 @@ async def strip_all_images_from_session(session: Session) -> bool:
     if not changed:
         return False
 
+    original = cast("list[TResponseInputItem]", list(items))
     await session.clear_session()
-    await session.add_items(cast("list[TResponseInputItem]", rebuilt))
+    try:
+        await session.add_items(cast("list[TResponseInputItem]", rebuilt))
+    except Exception:
+        with contextlib.suppress(Exception):
+            await session.add_items(original)
+        raise
     return True

--- a/strix/tools/view_image/README.md
+++ b/strix/tools/view_image/README.md
@@ -13,5 +13,5 @@ returns it as an image content block for vision-capable models.
   `containers/docker-entrypoint.sh`).
 - **Skill:** screenshot workflow lives in `strix/skills/tooling/agent_browser.md`.
 - **Recovery:** vision-not-supported model rejections are auto-recovered
-  via `strix.core.sessions.strip_latest_image_from_session`, invoked from
+  via `strix.core.sessions.strip_all_images_from_session`, invoked from
   `strix/core/execution.py`.


### PR DESCRIPTION
## Why

The existing recovery for vision-not-supported rejections in `_run_cycle` only stripped the **latest** session item — and only if that item was a `function_call_output` carrying an `input_image`. When a non-vision model rejects an image **mid-conversation** (e.g. DeepSeek v4-pro's `messages[14]: unknown variant \`image_url\``), the strip returned `False`, the recovery fell through, and the scan crashed.

## What

Generalise `strip_latest_image_from_session` → `strip_all_images_from_session`. The new version walks every session item, replaces every `function_call_output` containing an `input_image` with the same `[image rejected by the model]` placeholder text, and rebuilds the session via `clear_session()` + `add_items()`. Length and order preserved; non-image items pass through untouched.

## Verified

- Mid-conversation image stripped
- Multiple images stripped in one pass
- Order preserved
- Idempotent: returns `False` when no images remain
- ruff + mypy clean

Updates the single call site in `strix/core/execution.py` and the reference in `strix/tools/view_image/README.md`.