### PR TITLE
Add --sub flag for Claude Code / ChatGPT Codex subscription backends

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -39,7 +39,8 @@
               "llm-providers/bedrock",
               "llm-providers/azure",
               "llm-providers/novita",
-              "llm-providers/local"
+              "llm-providers/local",
+              "llm-providers/subscription"
             ]
           },
           {

--- a/docs/llm-providers/overview.mdx
+++ b/docs/llm-providers/overview.mdx
@@ -55,6 +55,9 @@ See the [Local Models guide](/llm-providers/local) for setup instructions and re
   <Card title="Local Models" href="/llm-providers/local">
     Llama 4, Mistral, and self-hosted models.
   </Card>
+  <Card title="Subscription" href="/llm-providers/subscription">
+    Claude Code or ChatGPT Codex subscription (experimental).
+  </Card>
 </CardGroup>
 
 ## Model Format

--- a/docs/llm-providers/subscription.mdx
+++ b/docs/llm-providers/subscription.mdx
@@ -1,0 +1,19 @@
+---
+title: "Subscription (experimental)"
+description: "Run Strix on a Claude Code or ChatGPT Codex subscription instead of an API key"
+---
+
+`--sub` runs Strix on your logged-in Claude Code or ChatGPT Codex subscription instead of an API key. Strix starts a bundled local proxy and configures itself.
+
+## Setup
+
+```bash
+strix --sub claude --target https://example.com
+strix --sub codex --target https://example.com
+```
+
+Set `STRIX_LLM` to override the model (defaults: `anthropic/claude-sonnet-4-6`, `openai/gpt-5.4`).
+
+<Warning>
+This borrows your CLI's OAuth token and presents requests as the official CLI, which may conflict with the provider's terms of service. Verify before use.
+</Warning>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
   "requests>=2.32.0",
   "cvss>=3.2",
   "caido-sdk-client>=0.2.0",
+  "fastapi>=0.115",
+  "uvicorn>=0.32",
+  "httpx>=0.27",
 ]
 
 [project.scripts]
@@ -105,6 +108,7 @@ module = [
     "docker.*",
     "caido_sdk_client.*",
     "pydantic_settings.*",
+    "uvicorn.*",
 ]
 ignore_missing_imports = true
 disable_error_code = ["import-untyped"]
@@ -112,6 +116,13 @@ disable_error_code = ["import-untyped"]
 [[tool.mypy.overrides]]
 module = ["tests.*"]
 disallow_untyped_decorators = false
+
+[[tool.mypy.overrides]]
+module = [
+    "strix.subscription.claude.*",
+    "strix.subscription.codex.*",
+]
+ignore_errors = true
 
 # ============================================================================
 # Ruff Configuration (Fast Python Linter & Formatter)
@@ -128,6 +139,8 @@ extend-exclude = [
     "build",
     "dist",
     "migrations",
+    "strix/subscription/claude",
+    "strix/subscription/codex",
 ]
 
 [tool.ruff.lint]
@@ -239,6 +252,8 @@ ignore = [
 "strix/interface/tui/app.py" = ["BLE001", "PLC0415", "PLR0912", "PLR0915", "SIM105"]
 "strix/interface/main.py" = ["BLE001", "PLC0415", "PLR0912", "PLR0915"]
 "strix/interface/tui/renderers/agent_message_renderer.py" = ["PLC0415"]
+"strix/subscription/registry.py" = ["PLC0415"]
+"strix/subscription/preflight.py" = ["S603", "S607"]
 
 [tool.ruff.lint.isort]
 force-single-line = false
@@ -261,7 +276,13 @@ line-ending = "auto"
 
 [tool.pyright]
 include = ["strix"]
-exclude = ["**/__pycache__", "build", "dist"]
+exclude = [
+    "**/__pycache__",
+    "build",
+    "dist",
+    "strix/subscription/claude",
+    "strix/subscription/codex",
+]
 pythonVersion = "3.12"
 pythonPlatform = "Linux"
 
@@ -327,6 +348,6 @@ known_third_party = ["pydantic", "litellm"]
 # ============================================================================
 
 [tool.bandit]
-exclude_dirs = ["docs", "build", "dist"]
+exclude_dirs = ["docs", "build", "dist", "strix/subscription/claude", "strix/subscription/codex"]
 skips = ["B101", "B601", "B404", "B603", "B607"]  # Skip assert, shell injection, subprocess import and partial path checks
 severity = "medium"

--- a/strix/config/__init__.py
+++ b/strix/config/__init__.py
@@ -8,11 +8,13 @@ Public surface:
   ``Settings``.
 - :func:`load_settings` — memoized resolve (env > JSON file > defaults).
 - :func:`apply_config_override` — switch the JSON source to a custom path.
+- :func:`invalidate_settings_cache` — drop the memoized settings.
 - :func:`persist_current` — write currently-set env vars to the active file.
 """
 
 from strix.config.loader import (
     apply_config_override,
+    invalidate_settings_cache,
     load_settings,
     persist_current,
 )
@@ -32,6 +34,7 @@ __all__ = [
     "Settings",
     "TelemetrySettings",
     "apply_config_override",
+    "invalidate_settings_cache",
     "load_settings",
     "persist_current",
 ]

--- a/strix/config/loader.py
+++ b/strix/config/loader.py
@@ -53,6 +53,12 @@ def apply_config_override(path: Path) -> None:
     logger.info("config override applied: %s", path)
 
 
+def invalidate_settings_cache() -> None:
+    """Drop the memoized settings so the next load re-reads env + config file."""
+    global _cached  # noqa: PLW0603
+    _cached = None
+
+
 def persist_current() -> None:
     """Write currently-set env vars to the active config file (0o600)."""
     s = load_settings()

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -310,6 +310,7 @@ def _positive_budget(value: str) -> float:
     except ValueError as exc:
         raise argparse.ArgumentTypeError(f"invalid float value: {value!r}") from exc
     import math
+
     if not math.isfinite(budget) or budget <= 0:
         raise argparse.ArgumentTypeError("must be a finite number greater than 0")
     return budget
@@ -465,6 +466,21 @@ Examples:
             "Resume a prior scan by its run name (the dir under ./strix_runs/). "
             "Picks up the root + every non-terminal subagent's full LLM history "
             "and agent topology. Skips fresh run-name generation."
+        ),
+    )
+
+    parser.add_argument(
+        "--sub",
+        type=str,
+        choices=["claude", "codex"],
+        metavar="BACKEND",
+        help=(
+            "Use a local subscription LLM backend instead of a pay-per-use API key. "
+            "Strix auto-starts a bundled loopback proxy and wires STRIX_LLM / "
+            "LLM_API_BASE / LLM_API_KEY for you. 'claude' borrows your Claude Code "
+            "OAuth token (~/.claude); 'codex' borrows your ChatGPT Codex token "
+            "(~/.codex). Experimental: ensure this complies with the provider's "
+            "terms of service."
         ),
     )
 
@@ -749,12 +765,19 @@ def main() -> None:
         apply_config_override(validate_config_file(args.config))
 
     check_docker_installed()
+
+    if args.sub:
+        from strix.subscription import maybe_start_subscription_proxy
+
+        maybe_start_subscription_proxy(args.sub)
+
     pull_docker_image()
 
     validate_environment()
     asyncio.run(warm_up_llm())
 
-    persist_current()
+    if not args.sub:
+        persist_current()
 
     args.run_name = args.resume or generate_run_name(args.targets_info)
 

--- a/strix/subscription/__init__.py
+++ b/strix/subscription/__init__.py
@@ -1,0 +1,8 @@
+"""Subscription-backed LLM providers exposed through ``strix --sub <backend>``."""
+
+from __future__ import annotations
+
+from strix.subscription.bringup import maybe_start_subscription_proxy
+
+
+__all__ = ["maybe_start_subscription_proxy"]

--- a/strix/subscription/_ui.py
+++ b/strix/subscription/_ui.py
@@ -1,0 +1,36 @@
+"""Small Rich helpers shared by the subscription bring-up path."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, NoReturn
+
+from rich.panel import Panel
+from rich.text import Text
+
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+def fail(console: Console, title: str, detail: str) -> NoReturn:
+    """Print a red error panel and exit the process with status 1."""
+    body = Text()
+    body.append(f"{title}\n\n", style="bold red")
+    body.append(detail, style="white")
+    panel = Panel(
+        body,
+        title="[bold white]STRIX",
+        title_align="left",
+        border_style="red",
+        padding=(1, 2),
+    )
+    console.print("\n")
+    console.print(panel)
+    console.print()
+    sys.exit(1)
+
+
+def notice(console: Console, message: str) -> None:
+    """Print a dim, single-line informational notice."""
+    console.print(f"[dim]{message}[/]")

--- a/strix/subscription/bringup.py
+++ b/strix/subscription/bringup.py
@@ -1,0 +1,62 @@
+"""Start the bundled subscription proxy and wire Strix's LLM env to it."""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+
+from rich.console import Console
+
+from strix.config import invalidate_settings_cache
+from strix.subscription._ui import fail, notice
+from strix.subscription.proxy import ProxyStartupError, SubscriptionProxy
+from strix.subscription.registry import BACKENDS
+
+
+logger = logging.getLogger(__name__)
+
+_PLACEHOLDER_API_KEY = "strix-subscription"
+
+
+def maybe_start_subscription_proxy(sub: str | None) -> SubscriptionProxy | None:
+    """Start the proxy for ``sub`` and point Strix's LLM config at it.
+
+    Returns ``None`` when ``sub`` is falsy so callers can invoke it
+    unconditionally. The proxy is torn down automatically at interpreter exit.
+    """
+    if not sub:
+        return None
+
+    console = Console()
+    backend = BACKENDS[sub]
+    backend.preflight(console)
+
+    proxy = SubscriptionProxy(backend.build_app())
+    try:
+        proxy.start()
+    except ProxyStartupError as exc:
+        fail(console, "Subscription proxy failed to start", str(exc))
+
+    atexit.register(proxy.stop)
+    _wire_env(sub, backend.default_model, proxy.base_url)
+    invalidate_settings_cache()
+
+    notice(
+        console,
+        f"Using your {sub} subscription via a local proxy "
+        "(experimental; ensure provider terms-of-service compliance).",
+    )
+    logger.info("Subscription backend '%s' ready at %s", sub, proxy.base_url)
+    return proxy
+
+
+def _wire_env(sub: str, default_model: str, api_base: str) -> None:
+    if not os.environ.get("STRIX_LLM"):
+        os.environ["STRIX_LLM"] = default_model
+
+    previous_base = os.environ.get("LLM_API_BASE")
+    if previous_base and previous_base != api_base:
+        logger.warning("--sub %s overrides LLM_API_BASE (%s -> %s)", sub, previous_base, api_base)
+    os.environ["LLM_API_BASE"] = api_base
+    os.environ.setdefault("LLM_API_KEY", _PLACEHOLDER_API_KEY)

--- a/strix/subscription/claude/__init__.py
+++ b/strix/subscription/claude/__init__.py
@@ -1,0 +1,1 @@
+"""Claude subscription proxy backend for the Strix subscription proxy."""

--- a/strix/subscription/claude/auth.py
+++ b/strix/subscription/claude/auth.py
@@ -68,7 +68,7 @@ def _read_auth(path: str) -> dict:
 
 def _write_auth(path: str, data: dict) -> None:
     tmp = path + ".tmp"
-    with open(tmp, "w") as f:
+    with os.fdopen(os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600), "w") as f:
         json.dump(data, f, indent=2)
     os.replace(tmp, path)
     os.chmod(path, 0o600)

