### PR TITLE
fix(proxy): actionable errors for bad list_requests/list_sitemap args

### DIFF
--- a/strix/tools/proxy/tools.py
+++ b/strix/tools/proxy/tools.py
@@ -207,6 +207,22 @@ async def list_requests(
             default=str,
         )
     except Exception as exc:  # noqa: BLE001
+        if "HTTPQL" in str(exc):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        f"Invalid httpql_filter: {httpql_filter!r}. The Caido HTTPQL "
+                        "parser rejected it. Fixes: omit httpql_filter entirely to list "
+                        "all captured requests, or use valid HTTPQL — e.g. "
+                        'req.path.cont:"/api", resp.code.eq:200 (ints unquoted, strings '
+                        'quoted), or a bare quoted term like "password" to search both '
+                        "req.raw and resp.raw. There is no NOT operator (use ne/ncont/"
+                        "nlike/nregex)."
+                    ),
+                },
+                ensure_ascii=False,
+            )
         return _err("list_requests", exc)
 
 
@@ -440,6 +456,24 @@ async def list_sitemap(
     client = _ctx_client(ctx)
     if client is None:
         return _no_client()
+    # Caido sitemap/scope IDs are i32 integers, not URLs/hosts/UUIDs. Reject
+    # non-numeric ids up front with actionable guidance so the model corrects
+    # itself instead of repeating an opaque "Invalid ID format" GraphQL error.
+    for _arg_name, _arg_val in (("parent_id", parent_id), ("scope_id", scope_id)):
+        if _arg_val is not None and not str(_arg_val).strip().lstrip("-").isdigit():
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        f"Invalid {_arg_name}: {_arg_val!r}. {_arg_name} must be a "
+                        "numeric Caido entry id (i32) taken from a prior list_sitemap "
+                        "response's `id` field — not a URL, host, or UUID. Call "
+                        "list_sitemap with no parent_id first to get root entries, then "
+                        "pass an entry's numeric `id`."
+                    ),
+                },
+                ensure_ascii=False,
+            )
     try:
         payload = await caido_api.list_sitemap_with_client(
             client,


### PR DESCRIPTION
## Problem
When the agent passes a malformed argument to the Caido proxy tools, it gets back an opaque GraphQL error that references the **query document**, not its own input — so it can't self-correct and repeats the same failing call. This is especially common with reasoning models served over an OpenAI-compatible endpoint (observed with Kimi-K2.7-Code on Cloudflare Workers AI driving Strix 1.0.4): the proxy tools were the only repeated failures across a 72-turn run.

Two cases:
- **`list_requests`** with an invalid `httpql_filter` → the agent sees only `"Invalid HTTPQL query (line 34, column 3)"` (the GraphQL doc line), with no hint about its filter.
- **`list_sitemap`** with a non-i32 `parent_id`/`scope_id` (the model passes a URL/host/UUID) → `"Invalid ID format, should be an i32"` with no guidance.

## Fix
Return **actionable, self-correcting** errors from `strix/tools/proxy/tools.py`:
- `list_requests`: on an HTTPQL parse error, name the offending filter and explain the fix (omit it to list all, or valid HTTPQL examples; note there's no `NOT` operator).
- `list_sitemap`: validate `parent_id`/`scope_id` are numeric i32 ids up front, and tell the agent to use a numeric `id` from a prior `list_sitemap` response.

Both stay non-fatal so the agent recovers on the next turn. No behavior change for well-formed args.

## Testing
Re-ran a full Strix 1.0.4 scan with the patch: the previously-recurring `list_requests`/`list_sitemap` errors dropped to **zero** across 72 turns, and the agent completed recon + spawned specialist agents cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)