### PR TITLE
fix(interface): drop dead reasoning-effort branches, fix stale model name and STRIX_IMAGE casing

### DIFF
--- a/strix/interface/cli.py
+++ b/strix/interface/cli.py
@@ -30,7 +30,8 @@ def _resolve_sandbox_image() -> str:
     image = load_settings().runtime.image
     if not image:
         raise RuntimeError(
-            "strix_image is not configured. Set it in ~/.strix/cli-config.json.",
+            "STRIX_IMAGE is not configured. Set it via export STRIX_IMAGE=<image> "
+            "or in ~/.strix/cli-config.json.",
         )
     return image
 

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -105,7 +105,7 @@ def validate_environment() -> None:
                 error_text.append("STRIX_LLM", style="bold cyan")
                 error_text.append(
                     " - Model name to use (e.g., 'openai/gpt-5.4' or "
-                    "'anthropic/claude-opus-4-7')\n",
+                    "'anthropic/claude-sonnet-4-6')\n",
                     style="white",
                 )
 
@@ -134,14 +134,6 @@ def validate_environment() -> None:
                         " - API key for Perplexity AI web search (enables real-time research)\n",
                         style="white",
                     )
-                elif var == "STRIX_REASONING_EFFORT":
-                    error_text.append("• ", style="white")
-                    error_text.append("STRIX_REASONING_EFFORT", style="bold cyan")
-                    error_text.append(
-                        " - Reasoning effort level: none, minimal, low, medium, high, xhigh "
-                        "(default: high)\n",
-                        style="white",
-                    )
 
         error_text.append("\nExample setup:\n", style="white")
         error_text.append("export STRIX_LLM='openai/gpt-5.4'\n", style="dim white")
@@ -163,11 +155,6 @@ def validate_environment() -> None:
                 elif var == "PERPLEXITY_API_KEY":
                     error_text.append(
                         "export PERPLEXITY_API_KEY='your-perplexity-key-here'\n", style="dim white"
-                    )
-                elif var == "STRIX_REASONING_EFFORT":
-                    error_text.append(
-                        "export STRIX_REASONING_EFFORT='high'\n",
-                        style="dim white",
                     )
 
         panel = Panel(
@@ -240,7 +227,7 @@ async def warm_up_llm() -> None:
             )
             warn_text.append("<provider>/<model>", style="bold cyan")
             warn_text.append(
-                "' form, e.g. 'anthropic/claude-opus-4-7', 'deepseek/deepseek-v4-pro'.",
+                "' form, e.g. 'anthropic/claude-sonnet-4-6', 'deepseek/deepseek-v4-pro'.",
                 style="white",
             )
             console.print(
@@ -310,6 +297,7 @@ def _positive_budget(value: str) -> float:
     except ValueError as exc:
         raise argparse.ArgumentTypeError(f"invalid float value: {value!r}") from exc
     import math
+
     if not math.isfinite(budget) or budget <= 0:
         raise argparse.ArgumentTypeError("must be a finite number greater than 0")
     return budget

--- a/tests/test_interface_messages.py
+++ b/tests/test_interface_messages.py
@@ -1,0 +1,33 @@
+"""Tests for interface message cleanups.
+
+Covers three cosmetic-correctness fixes:
+    * dead ``STRIX_REASONING_EFFORT`` branches removed from ``validate_environment``;
+    * stale ``claude-opus-4-7`` model name replaced with ``claude-sonnet-4-6``;
+    * ``_resolve_sandbox_image`` reports the env var with correct ``STRIX_IMAGE`` casing.
+"""
+
+import inspect
+import types
+
+import pytest
+
+from strix.interface import cli
+from strix.interface.main import validate_environment, warm_up_llm
+
+
+def test_reasoning_effort_branches_removed() -> None:
+    source = inspect.getsource(validate_environment)
+    assert "STRIX_REASONING_EFFORT" not in source
+
+
+def test_model_name_uses_sonnet_recommendation() -> None:
+    source = inspect.getsource(validate_environment) + inspect.getsource(warm_up_llm)
+    assert "claude-opus-4-7" not in source
+    assert "claude-sonnet-4-6" in source
+
+
+def test_resolve_sandbox_image_uses_correct_env_casing(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_settings = types.SimpleNamespace(runtime=types.SimpleNamespace(image=""))
+    monkeypatch.setattr(cli, "load_settings", lambda: fake_settings)
+    with pytest.raises(RuntimeError, match="STRIX_IMAGE"):
+        cli._resolve_sandbox_image()


### PR DESCRIPTION
Three small interface-message correctness fixes in `strix/interface/`:

- `validate_environment()` carried two `elif var == "STRIX_REASONING_EFFORT"` branches, but only `LLM_API_KEY`, `LLM_API_BASE`, and `PERPLEXITY_API_KEY` are ever appended to `missing_optional_vars`, so both branches were unreachable dead code — removed.
- The `STRIX_LLM` help text and the warm-up warning recommended `anthropic/claude-opus-4-7`, a model that appears nowhere in the README or docs; switched to `anthropic/claude-sonnet-4-6`, the canonical recommendation used throughout `README.md` and `docs/`.
- `_resolve_sandbox_image()` reported the missing setting as lowercase `strix_image`, while the actual env var / Pydantic alias is `STRIX_IMAGE`; corrected the casing and now points users at both `export STRIX_IMAGE=<image>` and `~/.strix/cli-config.json`.

## Testing
- `pytest tests/test_interface_messages.py` — 3 passed. Each test asserts one of the fixes; all three fail against current `main` (verified by reverting the source in-tree), so they are meaningful regression guards.
- `ruff check` (including pyupgrade `UP` rules) and `bandit` are clean on the changed files.
- Note: the repo's pinned pre-commit `mypy` hook crashes with an internal error on the bundled `openai` SDK on `main` as well, so it was not used as a gate here.