--- a/strix/subscription/claude/auth.py
+++ b/strix/subscription/claude/auth.py
@@ -1,0 +1,177 @@
+"""
+Claude Code OAuth token handling for the Strix subscription proxy.
+
+Borrows the OAuth access token that the Claude Code CLI stores locally
+(~/.claude/.credentials.json) and refreshes it when expired, so the proxy can
+authenticate to api.anthropic.com on the user's Claude *subscription* instead of
+a paid API key.
+
+This mirrors the token-borrowing approach in strix.subscription.codex.auth (which borrows
+ChatGPT/Codex tokens from ~/.codex/auth.json), adapted to Anthropic's OAuth
+scheme. No third-party deps — stdlib urllib only.
+
+Note: Anthropic's subscription OAuth tokens are intended for use within Claude
+Code / Claude.ai. Reusing them in another tool may violate the Consumer Terms.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+# Overridable via env so the refresh endpoint / client id / UA can be swapped
+# without code changes if Anthropic moves them.
+REFRESH_URL = os.environ.get(
+    "STRIX_SUB_CLAUDE_REFRESH_URL", "https://console.anthropic.com/v1/oauth/token"
+)
+CLIENT_ID = os.environ.get(
+    "STRIX_SUB_CLAUDE_OAUTH_CLIENT_ID", "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+)
+CLAUDE_CODE_USER_AGENT = os.environ.get(
+    "STRIX_SUB_CLAUDE_USER_AGENT", "claude-cli/2.0.0 (external)"
+)
+
+REFRESH_SKEW_SECONDS = 60
+
+ANTHROPIC_BASE_URL = os.environ.get(
+    "STRIX_SUB_CLAUDE_ANTHROPIC_BASE_URL", "https://api.anthropic.com"
+)
+ANTHROPIC_VERSION = "2023-06-01"
+ANTHROPIC_OAUTH_BETA = "oauth-2025-04-20"
+
+# The subscription credential is only accepted on /v1/messages when the request
+# presents as Claude Code: the first system block must be exactly this string.
+CLAUDE_CODE_SYSTEM_PROMPT = "You are Claude Code, Anthropic's official CLI for Claude."
+
+
+class BorrowKeyError(Exception):
+    pass
+
+
+def _auth_path() -> str:
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR", os.path.expanduser("~/.claude"))
+    path = os.path.join(config_dir, ".credentials.json")
+    if not os.path.exists(path):
+        raise BorrowKeyError(
+            f"Claude Code credentials not found at {path}. "
+            "Log in with the `claude` CLI first."
+        )
+    return path
+
+
+def _read_auth(path: str) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def _write_auth(path: str, data: dict) -> None:
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, path)
+    os.chmod(path, 0o600)
+
+
+def borrow_claude_key() -> str:
+    """Return a valid Claude Code OAuth access token.
+
+    Reads ~/.claude/.credentials.json, refreshes via Anthropic's OAuth token
+    endpoint if the access token is expired or near-expiry, and persists the
+    rotated tokens back to the credentials file (preserving any other fields).
+    """
+    # Prefer an explicit long-lived token (from `claude setup-token`) when set:
+    # no file dependency and no refresh, ideal for long unattended runs.
+    env_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
+    if env_token and env_token.strip():
+        return env_token.strip()
+
+    path = _auth_path()
+    data = _read_auth(path)
+
+    oauth = data.get("claudeAiOauth")
+    if not isinstance(oauth, dict) or not oauth.get("accessToken"):
+        raise BorrowKeyError(
+            "No Claude Code OAuth tokens found in credentials file. "
+            "Log in with the `claude` CLI first."
+        )
+
+    access_token = oauth["accessToken"]
+    expires_at_ms = oauth.get("expiresAt")
+
+    # expiresAt is epoch milliseconds. If absent we cannot check expiry; assume a
+    # running Claude Code keeps it fresh and use it as-is.
+    if not expires_at_ms:
+        return access_token
+    if time.time() * 1000 < (expires_at_ms - REFRESH_SKEW_SECONDS * 1000):
+        return access_token
+
+    refresh_token = oauth.get("refreshToken")
+    if not refresh_token:
+        raise BorrowKeyError(
+            "Access token expired and no refresh token available. "
+            "Log in with the `claude` CLI again."
+        )
+
+    new = _refresh(refresh_token)
+
+    oauth["accessToken"] = new["access_token"]
+    if new.get("refresh_token"):
+        oauth["refreshToken"] = new["refresh_token"]
+    if new.get("expires_in"):
+        oauth["expiresAt"] = int(time.time() * 1000) + int(new["expires_in"]) * 1000
+
+    data["claudeAiOauth"] = oauth
+    _write_auth(path, data)
+    return oauth["accessToken"]
+
+
+def get_token() -> str:
+    """Public alias for borrow_claude_key()."""
+    return borrow_claude_key()
+
+
+def _refresh(refresh_token: str) -> dict:
+    body = json.dumps(
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": CLIENT_ID,
+        }
+    ).encode()
+
+    req = urllib.request.Request(
+        REFRESH_URL,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": CLAUDE_CODE_USER_AGENT,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode(errors="replace")
+        hint = ""
+        if e.code in (403, 503) and "<html" in error_body.lower():
+            hint = (
+                " (endpoint returned an HTML block page; the refresh User-Agent "
+                "may be rejected; try setting STRIX_SUB_CLAUDE_USER_AGENT)"
+            )
+        try:
+            code = json.loads(error_body).get("error")
+        except Exception:
+            code = None
+        if code in ("invalid_grant", "refresh_token_expired", "refresh_token_revoked"):
+            raise BorrowKeyError(
+                f"Refresh token is no longer valid ({code}). "
+                "Log in with the `claude` CLI again."
+            ) from None
+        raise BorrowKeyError(
+            f"Token refresh failed (HTTP {e.code}): {error_body[:300]}{hint}"
+        ) from None
+    except urllib.error.URLError as e:
+        raise BorrowKeyError(f"Token refresh failed (network error): {e}") from None

--- a/strix/subscription/claude/payload.py
+++ b/strix/subscription/claude/payload.py
@@ -1,0 +1,132 @@
+"""Request-body and header massaging for the Anthropic passthrough.
+
+Pure functions (no I/O) so they are easy to unit-test. The proxy turns an
+incoming Anthropic Messages request (produced by Strix via litellm's `anthropic/`
+provider) into one that an Anthropic *subscription* OAuth token will accept, then
+builds the forwarded headers.
+"""
+from __future__ import annotations
+
+from .auth import (
+    ANTHROPIC_OAUTH_BETA,
+    ANTHROPIC_VERSION,
+    CLAUDE_CODE_SYSTEM_PROMPT,
+    CLAUDE_CODE_USER_AGENT,
+)
+
+
+def _normalize_system(system, identity: str) -> list:
+    """Return a list of system blocks whose first block is the identity prompt."""
+    if system is None:
+        blocks: list = []
+    elif isinstance(system, str):
+        blocks = [{"type": "text", "text": system}] if system.strip() else []
+    elif isinstance(system, list):
+        blocks = list(system)
+    else:
+        blocks = [{"type": "text", "text": str(system)}]
+
+    if (
+        blocks
+        and isinstance(blocks[0], dict)
+        and blocks[0].get("type") == "text"
+        and (blocks[0].get("text") or "").strip() == identity
+    ):
+        return blocks
+    return [{"type": "text", "text": identity}] + blocks
+
+
+def transform_body(
+    body: dict,
+    *,
+    default_model: str = "claude-opus-4-8",
+    max_tokens: int = 32000,
+    inject_system_prompt: bool = True,
+    strip_prefill: bool = True,
+    inject_thinking: bool = False,
+    effort: str = "high",
+) -> dict:
+    """Return a NEW request body adjusted for OAuth/subscription acceptance.
+
+    Does not mutate the input.
+    """
+    out = dict(body)
+
+    # Model: default when absent, otherwise pass through whatever Strix sent.
+    if not out.get("model"):
+        out["model"] = default_model
+
+    # Anthropic requires max_tokens; default it when the caller omits it.
+    if not out.get("max_tokens"):
+        out["max_tokens"] = max_tokens
+
+    # Subscription credential is only accepted when the request presents as
+    # Claude Code: the first system block must be the Claude Code identity.
+    if inject_system_prompt:
+        out["system"] = _normalize_system(out.get("system"), CLAUDE_CODE_SYSTEM_PROMPT)
+
+    # Opus 4.x returns 400 on a trailing assistant prefill turn.
+    if strip_prefill:
+        msgs = out.get("messages")
+        if (
+            isinstance(msgs, list)
+            and msgs
+            and isinstance(msgs[-1], dict)
+            and msgs[-1].get("role") == "assistant"
+        ):
+            out["messages"] = msgs[:-1]
+
+    # Optional: nudge adaptive thinking + effort for agentic performance.
+    if inject_thinking and "thinking" not in out:
+        out["thinking"] = {"type": "adaptive"}
+        oc = dict(out.get("output_config") or {})
+        oc.setdefault("effort", effort)
+        out["output_config"] = oc
+        # thinking is incompatible with a fixed temperature on Opus 4.x.
+        out.pop("temperature", None)
+
+    return out
+
+
+def merge_anthropic_beta(incoming: str | None, required: str = ANTHROPIC_OAUTH_BETA) -> str:
+    """Union the caller's anthropic-beta values with the required oauth beta."""
+    vals: list[str] = []
+    if incoming:
+        vals.extend(p.strip() for p in incoming.split(",") if p.strip())
+    if required and required not in vals:
+        vals.append(required)
+    seen: set[str] = set()
+    out: list[str] = []
+    for v in vals:
+        if v not in seen:
+            seen.add(v)
+            out.append(v)
+    return ",".join(out)
+
+
+def build_forward_headers(incoming_headers, token: str) -> dict:
+    """Build the headers used to call api.anthropic.com with the OAuth token.
+
+    Drops the incoming dummy x-api-key / authorization entirely and sets the
+    OAuth Bearer + required beta/version headers. The `anthropic-beta` value is
+    merged so any feature betas litellm added are preserved.
+    """
+    incoming_beta = None
+    incoming_accept = None
+    for k, v in (incoming_headers or {}).items():
+        kl = k.lower()
+        if kl == "anthropic-beta":
+            incoming_beta = v
+        elif kl == "accept":
+            incoming_accept = v
+
+    return {
+        "Authorization": f"Bearer {token}",
+        "anthropic-version": ANTHROPIC_VERSION,
+        "anthropic-beta": merge_anthropic_beta(incoming_beta),
+        "User-Agent": CLAUDE_CODE_USER_AGENT,
+        "Content-Type": "application/json",
+        "Accept": incoming_accept or "application/json",
+        # Force identity so raw passthrough bytes aren't compressed.
+        "Accept-Encoding": "identity",
+    }

