### PR TITLE
feat: add STRIX_DISABLE_FIX_AGENTS to skip dedicated fix subagents

### DIFF
--- a/strix/agents/prompt.py
+++ b/strix/agents/prompt.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
+from strix.config import load_settings
 from strix.skills import get_available_skills, load_skills
 from strix.utils.resource_paths import get_strix_resource_path
 
@@ -15,6 +16,16 @@ logger = logging.getLogger(__name__)
 
 
 _PROMPT_DIRNAME = "prompts"
+
+# Appended to the root coordinator's skill when STRIX_DISABLE_FIX_AGENTS is
+# set, overriding the "Fix agent provides remediation" delegation step.
+_DISABLE_FIX_AGENTS_DIRECTIVE = (
+    "\n\n## Fix Agents Disabled\n\n"
+    "Do NOT spawn dedicated fix or remediation subagents. Remediation is "
+    "captured inline in each report's `remediation_steps` field, which is "
+    "sufficient. A separate agent that only writes fixes wastes tokens and "
+    "concurrency, so skip that delegation step entirely."
+)
 
 
 def _resolve_skills(
@@ -85,6 +96,12 @@ def render_system_prompt(
             is_root=is_root,
         )
         skill_content = load_skills(skills_to_load)
+        if (
+            is_root
+            and "root_agent" in skill_content
+            and load_settings().agents.disable_fix_agents
+        ):
+            skill_content["root_agent"] += _DISABLE_FIX_AGENTS_DIRECTIVE
         env.globals["get_skill"] = lambda name: skill_content.get(name, "")
 
         rendered = env.get_template("system_prompt.jinja").render(

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -54,6 +54,15 @@ class RuntimeSettings(BaseSettings):
     max_local_copy_mb: int = Field(default=1024, alias="STRIX_MAX_LOCAL_COPY_MB")
 
 
+class AgentSettings(BaseSettings):
+    model_config = _BASE_CONFIG
+
+    # When true, the root coordinator is instructed not to spawn dedicated
+    # fix/remediation subagents; remediation still lands in each report's
+    # ``remediation_steps``. Off by default (no behavior change for others).
+    disable_fix_agents: bool = Field(default=False, alias="STRIX_DISABLE_FIX_AGENTS")
+
+
 class TelemetrySettings(BaseSettings):
     model_config = _BASE_CONFIG
 
@@ -71,5 +80,6 @@ class Settings(BaseSettings):
 
     llm: LlmSettings = Field(default_factory=LlmSettings)
     runtime: RuntimeSettings = Field(default_factory=RuntimeSettings)
+    agents: AgentSettings = Field(default_factory=AgentSettings)
     telemetry: TelemetrySettings = Field(default_factory=TelemetrySettings)
     integrations: IntegrationSettings = Field(default_factory=IntegrationSettings)


### PR DESCRIPTION
## What

Adds an opt-in env flag, `STRIX_DISABLE_FIX_AGENTS` (default `false`), that tells the root coordinator **not** to spawn dedicated fix/remediation subagents.

## Why

On large scans the coordinator routinely spawns a separate "… Fixing Agent" per confirmed finding (per the `coordination/root_agent` delegation guidance). For cost-conscious runs that just want findings + reports, those extra agents mostly burn tokens and concurrency: remediation is already required and captured inline in each report's `remediation_steps`, and the sandbox copy is ephemeral, so a dedicated fix agent adds little to the assessment itself.

## How

- New `AgentSettings.disable_fix_agents` (`STRIX_DISABLE_FIX_AGENTS`).
- When set, a short directive is appended to the **root agent's** prompt only, overriding the "Fix agent provides remediation" delegation step.
- **Off by default** — no behavior change for existing users. The shipped skill file and all child prompts are untouched.

## Notes
- This is a prompt-level directive (soft constraint), not a tool-level block. It reliably suppresses the dedicated fix-agent step without the brittleness of name-matching spawned agents. Happy to add hard enforcement at the spawn tool if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)