### PR TITLE
fix: stop gracefully with resume hint on persistent RateLimitError (#261)

### DIFF
--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -312,9 +312,10 @@ async def run_strix_scan(
     except RateLimitError as exc:
         logger.warning(
             "Scan %s stopped: persistent rate limit from the LLM provider (%s). "
-            "Resume with 'strix --resume <run_name>' once the limit clears.",
+            "Resume with 'strix --resume %s' once the limit clears.",
             scan_id,
             exc,
+            scan_id,
         )
         if root_id is not None:
             await coordinator.cancel_descendants(root_id)

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from agents import RunConfig
 from agents.sandbox import SandboxRunConfig
+from openai import RateLimitError
 
 from strix.agents.factory import build_strix_agent, make_child_factory
 from strix.config import load_settings
@@ -303,6 +304,18 @@ async def run_strix_scan(
         return result  # noqa: TRY300
     except BudgetExceededError as exc:
         logger.info("Scan %s stopped: %s", scan_id, exc)
+        if root_id is not None:
+            await coordinator.cancel_descendants(root_id)
+            with contextlib.suppress(Exception):
+                await coordinator.set_status(root_id, "stopped")
+        return None
+    except RateLimitError as exc:
+        logger.warning(
+            "Scan %s stopped: persistent rate limit from the LLM provider (%s). "
+            "Resume with 'strix --resume <run_name>' once the limit clears.",
+            scan_id,
+            exc,
+        )
         if root_id is not None:
             await coordinator.cancel_descendants(root_id)
             with contextlib.suppress(Exception):

--- a/tests/test_runner_rate_limit.py
+++ b/tests/test_runner_rate_limit.py
@@ -1,0 +1,79 @@
+"""Tests for graceful handling of persistent RateLimitError in run_strix_scan."""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import httpx
+import pytest
+from openai import RateLimitError
+
+import strix.tools.notes.tools as notes_tools
+import strix.tools.todo.tools as todo_tools
+from strix.core import runner
+from strix.core.agents import AgentCoordinator
+
+
+def _make_rate_limit_error() -> RateLimitError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/responses")
+    response = httpx.Response(status_code=429, request=request)
+    return RateLimitError("rate limited", response=response, body=None)
+
+
+@pytest.mark.asyncio
+async def test_persistent_rate_limit_stops_gracefully(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """A persistent RateLimitError stops the scan (root -> 'stopped') without raising."""
+    monkeypatch.setattr(runner, "run_dir_for", lambda _scan_id: tmp_path)
+    monkeypatch.setattr(runner, "runtime_state_dir", lambda _run_dir: tmp_path)
+    monkeypatch.setattr(runner, "setup_scan_logging", lambda _run_dir: lambda: None)
+    monkeypatch.setattr(runner, "set_scan_id", lambda _scan_id: None)
+
+    settings = types.SimpleNamespace(
+        llm=types.SimpleNamespace(model="openai/gpt-4o", reasoning_effort="high")
+    )
+    monkeypatch.setattr(runner, "load_settings", lambda: settings)
+    monkeypatch.setattr(runner, "configure_sdk_model_defaults", lambda _settings: None)
+    monkeypatch.setattr(
+        runner, "uses_chat_completions_tool_schema", lambda _model, _settings: False
+    )
+
+    monkeypatch.setattr(todo_tools, "hydrate_todos_from_disk", lambda _state_dir: None)
+    monkeypatch.setattr(notes_tools, "hydrate_notes_from_disk", lambda _state_dir: None)
+
+    async def _create_or_reuse(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"client": object(), "session": object(), "caido_client": None}
+
+    async def _cleanup(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(runner.session_manager, "create_or_reuse", _create_or_reuse)
+    monkeypatch.setattr(runner.session_manager, "cleanup", _cleanup)
+
+    monkeypatch.setattr(runner, "build_root_task", lambda _scan_config: "task")
+    monkeypatch.setattr(runner, "build_scope_context", lambda _scan_config: "")
+    monkeypatch.setattr(runner, "make_model_settings", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(runner, "build_strix_agent", lambda **_kwargs: object())
+    monkeypatch.setattr(runner, "make_child_factory", lambda **_kwargs: lambda **_k: object())
+    monkeypatch.setattr(runner, "open_agent_session", lambda _root_id, _db: object())
+
+    async def _raise_rate_limit(*_args: Any, **_kwargs: Any) -> None:
+        raise _make_rate_limit_error()
+
+    monkeypatch.setattr(runner, "run_agent_loop", _raise_rate_limit)
+
+    coordinator = AgentCoordinator()
+
+    result = await runner.run_strix_scan(
+        scan_config={"targets": [], "scan_mode": "deep"},
+        scan_id="scan-test",
+        image="img",
+        coordinator=coordinator,
+    )
+
+    assert result is None
+    root_ids = [aid for aid, parent in coordinator.parent_of.items() if parent is None]
+    assert len(root_ids) == 1
+    assert coordinator.statuses[root_ids[0]] == "stopped"

--- a/tests/test_runner_rate_limit.py
+++ b/tests/test_runner_rate_limit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import types
 from typing import Any
 
@@ -23,7 +24,7 @@ def _make_rate_limit_error() -> RateLimitError:
 
 @pytest.mark.asyncio
 async def test_persistent_rate_limit_stops_gracefully(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A persistent RateLimitError stops the scan (root -> 'stopped') without raising."""
     monkeypatch.setattr(runner, "run_dir_for", lambda _scan_id: tmp_path)
@@ -66,14 +67,18 @@ async def test_persistent_rate_limit_stops_gracefully(
 
     coordinator = AgentCoordinator()
 
-    result = await runner.run_strix_scan(
-        scan_config={"targets": [], "scan_mode": "deep"},
-        scan_id="scan-test",
-        image="img",
-        coordinator=coordinator,
-    )
+    with caplog.at_level(logging.WARNING):
+        result = await runner.run_strix_scan(
+            scan_config={"targets": [], "scan_mode": "deep"},
+            scan_id="scan-test",
+            image="img",
+            coordinator=coordinator,
+        )
 
     assert result is None
     root_ids = [aid for aid, parent in coordinator.parent_of.items() if parent is None]
     assert len(root_ids) == 1
     assert coordinator.statuses[root_ids[0]] == "stopped"
+    # the resume hint must carry the real scan id, not a literal placeholder
+    assert "strix --resume scan-test" in caplog.text
+    assert "<run_name>" not in caplog.text


### PR DESCRIPTION
Fixes #261

When the LLM provider returns a persistent `429` after the SDK's built-in retries are exhausted, `openai.RateLimitError` propagates out of `run_strix_scan` through the catch-all `except BaseException: raise`, which marks the root agent `failed`, re-raises, and surfaces a raw traceback while skipping `display_completion_message()` — so the user never sees the `strix --resume <run_name>` hint and loses the run. This adds a dedicated `except RateLimitError` clause between the existing `BudgetExceededError` and `BaseException` handlers in `strix/core/runner.py`, mirroring the budget-exceeded path verbatim: it logs a warning, cancels descendant agents, sets the root status to `stopped`, and returns `None`. Returning `None` (instead of raising) lets the caller fall through to the normal completion path, which prints the resume hint. It fires only for genuinely persistent limits, since litellm/the SDK already retry 429s with backoff before the error escapes.

## Testing
- `pytest tests/test_runner_rate_limit.py` → 1 passed. The test patches `run_agent_loop` to raise a real `openai.RateLimitError` (built from an httpx 429 response) plus the surrounding scan setup, then asserts `run_strix_scan` returns `None`, raises nothing, and leaves the root agent status `stopped`. Verified meaningful by reverting `runner.py` to `origin/main` in-tree: the test fails (the error propagates and the root is logged `failed`), and passes again with the fix restored.
- `ruff check` and `pyupgrade` (ruff `UP` ruleset) clean on both changed files; `bandit` clean apart from the expected `B101` assert-usage notes in the test file.
- mypy is not asserted here: the repo's pinned pre-commit mypy hook crashes with an internal error on the bundled openai SDK on `main` as well, so this PR makes no mypy claim.