--- a/strix/subscription/claude/server.py
+++ b/strix/subscription/claude/server.py
@@ -1,0 +1,165 @@
+"""FastAPI proxy exposing Anthropic-compatible message endpoints backed by
+the user's Claude Code subscription (OAuth) instead of an API key.
+
+Strix (via litellm's `anthropic/` provider) POSTs Anthropic Messages requests
+here; the proxy swaps the dummy x-api-key for the borrowed Claude Code OAuth
+Bearer token (+ required beta/version headers), lightly massages the body, and
+forwards to https://api.anthropic.com/v1/messages. Streaming is a raw SSE byte
+passthrough — no format translation.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from .auth import ANTHROPIC_BASE_URL, BorrowKeyError, borrow_claude_key
+from .payload import build_forward_headers, transform_body
+
+log = logging.getLogger("strix.subscription.claude.server")
+
+app = FastAPI(title="strix-subscription-claude", version="0.1.0")
+
+TIMEOUT = httpx.Timeout(connect=10.0, read=600.0, write=30.0, pool=10.0)
+
+ADVERTISED_MODELS = ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"]
+
+
+def _env(name: str, default: str) -> str:
+    return os.environ.get(name, default)
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in ("0", "false", "no", "off", "")
+
+
+def _transform(body: dict) -> dict:
+    return transform_body(
+        body,
+        default_model=_env("STRIX_SUB_CLAUDE_DEFAULT_MODEL", "claude-opus-4-8"),
+        max_tokens=int(_env("STRIX_SUB_CLAUDE_MAX_TOKENS", "32000")),
+        inject_system_prompt=_bool_env("STRIX_SUB_CLAUDE_INJECT_SYSTEM_PROMPT", True),
+        strip_prefill=_bool_env("STRIX_SUB_CLAUDE_STRIP_PREFILL", True),
+        inject_thinking=_bool_env("STRIX_SUB_CLAUDE_INJECT_THINKING", False),
+        effort=_env("STRIX_SUB_CLAUDE_EFFORT", "high"),
+    )
+
+
+def _upstream_url() -> str:
+    # Claude Code / litellm hit /v1/messages?beta=true.
+    return f"{ANTHROPIC_BASE_URL}/v1/messages?beta=true"
+
+
+@app.get("/healthz")
+async def healthz():
+    try:
+        borrow_claude_key()
+        return {"ok": True}
+    except BorrowKeyError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=503)
+
+
+@app.get("/models")
+@app.get("/{prefix:path}/models")
+async def list_models(prefix: str = ""):
+    _ensure_v1_prefix(prefix)
+    return {
+        "object": "list",
+        "data": [
+            {"id": m, "object": "model", "created": int(time.time()), "owned_by": "anthropic"}
+            for m in ADVERTISED_MODELS
+        ],
+    }
+
+
+@app.post("/messages")
+@app.post("/{prefix:path}/messages")
+async def messages(req: Request, prefix: str = ""):
+    _ensure_v1_prefix(prefix)
+    try:
+        body = await req.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    try:
+        token = borrow_claude_key()
+    except BorrowKeyError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+
+    out_body = _transform(body)
+    headers = build_forward_headers(req.headers, token)
+    payload = json.dumps(out_body).encode()
+    url = _upstream_url()
+
+    if bool(out_body.get("stream")):
+        return await _proxy_stream(url, headers, payload)
+    return await _proxy_once(url, headers, payload)
+
+
+def _ensure_v1_prefix(prefix: str) -> None:
+    """Allow /messages, /v1/messages, /v1/v1/messages, etc.; reject other prefixes."""
+    if not prefix:
+        return
+    if any(part != "v1" for part in prefix.split("/")):
+        raise HTTPException(status_code=404, detail="Not Found")
+
+
+async def _proxy_stream(url: str, headers: dict, payload: bytes) -> Response:
+    client = httpx.AsyncClient(timeout=TIMEOUT)
+    try:
+        r = await client.send(
+            client.build_request("POST", url, headers=headers, content=payload),
+            stream=True,
+        )
+    except Exception as e:
+        await client.aclose()
+        raise HTTPException(status_code=502, detail=f"upstream connection error: {e}")
+
+    # Check status before committing to a streaming response so upstream errors
+    # (e.g. the OAuth "out of extra usage" 400) surface with their real body.
+    if r.status_code >= 400:
+        err = await r.aread()
+        ctype = r.headers.get("content-type", "application/json")
+        await r.aclose()
+        await client.aclose()
+        log.error("anthropic error %s: %s", r.status_code, err[:500].decode(errors="replace"))
+        return Response(content=err, status_code=r.status_code, media_type=ctype)
+
+    async def gen():
+        try:
+            async for chunk in r.aiter_raw():
+                yield chunk
+        finally:
+            await r.aclose()
+            await client.aclose()
+
+    return StreamingResponse(
+        gen(),
+        status_code=r.status_code,
+        media_type=r.headers.get("content-type", "text/event-stream"),
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+async def _proxy_once(url: str, headers: dict, payload: bytes) -> Response:
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+            r = await client.post(url, headers=headers, content=payload)
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"upstream connection error: {e}")
+
+    if r.status_code >= 400:
+        log.error("anthropic error %s: %s", r.status_code, r.text[:500])
+    return Response(
+        content=r.content,
+        status_code=r.status_code,
+        media_type=r.headers.get("content-type", "application/json"),
+    )

--- a/strix/subscription/codex/__init__.py
+++ b/strix/subscription/codex/__init__.py
@@ -1,0 +1,1 @@
+"""Codex backend proxy for the Strix subscription proxy."""

--- a/strix/subscription/codex/auth.py
+++ b/strix/subscription/codex/auth.py
@@ -99,7 +99,7 @@ def _read_auth(path: str) -> dict:
 
 def _write_auth(path: str, data: dict) -> None:
     tmp = path + ".tmp"
-    with open(tmp, "w") as f:
+    with os.fdopen(os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600), "w") as f:
         json.dump(data, f, indent=2)
     os.replace(tmp, path)
     os.chmod(path, 0o600)

--- a/strix/subscription/codex/auth.py
+++ b/strix/subscription/codex/auth.py
@@ -1,0 +1,155 @@
+"""
+Codex OAuth token handling.
+
+Vendored from simonw/llm-openai-via-codex (Apache-2.0):
+https://github.com/simonw/llm-openai-via-codex/blob/main/llm_openai_via_codex.py
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+REFRESH_URL = "https://auth.openai.com/oauth/token"
+CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+REFRESH_SKEW_SECONDS = 30
+CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+
+
+class BorrowKeyError(Exception):
+    pass
+
+
+def borrow_codex_key() -> tuple[str, str | None]:
+    """Return (access_token, account_id) from local Codex CLI OAuth state.
+
+    Refreshes via auth.openai.com if the access token is expired or near-expiry.
+    Persists refreshed tokens back to ~/.codex/auth.json.
+    """
+    auth_path = _auth_path()
+    data = _read_auth(auth_path)
+
+    tokens = data.get("tokens")
+    if not tokens or not tokens.get("access_token"):
+        raise BorrowKeyError(
+            "No ChatGPT tokens found in auth.json. Run `codex login` first."
+        )
+
+    access_token = tokens["access_token"]
+    account_id = tokens.get("account_id")
+    exp = _jwt_exp(access_token)
+
+    if exp is not None and time.time() < (exp - REFRESH_SKEW_SECONDS):
+        return access_token, account_id
+
+    refresh_token = tokens.get("refresh_token")
+    if not refresh_token:
+        raise BorrowKeyError(
+            "No refresh token available. Run `codex login` to re-authenticate."
+        )
+
+    new_tokens = _refresh(refresh_token)
+
+    if new_tokens.get("access_token"):
+        tokens["access_token"] = new_tokens["access_token"]
+    if new_tokens.get("id_token"):
+        tokens["id_token"] = new_tokens["id_token"]
+    if new_tokens.get("refresh_token"):
+        tokens["refresh_token"] = new_tokens["refresh_token"]
+
+    data["tokens"] = tokens
+    data["last_refresh"] = time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime())
+
+    _write_auth(auth_path, data)
+    return tokens["access_token"], account_id
+
+
+def get_token_and_account() -> tuple[str, str | None]:
+    """Public alias for borrow_codex_key()."""
+    return borrow_codex_key()
+
+
+def _auth_path() -> str:
+    codex_home = os.environ.get("CODEX_HOME", os.path.expanduser("~/.codex"))
+    path = os.path.join(codex_home, "auth.json")
+    if not os.path.exists(path):
+        raise BorrowKeyError(
+            f"Codex auth file not found at {path}. Run `codex login` first."
+        )
+    return path
+
+
+def _read_auth(path: str) -> dict:
+    with open(path) as f:
+        data = json.load(f)
+    mode = data.get("auth_mode")
+    # Some codex builds omit auth_mode. Accept missing/None as long as ChatGPT-style
+    # OAuth tokens are present. Reject only when the mode is explicitly something else
+    # (e.g. "apikey").
+    if mode not in (None, "chatgpt"):
+        raise BorrowKeyError(
+            f"auth_mode '{mode}' is not supported. This proxy needs ChatGPT OAuth "
+            "tokens (run `codex login` and pick the ChatGPT option)."
+        )
+    return data
+
+
+def _write_auth(path: str, data: dict) -> None:
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, path)
+    os.chmod(path, 0o600)
+
+
+def _jwt_exp(token: str) -> int | None:
+    try:
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (4 - len(payload_b64) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        return payload.get("exp")
+    except Exception:
+        return None
+
+
+def _refresh(refresh_token: str) -> dict:
+    body = json.dumps(
+        {
+            "client_id": CLIENT_ID,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+    ).encode()
+
+    req = urllib.request.Request(
+        REFRESH_URL,
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode(errors="replace")
+        try:
+            error_code = json.loads(error_body).get("error")
+        except Exception:
+            error_code = None
+        if error_code in (
+            "refresh_token_expired",
+            "refresh_token_reused",
+            "refresh_token_invalidated",
+        ):
+            raise BorrowKeyError(
+                f"Refresh token is no longer valid ({error_code}). "
+                "Run `codex login` to re-authenticate."
+            ) from None
+        raise BorrowKeyError(
+            f"Token refresh failed (HTTP {e.code}): {error_body}"
+        ) from None
+    except urllib.error.URLError as e:
+        raise BorrowKeyError(f"Token refresh failed (network error): {e}") from None

--- a/strix/subscription/codex/server.py
+++ b/strix/subscription/codex/server.py
@@ -1,0 +1,243 @@
+"""FastAPI server exposing an OpenAI-compatible /v1 endpoint backed by Codex."""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import AsyncIterator
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from .auth import CODEX_BASE_URL, BorrowKeyError, borrow_codex_key
+from .translator import (
+    chat_to_responses,
+    responses_to_chat,
+    stream_responses_to_chat,
+)
+
+log = logging.getLogger("strix.subscription.codex.server")
+
+app = FastAPI(title="strix-subscription-codex", version="0.1.0")
+
+DEFAULT_MODELS = ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"]
+
+
+def _auth_headers() -> dict[str, str]:
+    token, account_id = borrow_codex_key()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "OpenAI-Beta": "responses=experimental",
+    }
+    if account_id:
+        headers["ChatGPT-Account-ID"] = account_id
+    return headers
+
+
+@app.get("/healthz")
+async def healthz():
+    try:
+        borrow_codex_key()
+        return {"ok": True}
+    except BorrowKeyError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=503)
+
+
+@app.get("/v1/models")
+async def list_models():
+    try:
+        headers = _auth_headers()
+    except BorrowKeyError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            r = await client.get(
+                f"{CODEX_BASE_URL}/models?client_version=1.0.0",
+                headers=headers,
+            )
+        r.raise_for_status()
+        data = r.json()
+        slugs = [
+            m["slug"]
+            for m in data.get("models", [])
+            if m.get("supported_in_api") and m.get("visibility") == "list"
+        ]
+    except Exception as e:
+        log.warning("failed to fetch codex models, falling back to defaults: %s", e)
+        slugs = DEFAULT_MODELS
+
+    return {
+        "object": "list",
+        "data": [
+            {"id": slug, "object": "model", "created": int(time.time()), "owned_by": "openai-codex"}
+            for slug in slugs
+        ],
+    }
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(req: Request):
+    try:
+        body = await req.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    if "messages" not in body or "model" not in body:
+        raise HTTPException(status_code=400, detail="`model` and `messages` are required")
+
+    try:
+        headers = _auth_headers()
+    except BorrowKeyError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+
+    responses_body = chat_to_responses(body)
+    is_stream = bool(body.get("stream"))
+    model = body["model"]
+
+    if is_stream:
+        return StreamingResponse(
+            _stream(responses_body, headers, model=model),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    # non-streaming: still hit the upstream as a stream and accumulate, since
+    # the Codex endpoint always streams. We then build a single Chat Completions reply.
+    responses_body_streamed = dict(responses_body)
+    responses_body_streamed["stream"] = True
+
+    accumulated = await _collect_full_response(responses_body_streamed, headers)
+    return responses_to_chat(accumulated, model=model)
+
+
+async def _stream(
+    responses_body: dict, headers: dict, *, model: str
+) -> AsyncIterator[bytes]:
+    sse_iter = _codex_sse_events(responses_body, headers)
+    async for chunk in stream_responses_to_chat(sse_iter, model=model):
+        yield chunk
+
+
+async def _codex_sse_events(
+    responses_body: dict, headers: dict
+) -> AsyncIterator[dict]:
+    """Open an SSE stream against the Codex /responses endpoint and yield event dicts."""
+    body = dict(responses_body)
+    body["stream"] = True
+    payload = json.dumps(body).encode()
+    url = f"{CODEX_BASE_URL}/responses"
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(connect=10.0, read=600.0, write=30.0, pool=10.0)) as client:
+        async with client.stream("POST", url, headers=headers, content=payload) as r:
+            if r.status_code >= 400:
+                error_body = (await r.aread()).decode(errors="replace")
+                log.error("codex error %s: %s", r.status_code, error_body)
+                yield {
+                    "type": "error",
+                    "error": {
+                        "message": f"upstream error {r.status_code}: {error_body[:500]}",
+                        "type": "upstream_error",
+                    },
+                }
+                return
+
+            current_event: str | None = None
+            data_buf: list[str] = []
+            async for line in r.aiter_lines():
+                if line == "":
+                    if data_buf:
+                        raw = "\n".join(data_buf)
+                        data_buf.clear()
+                        if raw == "[DONE]":
+                            current_event = None
+                            continue
+                        try:
+                            ev = json.loads(raw)
+                        except json.JSONDecodeError:
+                            current_event = None
+                            continue
+                        if "type" not in ev and current_event:
+                            ev["type"] = current_event
+                        yield ev
+                    current_event = None
+                    continue
+
+                if line.startswith(":"):
+                    continue
+                if line.startswith("event:"):
+                    current_event = line[6:].strip()
+                elif line.startswith("data:"):
+                    data_buf.append(line[5:].lstrip())
+
+
+async def _collect_full_response(responses_body: dict, headers: dict) -> dict:
+    """Consume the upstream SSE stream and synthesize a complete `response` object.
+
+    The streaming Codex backend delivers text via `response.output_text.delta` events
+    and only sends a final `response.completed` envelope. We accumulate locally and
+    use the final envelope just for `id` and `usage`.
+    """
+    text_parts: list[str] = []
+    tool_calls_ordered: list[dict] = []
+    tool_calls_by_key: dict[str, dict] = {}
+    final_envelope: dict | None = None
+
+    async for ev in _codex_sse_events(responses_body, headers):
+        et = ev.get("type")
+        if et == "response.completed":
+            final_envelope = ev.get("response") or {}
+        elif et == "response.output_text.delta":
+            text_parts.append(ev.get("delta") or "")
+        elif et == "response.output_item.added":
+            item = ev.get("item") or {}
+            if item.get("type") == "function_call":
+                key = item.get("id") or item.get("call_id") or f"_{len(tool_calls_ordered)}"
+                tc = {
+                    "type": "function_call",
+                    "id": item.get("id"),
+                    "call_id": item.get("call_id"),
+                    "name": item.get("name") or "",
+                    "arguments": "",
+                }
+                tool_calls_by_key[key] = tc
+                tool_calls_ordered.append(tc)
+        elif et == "response.function_call_arguments.delta":
+            key = ev.get("item_id") or ""
+            tc = tool_calls_by_key.get(key)
+            if tc is not None:
+                tc["arguments"] += ev.get("delta") or ""
+        elif et in ("response.failed", "response.error", "error"):
+            err = ev.get("error") or (ev.get("response") or {}).get("error") or {}
+            raise HTTPException(
+                status_code=502, detail=err.get("message") or "upstream stream error"
+            )
+
+    output: list[dict] = []
+    full_text = "".join(text_parts)
+    if full_text:
+        output.append(
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": full_text}],
+            }
+        )
+    for tc in tool_calls_ordered:
+        output.append(
+            {
+                "type": "function_call",
+                "id": tc.get("id"),
+                "call_id": tc.get("call_id"),
+                "name": tc.get("name"),
+                "arguments": tc.get("arguments") or "{}",
+            }
+        )
+
+    return {
+        "id": (final_envelope or {}).get("id"),
+        "output": output,
+        "usage": (final_envelope or {}).get("usage") or {},
+    }

