### PR TITLE
fix: declare socksio and guard tracing init against SOCKS-proxy ImportError (#478)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "docker>=7.1.0",
   "textual>=6.0.0",
   "requests>=2.32.0",
+  "socksio>=1.0.0",
   "cvss>=3.2",
   "caido-sdk-client>=0.2.0",
 ]
@@ -105,6 +106,7 @@ module = [
     "docker.*",
     "caido_sdk_client.*",
     "pydantic_settings.*",
+    "socksio.*",
 ]
 ignore_missing_imports = true
 disable_error_code = ["import-untyped"]

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING
 
@@ -18,6 +19,9 @@ if TYPE_CHECKING:
     from agents.models.interface import ModelProvider
 
     from strix.config.settings import Settings
+
+
+logger = logging.getLogger(__name__)
 
 
 class StrixProvider(MultiProvider):
@@ -63,7 +67,13 @@ DEFAULT_MODEL_RETRY = ModelRetrySettings(
 def configure_sdk_model_defaults(settings: Settings) -> None:
     """Apply Strix config to SDK-native defaults."""
     llm = settings.llm
-    set_tracing_disabled(True)
+    try:
+        set_tracing_disabled(True)
+    except ImportError as exc:
+        # Disabling tracing eagerly initializes an httpx client that may need an
+        # optional transport (e.g. socksio for SOCKS proxies). Tracing is already
+        # being turned off, so a failure here is non-fatal — log and continue.
+        logger.warning("Could not disable SDK tracing: %s", exc)
     _configure_litellm_compatibility()
     if llm.api_key:
         set_default_openai_key(llm.api_key, use_for_tracing=False)

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -71,9 +71,15 @@ def configure_sdk_model_defaults(settings: Settings) -> None:
         set_tracing_disabled(True)
     except ImportError as exc:
         # Disabling tracing eagerly initializes an httpx client that may need an
-        # optional transport (e.g. socksio for SOCKS proxies). Tracing is already
-        # being turned off, so a failure here is non-fatal — log and continue.
-        logger.warning("Could not disable SDK tracing: %s", exc)
+        # optional transport (e.g. socksio for SOCKS proxies). A failure here is
+        # non-fatal for startup, but tracing then stays at the SDK default
+        # (enabled), so make the consequence explicit rather than silent.
+        logger.warning(
+            "Could not disable SDK tracing (%s); tracing may remain enabled and "
+            "spans could be sent to the provider. Install the missing transport "
+            "(e.g. 'socksio') to resolve.",
+            exc,
+        )
     _configure_litellm_compatibility()
     if llm.api_key:
         set_default_openai_key(llm.api_key, use_for_tracing=False)

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,0 +1,43 @@
+"""Tests for SDK model configuration, including SOCKS-proxy startup resilience."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import socksio
+
+from strix.config import models
+
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _make_settings() -> SimpleNamespace:
+    """Build a minimal settings stub with no API key / base configured."""
+    llm = SimpleNamespace(api_key=None, api_base=None, model=None)
+    return SimpleNamespace(llm=llm)
+
+
+def test_socksio_importable() -> None:
+    """socksio must be declared so httpx can build a SOCKS transport at startup."""
+    assert socksio is not None
+
+
+def test_configure_tolerates_tracing_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing SOCKS transport during tracing init must not crash startup.
+
+    With a SOCKS proxy env var set, ``set_tracing_disabled`` eagerly builds an
+    httpx client that can raise ImportError. That failure is non-fatal and must
+    be swallowed so the rest of the SDK configuration still runs.
+    """
+
+    def _raise(_disabled: bool) -> None:
+        raise ImportError("Using SOCKS proxy, but the 'socksio' package is not installed")
+
+    monkeypatch.setattr(models, "set_tracing_disabled", _raise)
+    monkeypatch.setattr(models, "_configure_litellm_compatibility", lambda: None)
+
+    # Should not raise despite set_tracing_disabled blowing up.
+    models.configure_sdk_model_defaults(_make_settings())

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -38,6 +38,9 @@ def test_configure_tolerates_tracing_import_error(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setattr(models, "set_tracing_disabled", _raise)
     monkeypatch.setattr(models, "_configure_litellm_compatibility", lambda: None)
+    # With api_base=None the function reaches the real set_default_openai_api;
+    # stub it so the test stays isolated from SDK-side effects.
+    monkeypatch.setattr(models, "set_default_openai_api", lambda _mode: None)
 
     # Should not raise despite set_tracing_disabled blowing up.
     models.configure_sdk_model_defaults(_make_settings())

--- a/uv.lock
+++ b/uv.lock
@@ -2046,6 +2046,15 @@ wheels = [
 ]
 
 [[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2093,6 +2102,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "requests" },
     { name = "rich" },
+    { name = "socksio" },
     { name = "textual" },
 ]
 
@@ -2118,6 +2128,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.13.0" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "rich" },
+    { name = "socksio", specifier = ">=1.0.0" },
     { name = "textual", specifier = ">=6.0.0" },
 ]
 


### PR DESCRIPTION
Fixes #478

When a SOCKS proxy is configured through the standard `HTTPS_PROXY` / `ALL_PROXY=socks5://...` environment variables, Strix crashes at startup with `ImportError: Using SOCKS proxy, but the 'socksio' package is not installed`. The crash originates in `configure_sdk_model_defaults`: the first call to `set_tracing_disabled(True)` lazily initializes the openai-agents trace provider, which constructs an `httpx.Client()`; httpx then tries to build a SOCKS transport and requires `socksio`, which was never declared as a dependency. This PR declares `socksio>=1.0.0` so the transport can always be built, and additionally wraps the `set_tracing_disabled(True)` call in a narrow `try/except ImportError` (disabling tracing is non-fatal) as defense-in-depth, so an optional-transport failure can never take down startup.

## Testing
- `pytest tests/test_model_config.py` — 2 passed; reverting the guard (restoring `models.py` to `main`) makes the import-error test fail because the ImportError propagates, confirming the test is meaningful. Full suite: 40 passed.
- Reproduced the original crash directly: with `ALL_PROXY=socks5://...` set and `socksio` unavailable, `set_tracing_disabled(True)` raises the exact `Using SOCKS proxy, but the 'socksio' package is not installed` ImportError; with `socksio` installed it no longer raises.
- `ruff check`, `bandit`, and `pyupgrade --py312-plus` are clean on the changed files. (Note: the repo's pinned pre-commit mypy hook crashes with an internal error on the bundled openai SDK on `main` as well, unrelated to this change; file-scoped `mypy strix/config/models.py` reports no issues.)