### PR TITLE
fix: prevent long scans from hanging or dying on fd exhaustion

### DIFF
--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from agents import set_default_openai_api, set_default_openai_key, set_tracing_disabled
 from agents.models.multi_provider import MultiProvider
@@ -75,6 +75,37 @@ def configure_sdk_model_defaults(settings: Settings) -> None:
         set_default_openai_api("chat_completions")
     else:
         set_default_openai_api("responses")
+    _configure_openai_client_timeout(llm)
+
+
+def _configure_openai_client_timeout(llm: Any) -> None:
+    """Install a default AsyncOpenAI client whose read timeout is bounded.
+
+    Models on the ``openai/`` prefix (e.g. ``openai/gpt-5.5`` against a
+    custom ``api_base``) go through the SDK's OpenAI provider, NOT
+    litellm — so ``litellm.request_timeout`` does not apply to them. The
+    OpenAI SDK's default timeout is 600s, and as a *read* timeout that
+    means a stalled stream (server stops sending bytes without closing
+    the socket) parks the agent for 10 minutes — surfaced in the TUI as
+    an agent stuck at "Starting agent...".
+
+    Passing a float ``timeout`` makes the underlying httpx read timeout an
+    *idle* timeout: it resets on every received chunk, so a healthy long
+    generation is never cut off, but a truly stalled stream raises after
+    ``LLM_TIMEOUT`` seconds and the SDK retry policy recovers the agent.
+
+    The client carries the key/base_url because ``set_default_openai_client``
+    takes precedence over ``set_default_openai_key``.
+    """
+    if not llm.api_key or llm.timeout <= 0:
+        return
+    from agents import set_default_openai_client
+    from openai import AsyncOpenAI
+
+    client_kwargs: dict[str, Any] = {"api_key": llm.api_key, "timeout": float(llm.timeout)}
+    if llm.api_base:
+        client_kwargs["base_url"] = llm.api_base
+    set_default_openai_client(AsyncOpenAI(**client_kwargs), use_for_tracing=False)
 
 
 def _mirror_api_key_to_provider_env(model_name: str | None, api_key: str) -> None:

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -737,8 +737,35 @@ def pull_docker_image() -> None:
     console.print()
 
 
+def _raise_open_files_limit() -> None:
+    """Raise the soft RLIMIT_NOFILE toward the hard limit.
+
+    A long multi-agent scan accumulates file descriptors (litellm httpx
+    pools, docker socket polling, per-subagent resources). On macOS the
+    default soft limit is just 256, which a long scan blows past and then
+    dies with ``OSError: [Errno 24] Too many open files`` — surfacing at
+    whatever random fd-opening call happens to lose the race. Bumping the
+    soft limit to the hard limit removes that ceiling. Not available on
+    Windows, where ``resource`` is absent.
+    """
+    try:
+        import resource
+    except ImportError:
+        return
+
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    target = hard if hard != resource.RLIM_INFINITY else 1_048_576
+    if soft >= target:
+        return
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
+    except (ValueError, OSError):
+        logger.debug("Could not raise RLIMIT_NOFILE from %s to %s", soft, target, exc_info=True)
+
+
 def main() -> None:
     configure_dependency_logging()
+    _raise_open_files_limit()
 
     if sys.platform == "win32":
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
## Problem

Two independent failure modes show up on long-running multi-agent scans:

### 1. `OSError: [Errno 24] Too many open files`
A long scan steadily accumulates file descriptors (httpx connection pools, docker socket polling via `container.reload()`, per-subagent sessions). The process never raises its soft `RLIMIT_NOFILE`, so on macOS — where the default soft limit is **256** — a long scan eventually blows past the ceiling and crashes at whatever fd-opening call happens to lose the race. The traceback location is effectively random, which makes it look like a mysterious hang.

### 2. Agents stuck at "Starting agent…"
`LLM_TIMEOUT` was only ever applied to the startup warm-up call, never to the actual agent-loop LLM calls. Models on the `openai/` prefix go through the SDK's OpenAI provider, whose `AsyncOpenAI` client defaults to a **600s** timeout. Because httpx treats that as a *read* timeout, a stalled stream parks the agent for up to 10 minutes — surfaced in the TUI as an agent stuck at "Starting agent…".

## Fix

1. **`_raise_open_files_limit()`** at startup raises the soft `RLIMIT_NOFILE` toward the hard limit (best-effort; no-op on Windows / when already high).
2. **`_configure_openai_client_timeout()`** installs a default `AsyncOpenAI` client whose timeout is bounded by `LLM_TIMEOUT`. As an httpx *read* (idle) timeout it resets on every received chunk, so healthy long generations are never cut off, but a truly stalled stream raises after `LLM_TIMEOUT` and the existing retry policy recovers the agent.

Both changes are conservative and default-safe (`LLM_TIMEOUT` already defaults to 300s). The OpenAI-client fix is verified end-to-end against a custom `api_base`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)