--- a/strix/subscription/codex/translator.py
+++ b/strix/subscription/codex/translator.py
@@ -1,0 +1,343 @@
+"""
+Bidirectional translation between OpenAI Chat Completions and Responses API.
+
+Strix/LiteLLM speak Chat Completions (`/chat/completions`).
+The ChatGPT Codex backend only speaks the Responses API (`/responses`).
+This module bridges the two formats, including streaming SSE.
+"""
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from typing import Any, AsyncIterator, Iterable
+
+# ---------- request: chat completions -> responses ----------
+
+
+def chat_to_responses(payload: dict) -> dict:
+    """Convert a Chat Completions request body to a Responses API request body."""
+    out: dict[str, Any] = {
+        "model": payload["model"],
+        "store": False,
+    }
+
+    instructions, input_items = _messages_to_input(payload.get("messages", []))
+    out["instructions"] = instructions or "You are a helpful assistant."
+    out["input"] = input_items
+
+    if payload.get("stream"):
+        out["stream"] = True
+
+    if (v := payload.get("max_tokens")) is not None:
+        out["max_output_tokens"] = v
+    if (v := payload.get("max_completion_tokens")) is not None:
+        out["max_output_tokens"] = v
+    for k in ("temperature", "top_p"):
+        if (v := payload.get(k)) is not None:
+            out[k] = v
+
+    if (v := payload.get("reasoning_effort")) is not None:
+        out["reasoning"] = {"effort": v}
+
+    tools = payload.get("tools")
+    if tools:
+        out["tools"] = [_chat_tool_to_responses_tool(t) for t in tools if t]
+    if (tc := payload.get("tool_choice")) is not None:
+        out["tool_choice"] = tc
+
+    rf = payload.get("response_format")
+    if isinstance(rf, dict):
+        if rf.get("type") == "json_schema":
+            schema_block = rf.get("json_schema") or {}
+            out["text"] = {
+                "format": {
+                    "type": "json_schema",
+                    "name": schema_block.get("name") or "output",
+                    "schema": schema_block.get("schema") or {},
+                }
+            }
+        elif rf.get("type") == "json_object":
+            out["text"] = {"format": {"type": "json_object"}}
+
+    return out
+
+
+def _messages_to_input(messages: list[dict]) -> tuple[str, list[dict]]:
+    """Split chat completions messages into (instructions, input items)."""
+    instructions_parts: list[str] = []
+    items: list[dict] = []
+
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content")
+
+        if role == "system" or role == "developer":
+            instructions_parts.append(_flatten_text_content(content))
+            continue
+
+        if role == "tool":
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": msg.get("tool_call_id") or "",
+                    "output": _flatten_text_content(content),
+                }
+            )
+            continue
+
+        if role == "assistant":
+            text = _flatten_text_content(content)
+            tool_calls = msg.get("tool_calls") or []
+            if text:
+                items.append({"role": "assistant", "content": text})
+            for tc in tool_calls:
+                fn = tc.get("function") or {}
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": tc.get("id") or "",
+                        "name": fn.get("name") or "",
+                        "arguments": fn.get("arguments") or "{}",
+                    }
+                )
+            continue
+
+        if role == "user":
+            items.append({"role": "user", "content": _user_content_blocks(content)})
+            continue
+
+    instructions = "\n\n".join(p for p in instructions_parts if p)
+    return instructions, items
+
+
+def _flatten_text_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") in ("text", "input_text", "output_text"):
+                    parts.append(block.get("text") or "")
+                elif "text" in block:
+                    parts.append(block["text"] or "")
+        return "".join(parts)
+    return str(content)
+
+
+def _user_content_blocks(content: Any) -> list[dict]:
+    if isinstance(content, str):
+        return [{"type": "input_text", "text": content}]
+    if isinstance(content, list):
+        out = []
+        for block in content:
+            if not isinstance(block, dict):
+                out.append({"type": "input_text", "text": str(block)})
+                continue
+            t = block.get("type")
+            if t in ("text", "input_text"):
+                out.append({"type": "input_text", "text": block.get("text") or ""})
+            elif t == "image_url":
+                url = block.get("image_url")
+                if isinstance(url, dict):
+                    url = url.get("url")
+                out.append({"type": "input_image", "image_url": url, "detail": "low"})
+            elif t == "input_image":
+                out.append(block)
+            else:
+                if "text" in block:
+                    out.append({"type": "input_text", "text": block["text"]})
+        return out or [{"type": "input_text", "text": ""}]
+    return [{"type": "input_text", "text": str(content) if content else ""}]
+
+
+def _chat_tool_to_responses_tool(tool: dict) -> dict:
+    fn = tool.get("function") or {}
+    return {
+        "type": "function",
+        "name": fn.get("name") or "",
+        "description": fn.get("description"),
+        "parameters": fn.get("parameters") or {"type": "object", "properties": {}},
+        "strict": False,
+    }
+
+
+# ---------- response: responses -> chat completions (non-streaming) ----------
+
+
+def responses_to_chat(resp: dict, *, model: str) -> dict:
+    """Convert a non-streaming Responses API result to a Chat Completions result."""
+    text_parts: list[str] = []
+    tool_calls: list[dict] = []
+    finish_reason = "stop"
+
+    for item in resp.get("output", []) or []:
+        item_type = item.get("type")
+        if item_type == "message":
+            for block in item.get("content", []) or []:
+                if block.get("type") == "output_text":
+                    text_parts.append(block.get("text") or "")
+        elif item_type == "function_call":
+            tool_calls.append(
+                {
+                    "id": item.get("call_id") or item.get("id") or _short_id("call"),
+                    "type": "function",
+                    "function": {
+                        "name": item.get("name") or "",
+                        "arguments": item.get("arguments") or "{}",
+                    },
+                }
+            )
+
+    if tool_calls:
+        finish_reason = "tool_calls"
+
+    message: dict[str, Any] = {"role": "assistant", "content": "".join(text_parts) or None}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
+    usage_in = resp.get("usage") or {}
+    usage_out = {
+        "prompt_tokens": usage_in.get("input_tokens", 0),
+        "completion_tokens": usage_in.get("output_tokens", 0),
+        "total_tokens": usage_in.get("total_tokens")
+        or (usage_in.get("input_tokens", 0) + usage_in.get("output_tokens", 0)),
+    }
+
+    return {
+        "id": resp.get("id") or _short_id("chatcmpl"),
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": finish_reason,
+            }
+        ],
+        "usage": usage_out,
+    }
+
+
+# ---------- response: responses SSE stream -> chat completions SSE stream ----------
+
+
+async def stream_responses_to_chat(
+    sse_events: AsyncIterator[dict], *, model: str
+) -> AsyncIterator[bytes]:
+    """Translate a stream of Responses SSE event dicts into Chat Completions SSE bytes."""
+    chunk_id = _short_id("chatcmpl")
+    created = int(time.time())
+    role_sent = False
+    tool_call_index_by_item: dict[str, int] = {}
+    next_tool_index = 0
+    finish_reason = "stop"
+    final_usage: dict | None = None
+
+    def chunk(delta: dict, finish: str | None = None) -> bytes:
+        body = {
+            "id": chunk_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": delta,
+                    "finish_reason": finish,
+                }
+            ],
+        }
+        return f"data: {json.dumps(body)}\n\n".encode()
+
+    async for ev in sse_events:
+        et = ev.get("type")
+
+        if et == "response.output_text.delta":
+            if not role_sent:
+                yield chunk({"role": "assistant", "content": ""})
+                role_sent = True
+            delta = ev.get("delta") or ""
+            yield chunk({"content": delta})
+
+        elif et == "response.output_item.added":
+            item = ev.get("item") or {}
+            if item.get("type") == "function_call":
+                if not role_sent:
+                    yield chunk({"role": "assistant", "content": None})
+                    role_sent = True
+                item_id = item.get("id") or item.get("call_id") or _short_id("item")
+                idx = next_tool_index
+                next_tool_index += 1
+                tool_call_index_by_item[item_id] = idx
+                finish_reason = "tool_calls"
+                yield chunk(
+                    {
+                        "tool_calls": [
+                            {
+                                "index": idx,
+                                "id": item.get("call_id")
+                                or item.get("id")
+                                or _short_id("call"),
+                                "type": "function",
+                                "function": {
+                                    "name": item.get("name") or "",
+                                    "arguments": "",
+                                },
+                            }
+                        ]
+                    }
+                )
+
+        elif et == "response.function_call_arguments.delta":
+            item_id = ev.get("item_id") or ""
+            idx = tool_call_index_by_item.get(item_id, 0)
+            yield chunk(
+                {
+                    "tool_calls": [
+                        {
+                            "index": idx,
+                            "function": {"arguments": ev.get("delta") or ""},
+                        }
+                    ]
+                }
+            )
+
+        elif et == "response.completed":
+            resp = ev.get("response") or {}
+            usage_in = resp.get("usage") or {}
+            final_usage = {
+                "prompt_tokens": usage_in.get("input_tokens", 0),
+                "completion_tokens": usage_in.get("output_tokens", 0),
+                "total_tokens": usage_in.get("total_tokens")
+                or (
+                    usage_in.get("input_tokens", 0) + usage_in.get("output_tokens", 0)
+                ),
+            }
+
+        elif et in ("response.failed", "response.error", "error"):
+            err = ev.get("response", {}).get("error") or ev.get("error") or {"message": "stream error"}
+            payload = {"error": {"message": err.get("message", "stream error"), "type": err.get("type", "server_error")}}
+            yield f"data: {json.dumps(payload)}\n\n".encode()
+            yield b"data: [DONE]\n\n"
+            return
+
+    final_chunk: dict = {
+        "id": chunk_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
+    }
+    if final_usage is not None:
+        final_chunk["usage"] = final_usage
+    yield f"data: {json.dumps(final_chunk)}\n\n".encode()
+    yield b"data: [DONE]\n\n"
+
+
+def _short_id(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:24]}"

