### PR TITLE
Strip ANSI escapes and control bytes from terminal tool output

### DIFF
--- a/strix/interface/tui/renderers/shell_renderer.py
+++ b/strix/interface/tui/renderers/shell_renderer.py
@@ -26,6 +26,11 @@ _EXIT_RE = re.compile(r"Process exited with code (-?\d+)")
 _SESSION_RE = re.compile(r"Process running with session ID (\d+)")
 _OUTPUT_HEADER = "\nOutput:\n"
 
+_CONTROL_BYTES_TO_DROP = dict.fromkeys(
+    [b for b in range(0x20) if b not in (0x09, 0x0A)] + [0x7F],
+    None,
+)
+
 
 @cache
 def _get_style_colors() -> dict[Any, str]:
@@ -60,14 +65,13 @@ def _parse_sdk_shell_result(result: Any) -> dict[str, Any]:
 
 
 def _truncate_line(line: str) -> str:
-    clean_line = re.sub(r"\x1b\[[0-9;]*m", "", line)
-    if len(clean_line) > MAX_LINE_LENGTH:
+    if len(line) > MAX_LINE_LENGTH:
         return line[: MAX_LINE_LENGTH - 3] + "..."
     return line
 
 
 def _clean_output(output: str) -> str:
-    cleaned = output
+    cleaned = Text.from_ansi(output).plain.translate(_CONTROL_BYTES_TO_DROP)
     for pattern in STRIP_PATTERNS:
         cleaned = re.sub(pattern, "", cleaned, flags=re.MULTILINE)
 


### PR DESCRIPTION
## Why

Shell tool output was passed to Rich's `Text` verbatim, so SGR colour codes, cursor-movement CSI sequences, DEC private mode toggles, bracketed paste markers, OSC window-title escapes, and raw control bytes (NUL, backspace, BEL) all rendered as literal characters. The TUI layout broke whenever a command produced colour output (`ls --color`, `npm`, `pip`, `make`) or when the target's shell printed a title escape.

## What

`_clean_output` runs `Text.from_ansi(...).plain` so Rich's parser strips all ANSI sequences, then a stdlib `str.translate` drops remaining control bytes (preserves `\t` and `\n`). `_truncate_line` drops its now-redundant in-place SGR strip.

## Verified

11-case offline before/after diff over realistic samples (`ls --color`, npm/pip output, bracketed paste, DEC private modes, OSC titles, raw NUL/BS/BEL bytes, CR progress bars, ssh banner with title escape). Plus an in-scan probe prompt that exercises each category via the agent's shell tool.

## Known partial cases (acceptable)

- OSC payloads (`\x1b]0;title\x07`) — Rich strips the opener and BEL, the title string leaks as plain text. Not TUI-corrupting (no cursor moves), just a visual artefact.
- CR progress bars expand to multi-line — Rich converts `\r` to `\n`. Same behaviour as before this PR.