### PR TITLE
fix(interface): correct copy-diff classification and workspace-subdir collision

### DIFF
--- a/strix/interface/utils.py
+++ b/strix/interface/utils.py
@@ -1163,6 +1163,7 @@ def derive_local_base_name(path_str: str) -> str:
 
 def assign_workspace_subdirs(targets_info: list[dict[str, Any]]) -> None:
     name_counts: dict[str, int] = {}
+    allocated_subdirs: set[str] = set()
 
     for target in targets_info:
         target_type = target["type"]
@@ -1182,15 +1183,17 @@ def assign_workspace_subdirs(targets_info: list[dict[str, Any]]) -> None:
 
         # Avoid colliding with a subdir already allocated to another target
         # (e.g. base names ["api-2", "api", "api"] would otherwise both map to "api-2").
+        # Track allocated subdirs separately from base-name counts so a derived
+        # suffix never poisons the count of a later target sharing that name.
         max_attempts = len(targets_info) + 1
         attempts = 0
-        while workspace_subdir in name_counts and attempts < max_attempts:
+        while workspace_subdir in allocated_subdirs and attempts < max_attempts:
             count += 1
             workspace_subdir = f"{base_name}-{count}"
             attempts += 1
 
         name_counts[base_name] = count
-        name_counts[workspace_subdir] = count
+        allocated_subdirs.add(workspace_subdir)
 
         details["workspace_subdir"] = workspace_subdir
 

--- a/strix/interface/utils.py
+++ b/strix/interface/utils.py
@@ -746,6 +746,7 @@ def _classify_diff_entries(entries: list[DiffEntry]) -> dict[str, Any]:
     analyzable_files: list[str] = []
     analyzable_seen: set[str] = set()
     modified_seen: set[str] = set()
+    added_seen: set[str] = set()
 
     for entry in entries:
         path = entry.path
@@ -757,7 +758,7 @@ def _classify_diff_entries(entries: list[DiffEntry]) -> dict[str, Any]:
             continue
 
         if entry.status == "A":
-            added_files.append(path)
+            _append_unique(added_files, added_seen, path)
             _append_unique(analyzable_files, analyzable_seen, path)
             continue
 
@@ -780,7 +781,7 @@ def _classify_diff_entries(entries: list[DiffEntry]) -> dict[str, Any]:
             continue
 
         if entry.status == "C":
-            _append_unique(modified_files, modified_seen, path)
+            _append_unique(added_files, added_seen, path)
             _append_unique(analyzable_files, analyzable_seen, path)
             continue
 
@@ -1177,9 +1178,19 @@ def assign_workspace_subdirs(targets_info: list[dict[str, Any]]) -> None:
             continue
 
         count = name_counts.get(base_name, 0) + 1
-        name_counts[base_name] = count
-
         workspace_subdir = base_name if count == 1 else f"{base_name}-{count}"
+
+        # Avoid colliding with a subdir already allocated to another target
+        # (e.g. base names ["api-2", "api", "api"] would otherwise both map to "api-2").
+        max_attempts = len(targets_info) + 1
+        attempts = 0
+        while workspace_subdir in name_counts and attempts < max_attempts:
+            count += 1
+            workspace_subdir = f"{base_name}-{count}"
+            attempts += 1
+
+        name_counts[base_name] = count
+        name_counts[workspace_subdir] = count
 
         details["workspace_subdir"] = workspace_subdir
 

--- a/tests/test_diff_workspace_utils.py
+++ b/tests/test_diff_workspace_utils.py
@@ -33,6 +33,25 @@ def test_assign_workspace_subdirs_avoids_suffix_collision() -> None:
     assert subdirs[2] not in {"api-2", "api"}
 
 