--- a/strix/subscription/preflight.py
+++ b/strix/subscription/preflight.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-import json
-import logging
 import os
 import shutil
 import subprocess
-from datetime import UTC, datetime
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from strix.subscription._ui import fail
@@ -21,8 +17,6 @@ from strix.subscription.codex.auth import borrow_codex_key
 if TYPE_CHECKING:
     from rich.console import Console
 
-
-logger = logging.getLogger(__name__)
 
 _CLAUDE_WAKE_TIMEOUT_SECONDS = 60
 
@@ -39,9 +33,6 @@ def claude_preflight(console: Console) -> None:
             "Claude subscription auth failed",
             f"{exc}\n\nLog in with the `claude` CLI, or set CLAUDE_CODE_OAUTH_TOKEN.",
         )
-    status = _claude_token_expiry_status()
-    if status:
-        logger.info("%s", status)
 
 
 def codex_preflight(console: Console) -> None:
@@ -85,38 +76,3 @@ def _wake_claude_cli(console: Console) -> None:
             "Claude CLI preflight failed",
             f"`claude` exited with code {result.returncode}.",
         )
-
-
-def _claude_token_expiry_status() -> str | None:
-    expires_at_ms = _read_claude_expires_at()
-    if expires_at_ms is None:
-        return None
-    expiry = datetime.fromtimestamp(expires_at_ms / 1000, tz=UTC).astimezone()
-    remaining = max(0, int((expiry - datetime.now(tz=UTC)).total_seconds()))
-    return f"Claude token expires in {_format_duration(remaining)} at {expiry:%Y-%m-%d %H:%M:%S}"
-
-
-def _read_claude_expires_at() -> int | None:
-    config_dir = Path(os.environ.get("CLAUDE_CONFIG_DIR", "~/.claude")).expanduser()
-    try:
-        data = json.loads((config_dir / ".credentials.json").read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    oauth = data.get("claudeAiOauth")
-    if not isinstance(oauth, dict):
-        return None
-    expires_at = oauth.get("expiresAt")
-    return expires_at if isinstance(expires_at, int) else None
-
-
-def _format_duration(total_seconds: int) -> str:
-    minutes, _ = divmod(total_seconds, 60)
-    hours, minutes = divmod(minutes, 60)
-    days, hours = divmod(hours, 24)
-    parts: list[str] = []
-    if days:
-        parts.append(f"{days}d")
-    if hours or days:
-        parts.append(f"{hours}h")
-    parts.append(f"{minutes}m")
-    return " ".join(parts)

--- a/strix/subscription/preflight.py
+++ b/strix/subscription/preflight.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import os
-import shutil
-import subprocess
 from typing import TYPE_CHECKING
 
 from strix.subscription._ui import fail
@@ -18,13 +15,8 @@ if TYPE_CHECKING:
     from rich.console import Console
 
 
-_CLAUDE_WAKE_TIMEOUT_SECONDS = 60
-
-
 def claude_preflight(console: Console) -> None:
     """Ensure a Claude Code subscription token is usable before the proxy starts."""
-    if not _has_claude_env_token() and shutil.which("claude") is not None:
-        _wake_claude_cli(console)
     try:
         borrow_claude_key()
     except ClaudeBorrowKeyError as exc:
@@ -44,35 +36,4 @@ def codex_preflight(console: Console) -> None:
             console,
             "Codex subscription auth failed",
             f"{exc}\n\nLog in with the `codex` CLI and pick the ChatGPT option.",
-        )
-
-
-def _has_claude_env_token() -> bool:
-    token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
-    return bool(token and token.strip())
-
-
-def _wake_claude_cli(console: Console) -> None:
-    """Nudge the Claude CLI so it refreshes its on-disk token if needed."""
-    try:
-        result = subprocess.run(
-            ["claude", "-p", "just print 'working'"],
-            capture_output=True,
-            text=True,
-            timeout=_CLAUDE_WAKE_TIMEOUT_SECONDS,
-            check=False,
-        )
-    except FileNotFoundError:
-        return
-    except subprocess.TimeoutExpired:
-        fail(
-            console,
-            "Claude CLI preflight timed out",
-            f"`claude` did not respond within {_CLAUDE_WAKE_TIMEOUT_SECONDS}s.",
-        )
-    if result.returncode != 0:
-        fail(
-            console,
-            "Claude CLI preflight failed",
-            f"`claude` exited with code {result.returncode}.",
         )

