### PR TITLE
Remove collection of unhandled exception error messages from telemetry

### DIFF
--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -822,8 +822,8 @@ def main() -> None:
         exit_reason = "interrupted"
     except Exception as e:
         exit_reason = "error"
-        posthog.error("unhandled_exception", str(e))
-        scarf.error("unhandled_exception", str(e))
+        posthog.error("unhandled_exception")
+        scarf.error("unhandled_exception")
         raise
     finally:
         report_state = get_global_report_state()

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -820,7 +820,7 @@ def main() -> None:
             asyncio.run(run_tui(args))
     except KeyboardInterrupt:
         exit_reason = "interrupted"
-    except Exception as e:
+    except Exception:
         exit_reason = "error"
         posthog.error("unhandled_exception")
         scarf.error("unhandled_exception")

--- a/strix/telemetry/posthog.py
+++ b/strix/telemetry/posthog.py
@@ -123,8 +123,6 @@ def end(report_state: "ReportState", exit_reason: str = "completed") -> None:
     )
 
 
-def error(error_type: str, error_msg: str | None = None) -> None:
+def error(error_type: str) -> None:
     props = {**base_props(), "error_type": error_type}
-    if error_msg:
-        props["error_msg"] = error_msg
     _send("error", props)

--- a/strix/telemetry/scarf.py
+++ b/strix/telemetry/scarf.py
@@ -129,12 +129,10 @@ def end(report_state: ReportState, exit_reason: str = "completed") -> None:
     )
 
 
-def error(error_type: str, error_msg: str | None = None) -> None:
+def error(error_type: str) -> None:
     props: dict[str, Any] = {
         **base_props(),
         "session": SESSION_ID,
         "error_type": error_type,
     }
-    if error_msg:
-        props["error_msg"] = error_msg
     _send("error", props)


### PR DESCRIPTION
This PR addresses issue https://github.com/usestrix/strix/issues/584

The telemetry collection policy states that error messages are not collected, this PR modifies the code to align it with the telemetry policy.