### PR TITLE
test: cover report helpers _parse_dedupe_response and litellm routing predicates

### DIFF
--- a/tests/test_dedupe_parsing.py
+++ b/tests/test_dedupe_parsing.py
@@ -1,0 +1,65 @@
+"""Unit tests for :func:`strix.report.dedupe._parse_dedupe_response`."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from strix.report.dedupe import _parse_dedupe_response
+
+
+def test_plain_json_round_trip() -> None:
+    content = json.dumps(
+        {
+            "is_duplicate": True,
+            "duplicate_id": "vuln-1",
+            "confidence": 0.75,
+            "reason": "same endpoint",
+        }
+    )
+
+    result = _parse_dedupe_response(content)
+
+    assert result == {
+        "is_duplicate": True,
+        "duplicate_id": "vuln-1",
+        "confidence": 0.75,
+        "reason": "same endpoint",
+    }
+
+
+def test_json_fenced_block_is_unwrapped() -> None:
+    payload = {"is_duplicate": False, "duplicate_id": "", "confidence": 0.1, "reason": "n/a"}
+    content = f"```json\n{json.dumps(payload)}\n```"
+
+    result = _parse_dedupe_response(content)
+
+    assert result["is_duplicate"] is False
+    assert result["confidence"] == 0.1
+    assert result["reason"] == "n/a"
+
+
+def test_no_json_object_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="No JSON object found"):
+        _parse_dedupe_response("there is no json here")
+
+
+def test_duplicate_id_truncated_to_64_chars() -> None:
+    long_id = "a" * 200
+    content = json.dumps({"is_duplicate": True, "duplicate_id": long_id, "confidence": 1.0})
+
+    result = _parse_dedupe_response(content)
+
+    assert result["duplicate_id"] == "a" * 64
+    assert len(result["duplicate_id"]) == 64
+
+
+def test_non_numeric_or_null_confidence_defaults_to_zero() -> None:
+    non_numeric = _parse_dedupe_response(json.dumps({"is_duplicate": False, "confidence": "high"}))
+    null_confidence = _parse_dedupe_response(
+        json.dumps({"is_duplicate": False, "confidence": None})
+    )
+
+    assert non_numeric["confidence"] == 0.0
+    assert null_confidence["confidence"] == 0.0

--- a/tests/test_usage_helpers.py
+++ b/tests/test_usage_helpers.py
@@ -1,0 +1,39 @@
+"""Unit tests for litellm routing predicates in :mod:`strix.report.usage`."""
+
+from __future__ import annotations
+
+import pytest
+
+from strix.report.usage import _is_litellm_routed, _litellm_model_name
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        ("gpt-4", "gpt-4"),
+        ("litellm/gpt-4", "gpt-4"),
+        ("any-llm/gpt-4", "gpt-4"),
+        ("openai/gpt-4", "gpt-4"),
+        ("deepseek/deepseek-chat", "deepseek/deepseek-chat"),
+    ],
+)
+def test_litellm_model_name(model: str | None, expected: str | None) -> None:
+    assert _litellm_model_name(model) == expected
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        (None, False),
+        ("gpt-4", False),
+        ("openai/gpt-4", False),
+        ("deepseek/deepseek-chat", True),
+        ("litellm/gpt-4", True),
+        ("any-llm/gpt-4", True),
+    ],
+)
+def test_is_litellm_routed(model: str | None, expected: bool) -> None:
+    assert _is_litellm_routed(model) is expected


### PR DESCRIPTION
Adds focused unit tests for three previously-uncovered pure helpers in `strix/report/`, locking in their string-parsing and routing behavior so future refactors can't silently regress them. `tests/test_dedupe_parsing.py` exercises `strix.report.dedupe._parse_dedupe_response`: plain-JSON round-trip, ```json``` fenced-block unwrapping, the `ValueError("No JSON object found")` path when no object is present, `duplicate_id` truncation to 64 chars, and the non-numeric / null `confidence` -> `0.0` fallback. `tests/test_usage_helpers.py` parametrizes `strix.report.usage._litellm_model_name` (None / "" / whitespace -> None, plain passthrough, `litellm/` `any-llm/` `openai/` prefix stripping, `deepseek/` preserved) and `_is_litellm_routed` (None / plain / `openai/` -> False; `deepseek/` `litellm/` `any-llm/` -> True). The tests are pure and offline — no network, no API keys, no Docker, and litellm is never imported (the helpers operate on strings only). These behaviors had zero direct coverage on main.

## Testing
- `pytest tests/test_dedupe_parsing.py tests/test_usage_helpers.py -v` -> 19 passed in <2s (no network / LLM / Docker).
- Verified meaningfulness by temporarily mutating the source (`[:64]` -> `[:32]` in dedupe; dropping the `openai/` special-case in usage): exactly the corresponding assertions failed, and all 19 passed again once the source was restored.
- `ruff check` clean; `bandit -c pyproject.toml` clean; `pyupgrade --py310-plus` no changes. Note: the repo's pinned pre-commit mypy hook crashes with an internal error on the bundled openai SDK on `main` as well, so mypy was not run as a gate here; these test files add no new typing surface.