--- a/strix/subscription/preflight.py
+++ b/strix/subscription/preflight.py
@@ -1,0 +1,122 @@
+"""Pre-flight subscription auth checks, run before the proxy starts."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from strix.subscription._ui import fail
+from strix.subscription.claude.auth import BorrowKeyError as ClaudeBorrowKeyError
+from strix.subscription.claude.auth import borrow_claude_key
+from strix.subscription.codex.auth import BorrowKeyError as CodexBorrowKeyError
+from strix.subscription.codex.auth import borrow_codex_key
+
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+logger = logging.getLogger(__name__)
+
+_CLAUDE_WAKE_TIMEOUT_SECONDS = 60
+
+
+def claude_preflight(console: Console) -> None:
+    """Ensure a Claude Code subscription token is usable before the proxy starts."""
+    if not _has_claude_env_token() and shutil.which("claude") is not None:
+        _wake_claude_cli(console)
+    try:
+        borrow_claude_key()
+    except ClaudeBorrowKeyError as exc:
+        fail(
+            console,
+            "Claude subscription auth failed",
+            f"{exc}\n\nLog in with the `claude` CLI, or set CLAUDE_CODE_OAUTH_TOKEN.",
+        )
+    status = _claude_token_expiry_status()
+    if status:
+        logger.info("%s", status)
+
+
+def codex_preflight(console: Console) -> None:
+    """Ensure a ChatGPT Codex subscription token is usable before the proxy starts."""
+    try:
+        borrow_codex_key()
+    except CodexBorrowKeyError as exc:
+        fail(
+            console,
+            "Codex subscription auth failed",
+            f"{exc}\n\nLog in with the `codex` CLI and pick the ChatGPT option.",
+        )
+
+
+def _has_claude_env_token() -> bool:
+    token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
+    return bool(token and token.strip())
+
+
+def _wake_claude_cli(console: Console) -> None:
+    """Nudge the Claude CLI so it refreshes its on-disk token if needed."""
+    try:
+        result = subprocess.run(
+            ["claude", "-p", "just print 'working'"],
+            capture_output=True,
+            text=True,
+            timeout=_CLAUDE_WAKE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except FileNotFoundError:
+        return
+    except subprocess.TimeoutExpired:
+        fail(
+            console,
+            "Claude CLI preflight timed out",
+            f"`claude` did not respond within {_CLAUDE_WAKE_TIMEOUT_SECONDS}s.",
+        )
+    if result.returncode != 0:
+        fail(
+            console,
+            "Claude CLI preflight failed",
+            f"`claude` exited with code {result.returncode}.",
+        )
+
+
+def _claude_token_expiry_status() -> str | None:
+    expires_at_ms = _read_claude_expires_at()
+    if expires_at_ms is None:
+        return None
+    expiry = datetime.fromtimestamp(expires_at_ms / 1000, tz=UTC).astimezone()
+    remaining = max(0, int((expiry - datetime.now(tz=UTC)).total_seconds()))
+    return f"Claude token expires in {_format_duration(remaining)} at {expiry:%Y-%m-%d %H:%M:%S}"
+
+
+def _read_claude_expires_at() -> int | None:
+    config_dir = Path(os.environ.get("CLAUDE_CONFIG_DIR", "~/.claude")).expanduser()
+    try:
+        data = json.loads((config_dir / ".credentials.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    oauth = data.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return None
+    expires_at = oauth.get("expiresAt")
+    return expires_at if isinstance(expires_at, int) else None
+
+
+def _format_duration(total_seconds: int) -> str:
+    minutes, _ = divmod(total_seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    days, hours = divmod(hours, 24)
+    parts: list[str] = []
+    if days:
+        parts.append(f"{days}d")
+    if hours or days:
+        parts.append(f"{hours}h")
+    parts.append(f"{minutes}m")
+    return " ".join(parts)

--- a/strix/subscription/proxy.py
+++ b/strix/subscription/proxy.py
@@ -1,0 +1,77 @@
+"""Run a bundled subscription proxy app on a loopback port in a daemon thread."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import uvicorn
+
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+class ProxyStartupError(RuntimeError):
+    """Raised when the subscription proxy cannot bind or become ready."""
+
+
+class SubscriptionProxy:
+    """A uvicorn server hosting a subscription proxy app on ``127.0.0.1``.
+
+    The server runs in a daemon thread so it survives Strix's separate
+    ``asyncio.run()`` phases and never blocks interpreter exit.
+    """
+
+    def __init__(self, app: Any, *, host: str = "127.0.0.1") -> None:
+        self._host = host
+        self._port: int | None = None
+        config = uvicorn.Config(
+            app,
+            host=host,
+            port=0,
+            log_level="warning",
+            access_log=False,
+            loop="asyncio",
+        )
+        self._server = uvicorn.Server(config)
+        self._thread = threading.Thread(
+            target=self._server.run,
+            name="strix-subscription-proxy",
+            daemon=True,
+        )
+
+    @property
+    def base_url(self) -> str:
+        """Loopback base URL (with the ``/v1`` suffix) once the proxy is running."""
+        return f"http://{self._host}:{self._require_port()}/v1"
+
+    def start(self, *, timeout: float = 15.0) -> None:
+        """Launch the proxy thread and block until it is bound and ready."""
+        self._thread.start()
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._server.started and self._server.servers:
+                self._port = self._read_bound_port()
+                return
+            if not self._thread.is_alive():
+                raise ProxyStartupError("subscription proxy thread exited during startup")
+            time.sleep(0.05)
+        self.stop()
+        raise ProxyStartupError(f"subscription proxy was not ready within {timeout:.0f}s")
+
+    def stop(self, *, timeout: float = 5.0) -> None:
+        """Signal the server to exit and join its thread."""
+        self._server.should_exit = True
+        if self._thread.is_alive():
+            self._thread.join(timeout=timeout)
+
+    def _require_port(self) -> int:
+        if self._port is None:
+            raise ProxyStartupError("subscription proxy port requested before start()")
+        return self._port
+
+    def _read_bound_port(self) -> int:
+        sock = self._server.servers[0].sockets[0]
+        return int(sock.getsockname()[1])

