### PR TITLE
fix(core): return True when image-strip retry succeeds in strip_all_images_from_session

### DIFF
--- a/strix/core/sessions.py
+++ b/strix/core/sessions.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 from typing import TYPE_CHECKING, Any, cast
 
 from agents.memory import SQLiteSession
@@ -58,8 +57,6 @@ async def strip_all_images_from_session(session: Session) -> bool:
     await session.clear_session()
     try:
         await session.add_items(rebuilt_items)
-    except Exception:
-        with contextlib.suppress(Exception):
-            await session.add_items(rebuilt_items)
-        raise
+    except Exception:  # noqa: BLE001
+        await session.add_items(rebuilt_items)
     return True

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,68 @@
+"""Tests for SDK session helpers in strix/core/sessions.py."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from strix.core.sessions import strip_all_images_from_session
+
+
+class _FakeSession:
+    """Minimal Session stub whose add_items can be scripted to fail then succeed."""
+
+    def __init__(self, items: list[Any], add_items_errors: list[Exception | None]) -> None:
+        self._items = items
+        self._add_items_errors = add_items_errors
+        self.add_items_calls = 0
+        self.cleared = False
+        self.added_items: list[Any] | None = None
+
+    async def get_items(self) -> list[Any]:
+        return self._items
+
+    async def clear_session(self) -> None:
+        self.cleared = True
+
+    async def add_items(self, items: list[Any]) -> None:
+        index = self.add_items_calls
+        self.add_items_calls += 1
+        error = self._add_items_errors[index] if index < len(self._add_items_errors) else None
+        if error is not None:
+            raise error
+        self.added_items = items
+
+
+def _image_item() -> dict[str, Any]:
+    return {
+        "type": "function_call_output",
+        "call_id": "call-1",
+        "output": [{"type": "input_image", "image_url": "data:image/png;base64,abc"}],
+    }
+
+
+async def test_retry_success_returns_true() -> None:
+    session = _FakeSession(
+        items=[_image_item()],
+        add_items_errors=[RuntimeError("first attempt failed"), None],
+    )
+
+    result = await strip_all_images_from_session(session)  # type: ignore[arg-type]
+
+    assert result is True
+    assert session.add_items_calls == 2
+    assert session.added_items is not None
+
+
+async def test_retry_double_failure_propagates_second_error() -> None:
+    second_error = ValueError("second attempt failed")
+    session = _FakeSession(
+        items=[_image_item()],
+        add_items_errors=[RuntimeError("first attempt failed"), second_error],
+    )
+
+    with pytest.raises(ValueError, match="second attempt failed"):
+        await strip_all_images_from_session(session)  # type: ignore[arg-type]
+
+    assert session.add_items_calls == 2


### PR DESCRIPTION
## What & why

`strip_all_images_from_session` is the recovery path invoked by `_run_cycle` (strix/core/execution.py) when the model rejects image input (HTTP 400/404/422): it rebuilds the session with images swapped for placeholders and re-adds the items. The retry block re-added the items inside `contextlib.suppress(Exception)` and then unconditionally `raise`d, which produced two bad outcomes:

- A **successful** retry still raised the original error, so the caller logged "image-strip recovery failed", set `stripped = False`, and threw away a session that had actually been rebuilt correctly — the scan never retried.
- A **double** failure swallowed the genuine second error (the real reason the re-add failed) and re-raised the stale first one.

This change drops the suppress/raise dance: the first attempt runs, and on failure a single retry runs outside any suppression. A successful retry now falls through to `return True` so recovery proceeds; a failed retry propagates the genuine second exception. Behaviour on the first-attempt-success path is unchanged.

## Testing

- `pytest tests/test_sessions.py` — 2 passed. The new tests script a session whose `add_items` fails once then succeeds (asserts `True` is returned and `add_items` was called twice) and one that fails twice (asserts the second exception propagates). Both tests fail against the current `main` implementation and pass with this change.
- `ruff check` / `ruff format --check` — clean (the repo enables the `UP`/pyupgrade and `S`/bandit rule sets; the intentional broad-`except` retry carries a scoped `# noqa: BLE001`).
- `bandit` — no findings; `pyupgrade --py310-plus` — no changes.
- mypy is not asserted: the repo's pinned pre-commit mypy hook crashes with an internal error on the bundled openai SDK on `main` as well, so this PR makes no mypy claim.