### PR TITLE
Fix Bedrock reasoning for adaptive-thinking models (Claude Opus 4.8)

### DIFF
--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -138,7 +138,7 @@ def uses_chat_completions_tool_schema(model_name: str, settings: Settings) -> bo
     return not model_supports_reasoning(model_name)
 
 
-def model_supports_reasoning(model_name: str) -> bool:
+def _model_cost_entry(model_name: str) -> dict[str, object] | None:
     import litellm
 
     name = model_name.strip().lower()
@@ -149,7 +149,23 @@ def model_supports_reasoning(model_name: str) -> bool:
     entry = litellm.model_cost.get(name)
     if entry is None and "/" in name:
         entry = litellm.model_cost.get(name.rsplit("/", 1)[1])
+    return entry
+
+
+def model_supports_reasoning(model_name: str) -> bool:
+    entry = _model_cost_entry(model_name)
     return bool(entry and entry.get("supports_reasoning"))
+
+
+def model_supports_adaptive_thinking(model_name: str) -> bool:
+    """Whether the model uses Anthropic's newer adaptive-thinking API.
+
+    Models like Claude Opus 4.8 reject the legacy ``thinking.type=enabled`` shape
+    that LiteLLM emits when it converts ``reasoning_effort``. They require
+    ``thinking.type=adaptive`` plus ``output_config.effort`` instead.
+    """
+    entry = _model_cost_entry(model_name)
+    return bool(entry and entry.get("supports_adaptive_thinking"))
 
 
 def is_known_openai_bare_model(model_name: str) -> bool:

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -168,6 +168,12 @@ def model_supports_adaptive_thinking(model_name: str) -> bool:
     return bool(entry and entry.get("supports_adaptive_thinking"))
 
 
+def model_supports_xhigh_effort(model_name: str) -> bool:
+    """Whether the model accepts the ``xhigh`` effort tier."""
+    entry = _model_cost_entry(model_name)
+    return bool(entry and entry.get("supports_xhigh_reasoning_effort"))
+
+
 def is_known_openai_bare_model(model_name: str) -> bool:
     import litellm
 

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -12,6 +12,7 @@ from strix.config.models import (
     DEFAULT_MODEL_RETRY,
     model_supports_adaptive_thinking,
     model_supports_reasoning,
+    model_supports_xhigh_effort,
 )
 
 
@@ -129,11 +130,19 @@ def make_model_settings(
             # Newer Anthropic models (e.g. Claude Opus 4.8) reject the legacy
             # ``thinking.type=enabled`` shape that LiteLLM emits from
             # ``reasoning_effort``. Send the adaptive-thinking API instead.
+            # Bedrock's ``output_config.effort`` only accepts low/medium/high
+            # (plus xhigh on models that advertise it), so normalize the wider
+            # ReasoningEffort range onto that set.
+            effort = reasoning_effort
+            if effort == "minimal":
+                effort = "low"
+            elif effort == "xhigh" and not model_supports_xhigh_effort(model_name):
+                effort = "high"
             model_settings = model_settings.resolve(
                 ModelSettings(
                     extra_args={
                         "thinking": {"type": "adaptive"},
-                        "output_config": {"effort": reasoning_effort},
+                        "output_config": {"effort": effort},
                     },
                 ),
             )

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any
 from agents.model_settings import ModelSettings
 from openai.types.shared import Reasoning
 
-from strix.config.models import DEFAULT_MODEL_RETRY, model_supports_reasoning
+from strix.config.models import (
+    DEFAULT_MODEL_RETRY,
+    model_supports_adaptive_thinking,
+    model_supports_reasoning,
+)
 
 
 if TYPE_CHECKING:
@@ -121,9 +125,22 @@ def make_model_settings(
         and reasoning_effort != "none"
         and model_supports_reasoning(model_name)
     ):
-        model_settings = model_settings.resolve(
-            ModelSettings(reasoning=Reasoning(effort=reasoning_effort)),
-        )
+        if model_supports_adaptive_thinking(model_name):
+            # Newer Anthropic models (e.g. Claude Opus 4.8) reject the legacy
+            # ``thinking.type=enabled`` shape that LiteLLM emits from
+            # ``reasoning_effort``. Send the adaptive-thinking API instead.
+            model_settings = model_settings.resolve(
+                ModelSettings(
+                    extra_args={
+                        "thinking": {"type": "adaptive"},
+                        "output_config": {"effort": reasoning_effort},
+                    },
+                ),
+            )
+        else:
+            model_settings = model_settings.resolve(
+                ModelSettings(reasoning=Reasoning(effort=reasoning_effort)),
+            )
     return model_settings
 
 


### PR DESCRIPTION
## Problem

Running a scan against an AWS Bedrock Claude Opus 4.8 inference profile fails immediately with a `400 BadRequestError`:

```
litellm.BadRequestError: BedrockException - {"message":"The model returned the
following errors: \"thinking.type.enabled\" is not supported for this model. Use
\"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}
```

## Root cause

Strix detects that the model supports reasoning and passes `reasoning_effort` to the SDK, which forwards it to LiteLLM. LiteLLM converts `reasoning_effort` into Bedrock's legacy `thinking.type=enabled` payload. Newer Anthropic models (e.g. Claude Opus 4.8) no longer accept that shape and require `thinking.type=adaptive` plus `output_config.effort`.

LiteLLM's own model metadata already flags these models with `supports_adaptive_thinking: true` (alongside `supports_output_config`), but its request-conversion code still emits the old shape, so the request is rejected before any tokens are generated.

## Fix

- Add `model_supports_adaptive_thinking()` which reads LiteLLM's `supports_adaptive_thinking` flag (refactors the shared model-cost lookup into a helper).
- In `make_model_settings`, for reasoning-capable models that support adaptive thinking, send the adaptive-thinking API via `extra_args` (`thinking.type=adaptive` + `output_config.effort`) instead of the `reasoning_effort` scalar.

All other models keep their existing behavior.

## Testing

Verified against live Bedrock:

- The settings Strix now generates for the Opus 4.8 inference profile succeed in both non-streaming and streaming (`converse-stream`) calls. Before the change, the same call reproduced the `thinking.type.enabled` error.
- Confirmed no behavior change for other model classes: `o3` still uses the `reasoning` path, `gpt-4o` and Claude 3.5 Sonnet are unaffected.
- `ruff check` and `mypy` pass on the changed files.