--- a/strix/subscription/registry.py
+++ b/strix/subscription/registry.py
@@ -1,0 +1,54 @@
+"""Registry of subscription backends available through ``strix --sub``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from strix.subscription.preflight import claude_preflight, codex_preflight
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from rich.console import Console
+
+
+@dataclass(frozen=True)
+class SubscriptionBackend:
+    """A subscription-backed LLM provider exposed through ``strix --sub``."""
+
+    name: str
+    default_model: str
+    build_app: Callable[[], Any]
+    preflight: Callable[[Console], None]
+
+
+def _claude_app() -> Any:
+    from strix.subscription.claude.server import app
+
+    return app
+
+
+def _codex_app() -> Any:
+    from strix.subscription.codex.server import app
+
+    return app
+
+
+BACKENDS: dict[str, SubscriptionBackend] = {
+    "claude": SubscriptionBackend(
+        name="claude",
+        default_model="anthropic/claude-sonnet-4-6",
+        build_app=_claude_app,
+        preflight=claude_preflight,
+    ),
+    "codex": SubscriptionBackend(
+        name="codex",
+        default_model="openai/gpt-5.4",
+        build_app=_codex_app,
+        preflight=codex_preflight,
+    ),
+}
+
+SUB_CHOICES: list[str] = list(BACKENDS)

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -1,0 +1,40 @@
+"""Tests for the ``strix --sub`` subscription wiring."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from strix.subscription.bringup import _wire_env
+from strix.subscription.registry import BACKENDS, SUB_CHOICES
+
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_sub_choices_match_implemented_backends() -> None:
+    assert SUB_CHOICES == ["claude", "codex"]
+    assert BACKENDS["claude"].default_model == "anthropic/claude-sonnet-4-6"
+    assert BACKENDS["codex"].default_model == "openai/gpt-5.4"
+
+
+def test_wire_env_fills_defaults_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("STRIX_LLM", "LLM_API_BASE", "LLM_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+    _wire_env("claude", "anthropic/claude-sonnet-4-6", "http://127.0.0.1:9999/v1")
+
+    assert os.environ["STRIX_LLM"] == "anthropic/claude-sonnet-4-6"
+    assert os.environ["LLM_API_BASE"] == "http://127.0.0.1:9999/v1"
+    assert os.environ["LLM_API_KEY"]
+
+
+def test_wire_env_preserves_user_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIX_LLM", "anthropic/claude-sonnet-4-6")
+    monkeypatch.delenv("LLM_API_BASE", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+
+    _wire_env("claude", "anthropic/claude-opus-4-8", "http://127.0.0.1:9999/v1")
+
+    assert os.environ["STRIX_LLM"] == "anthropic/claude-sonnet-4-6"

--- a/uv.lock
+++ b/uv.lock
@@ -459,6 +459,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.138.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c9/5e8defe249899c0dc900643695fc07829a67fc88b4ff2cdb03fcbdbf5a4b/fastapi-0.138.1.tar.gz", hash = "sha256:96e3702dce09ee0dce48856135620d3d865ca684a79fe7513fd7b13a12f82862", size = 419646, upload-time = "2026-06-25T15:40:42.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/a9/69a6924f645eb4dd8cd625bf255b3625990eb3e14e073438a53c405dcd3e/fastapi-0.138.1-py3-none-any.whl", hash = "sha256:b994cae7ba8b82c976a728b544244de31333fa5f7d261f9a1dffe526444cae23", size = 129182, upload-time = "2026-06-25T15:40:40.771Z" },
+]
+
+[[package]]
 name = "fastuuid"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2088,12 +2104,15 @@ dependencies = [
     { name = "caido-sdk-client" },
     { name = "cvss" },
     { name = "docker" },
+    { name = "fastapi" },
+    { name = "httpx" },
     { name = "openai-agents", extra = ["litellm"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "requests" },
     { name = "rich" },
     { name = "textual" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -2113,12 +2132,15 @@ requires-dist = [
     { name = "caido-sdk-client", specifier = ">=0.2.0" },
     { name = "cvss", specifier = ">=3.2" },
     { name = "docker", specifier = ">=7.1.0" },
+    { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "openai-agents", extras = ["litellm"], specifier = "==0.14.6" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "pydantic-settings", specifier = ">=2.13.0" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "rich" },
     { name = "textual", specifier = ">=6.0.0" },
+    { name = "uvicorn", specifier = ">=0.32" },
 ]
 
 [package.metadata.requires-dev]
@@ -2305,8 +2327,8 @@ name = "uvicorn"
 version = "0.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform != 'emscripten'" },
-    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/81/a083ae41716b00df56d45d4b5f6ca8e90fc233a62e6c04ab3ad3c476b6c4/uvicorn-0.33.0.tar.gz", hash = "sha256:3577119f82b7091cf4d3d4177bfda0bae4723ed92ab1439e8d779de880c9cc59", size = 76590, upload-time = "2024-12-14T11:14:46.526Z" }
 wheels = [


### PR DESCRIPTION
## Description
Strix already talks to any OpenAI-/Anthropic-compatible endpoint through LiteLLM, so this
bundles a small local proxy and wires it up automatically
- `strix --sub [codex|claude]` auto-starts it on loopback and wires STRIX_LLM/LLM_API_BASE/LLM_API_KEY, so a subscription can be used instead of a pay-per-use API key.
- No persisted config after you finish/stop scanning. Nothing is saved or changed in `~/.strix/cli-config.json`
- Defaults: claude → `anthropic/claude-sonnet-4-6`, codex → `openai/gpt-5.4`. Set `STRIX_LLM`
  yourself to override. 
- Proxy modules are vendored under `strix/subscription/` 

## Changes
- New `backends` slot-in via a small registry, to make space for additional providers :)

## Verified
- full `pytest` green with new subscription wiring tests.