### PR TITLE
fix: route ollama models through ollama_chat so tool calling works

### DIFF
--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -39,6 +39,14 @@ class StrixProvider(MultiProvider):
                 prefix=prefix,
                 stripped_model_name=stripped_model_name,
             )
+        if prefix == "ollama" and stripped_model_name:
+            # Route Ollama through LiteLLM's chat endpoint. The bare ``ollama/``
+            # provider hits ``/api/generate``, which has no function-calling
+            # support, so with ``litellm.drop_params=True`` Strix's tools are
+            # dropped silently and the agent stops after one toolless turn.
+            # ``ollama_chat/`` uses ``/api/chat``, where tool-capable models can
+            # actually drive the agent loop.
+            return self._get_fallback_provider("litellm"), f"ollama_chat/{stripped_model_name}"
         return self._get_fallback_provider("litellm"), original_model_name
 
 

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -40,12 +40,6 @@ class StrixProvider(MultiProvider):
                 stripped_model_name=stripped_model_name,
             )
         if prefix == "ollama" and stripped_model_name:
-            # Route Ollama through LiteLLM's chat endpoint. The bare ``ollama/``
-            # provider hits ``/api/generate``, which has no function-calling
-            # support, so with ``litellm.drop_params=True`` Strix's tools are
-            # dropped silently and the agent stops after one toolless turn.
-            # ``ollama_chat/`` uses ``/api/chat``, where tool-capable models can
-            # actually drive the agent loop.
             return self._get_fallback_provider("litellm"), f"ollama_chat/{stripped_model_name}"
         return self._get_fallback_provider("litellm"), original_model_name
 


### PR DESCRIPTION
Fixes #526

## Problem
Ollama models do nothing: the agent makes one LLM call, gets a plain message, and ends the scan after one turn with no tool calls (the `NextStepFinalOutput` in the issue log).

Root cause is the `ollama/` prefix. It routes through LiteLLM's `ollama` provider, which uses Ollama's `/api/generate` endpoint, and that endpoint has no function-calling support. Since Strix sets `litellm.drop_params=True`, the agent's tools are dropped silently instead of erroring, so the model never sees them and replies with prose. LiteLLM's `ollama_chat/` route uses `/api/chat`, which supports tools.

## Fix
Route the `ollama` prefix through `ollama_chat` in `StrixProvider._resolve_prefixed_model`. The tool-capable models the docs recommend (qwen3-vl, deepseek-v3.1, devstral-2) can then drive the agent loop. `ollama_chat/` and other prefixes are unchanged.

## Note
Models that don't support Ollama tool calling at all (e.g. `gemma4:12b` from the issue) still won't drive the agent, that's a model limitation not routing. This makes the documented tool-capable models work.

## Verified
- `ruff check` + `ruff format --check` pass
- `mypy` clean (no issues), `bandit` clean (0 issues)
- `pyright` adds no new errors (this file already has 20 pre-existing on `main` from untyped litellm)
- Could not run Ollama end-to-end here; `ollama_chat/` is LiteLLM's documented route for chat + tool calling