### PR TITLE
Recompute Content-Length when repeat_request replaces body

### DIFF
--- a/strix/tools/proxy/caido_api.py
+++ b/strix/tools/proxy/caido_api.py
@@ -157,7 +157,7 @@ def build_raw_request(
     final_headers = {**headers}
     final_headers.setdefault("Host", parsed.netloc)
     final_headers.setdefault("User-Agent", "strix")
-    if body and "Content-Length" not in {k.title() for k in final_headers}:
+    if body is not None and "Content-Length" not in {k.title() for k in final_headers}:
         final_headers["Content-Length"] = str(len(body.encode("utf-8")))
 
     lines = [f"{method.upper()} {path} HTTP/1.1"]

--- a/strix/tools/proxy/caido_api.py
+++ b/strix/tools/proxy/caido_api.py
@@ -261,6 +261,12 @@ def apply_modifications(
         headers.update(modifications["headers"])
     if "body" in modifications:
         body = modifications["body"]
+        explicit_content_length = "Content-Length" in {
+            k.title() for k in modifications.get("headers", {})
+        }
+        if not explicit_content_length:
+            for key in [k for k in headers if k.title() == "Content-Length"]:
+                del headers[key]
     if "cookies" in modifications:
         cookies: dict[str, str] = {}
         if headers.get("Cookie"):

--- a/tests/test_caido_api.py
+++ b/tests/test_caido_api.py
@@ -60,3 +60,20 @@ def test_build_raw_request_recomputes_content_length_after_replacement() -> None
     )
     head = raw.decode("utf-8").split("\r\n\r\n", 1)[0]
     assert f"Content-Length: {len(new_body.encode('utf-8'))}" in head
+
+
+def test_build_raw_request_sets_content_length_zero_for_empty_body() -> None:
+    components = _components(body="old")
+    modified = apply_modifications(
+        components,
+        {"body": ""},
+        "http://example.com/submit",
+    )
+    _, raw = build_raw_request(
+        method=modified["method"],
+        url=modified["url"],
+        headers=modified["headers"],
+        body=modified["body"],
+    )
+    head = raw.decode("utf-8").split("\r\n\r\n", 1)[0]
+    assert "Content-Length: 0" in head

--- a/tests/test_caido_api.py
+++ b/tests/test_caido_api.py
@@ -1,0 +1,62 @@
+"""Tests for request modification in the Caido proxy integration."""
+
+from __future__ import annotations
+
+from strix.tools.proxy.caido_api import apply_modifications, build_raw_request
+
+
+def _components(body: str = "old", headers: dict[str, str] | None = None) -> dict:
+    return {
+        "method": "POST",
+        "url_path": "/submit",
+        "headers": headers or {"Content-Length": str(len(body))},
+        "body": body,
+    }
+
+
+def test_apply_modifications_drops_stale_content_length_on_body_replace() -> None:
+    components = _components(body="old")
+    result = apply_modifications(
+        components,
+        {"body": "a much longer replacement body than the original"},
+        "http://example.com/submit",
+    )
+    assert "Content-Length" not in {k.title() for k in result["headers"]}
+
+
+def test_apply_modifications_keeps_explicit_content_length_on_body_replace() -> None:
+    components = _components(body="old")
+    result = apply_modifications(
+        components,
+        {"body": "new-body", "headers": {"Content-Length": "8"}},
+        "http://example.com/submit",
+    )
+    assert result["headers"]["Content-Length"] == "8"
+
+
+def test_apply_modifications_without_body_change_keeps_headers() -> None:
+    components = _components(body="old")
+    result = apply_modifications(
+        components,
+        {"headers": {"X-Test": "1"}},
+        "http://example.com/submit",
+    )
+    assert result["headers"]["Content-Length"] == "3"
+
+
+def test_build_raw_request_recomputes_content_length_after_replacement() -> None:
+    components = _components(body="old")
+    new_body = "a much longer replacement body than the original"
+    modified = apply_modifications(
+        components,
+        {"body": new_body},
+        "http://example.com/submit",
+    )
+    _, raw = build_raw_request(
+        method=modified["method"],
+        url=modified["url"],
+        headers=modified["headers"],
+        body=modified["body"],
+    )
+    head = raw.decode("utf-8").split("\r\n\r\n", 1)[0]
+    assert f"Content-Length: {len(new_body.encode('utf-8'))}" in head


### PR DESCRIPTION
## Summary
- `apply_modifications()` in `strix/tools/proxy/caido_api.py` replaced the request body via `modifications={"body": ...}` but left the original `Content-Length` header untouched.
- `build_raw_request()` only computes `Content-Length` when the header is absent, so the stale, smaller value from the original request was sent alongside the new, larger body.
- A target server reading exactly `Content-Length` bytes truncates the replayed body (or stalls), silently dropping the modified/injected payload — defeating parameter-tampering / injection replays, which is the core use case of `repeat_request`, and producing misleading negative results.

## Fix
When `modifications["body"]` is present, drop any existing `Content-Length` header from the carried-over headers (matched case-insensitively), unless the caller explicitly supplies `Content-Length` in that same call's `modifications["headers"]`. This lets `build_raw_request`'s existing "fill in if absent" logic recompute the correct length from the new body.

## Test plan
- [x] Added `tests/test_caido_api.py`: stale header dropped on body replacement, explicit caller-supplied `Content-Length` respected, headers untouched when body isn't modified, and an end-to-end check that `build_raw_request` emits the recomputed length in the raw HTTP request.
- [x] Verified RED on unmodified code (reproduces the exact stale `Content-Length: 3` scenario from the bug report), then GREEN after the fix.
- [x] Full test suite (`uv run pytest tests/`) has no new failures.
- [x] `ruff check` and `mypy` clean on changed files.

Resolves #603