+def test_assign_workspace_subdirs_suffix_does_not_poison_later_base() -> None:
+    # Base names ["api", "api", "api-2"]: the second "api" target allocates the
+    # subdir "api-2"; the later real "api-2" target must still get a unique,
+    # non-colliding subdir without the earlier allocation poisoning its counter.
+    targets = [
+        _local_target("/srv/api"),
+        _local_target("/other/api"),
+        _local_target("/srv/api-2"),
+    ]
+
+    assign_workspace_subdirs(targets)
+
+    subdirs = [t["details"]["workspace_subdir"] for t in targets]
+    assert len(set(subdirs)) == 3
+    assert subdirs[0] == "api"
+    assert subdirs[1] == "api-2"
+    assert subdirs[2].startswith("api-2")
+
+
 def test_classify_diff_entries_copy_is_added_not_modified() -> None:
     result = _classify_diff_entries(
         [DiffEntry(status="C", path="new.py", old_path="orig.py", similarity=100)]

--- a/tests/test_diff_workspace_utils.py
+++ b/tests/test_diff_workspace_utils.py
@@ -1,0 +1,43 @@
+"""Tests for diff classification and workspace-subdir assignment in interface.utils."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from strix.interface.utils import (
+    DiffEntry,
+    _classify_diff_entries,
+    assign_workspace_subdirs,
+)
+
+
+def _local_target(path: str) -> dict[str, Any]:
+    return {"type": "local_code", "details": {"target_path": path}}
+
+
+def test_assign_workspace_subdirs_avoids_suffix_collision() -> None:
+    # Base names derive to ["api-2", "api", "api"]; the third target's naive
+    # suffix "api-2" would collide with the first, silently dropping a repo.
+    targets = [
+        _local_target("/srv/api-2"),
+        _local_target("/srv/api"),
+        _local_target("/other/api"),
+    ]
+
+    assign_workspace_subdirs(targets)
+
+    subdirs = [t["details"]["workspace_subdir"] for t in targets]
+    assert len(set(subdirs)) == 3
+    assert subdirs[0] == "api-2"
+    assert subdirs[1] == "api"
+    assert subdirs[2] not in {"api-2", "api"}
+
+
+def test_classify_diff_entries_copy_is_added_not_modified() -> None:
+    result = _classify_diff_entries(
+        [DiffEntry(status="C", path="new.py", old_path="orig.py", similarity=100)]
+    )
+
+    assert "new.py" in result["added_files"]
+    assert "new.py" not in result["modified_files"]
+    assert "new.py" in result["analyzable_files"]


### PR DESCRIPTION
## What & why

Two small, independent correctness fixes in `strix/interface/utils.py`, both in the multi-repo / diff-scope path:

1. **Copy entries misclassified as modified.** `_classify_diff_entries` routed `status == "C"` (git copy, e.g. C100) entries to `modified_files`. A copied file is new at its destination path, so — like the `A` branch — it should be reported under `added_files`. The previous behavior gave the agent wrong "focus on the changes" guidance for copied files. Fixed by appending copies to `added_files` (via a parallel `added_seen` set, matching the existing `_append_unique` dedupe pattern used elsewhere).

2. **Workspace-subdir suffix collision silently drops a repo.** `assign_workspace_subdirs` allocated `f"{base}-{count}"` without checking the candidate wasn't already used as another target's base name. Base names `["api-2", "api", "api"]` therefore mapped the first and third targets to the same `api-2`, and `build_session_entries` silently collapses targets that share a `workspace_subdir`. Fixed with a bounded loop that increments the suffix until the subdir is unique (bound `len(targets)+1`, so no unbounded loop), recording both the base and the chosen suffix in `name_counts`.

Both changes are local, additive, and introduce no new input/shell/path surface.

## Testing

New `tests/test_diff_workspace_utils.py` (pure, offline — no keys/Docker/network):
- `test_assign_workspace_subdirs_avoids_suffix_collision` — 3 targets deriving `["api-2","api","api"]` now yield 3 distinct subdirs.
- `test_classify_diff_entries_copy_is_added_not_modified` — a `status="C"` entry lands in `added_files` (and `analyzable_files`), not `modified_files`.

- `pytest tests/test_diff_workspace_utils.py` → 2 passed; both tests fail when `utils.py` is reverted to current `main`, confirming they're meaningful.
- `pytest tests/` → 40 passed, no regressions.
- `ruff check` (incl. pyupgrade UP rules) and `bandit` clean on the changed file; `mypy` reports no errors on `strix/interface/utils.py` or the new test.

Note: the repo's pinned pre-commit `mypy` hook errors out on the bundled `openai` SDK on `main` as well, so I'm not claiming a green hook run — but `mypy` over the changed files specifically is clean.