### PR TITLE
fix: report cost for streamed OpenRouter calls

### DIFF
--- a/docs/usage/cli.mdx
+++ b/docs/usage/cli.mdx
@@ -73,6 +73,11 @@ strix --target <target> [options]
     concurrently).
   - Cost is a best-effort estimate derived from token usage and model pricing;
     providers that do not expose priced usage may under-count.
+  - For LiteLLM-routed models, Strix enables streaming success callbacks to
+    capture provider-reported cost. Message content remains excluded, but
+    third-party LiteLLM callbacks configured in the same process can receive
+    other streaming metadata such as model names, request IDs, and token
+    counts.
 </ParamField>
 
 ## Examples

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -97,13 +97,15 @@ def _mirror_api_key_to_provider_env(model_name: str | None, api_key: str) -> Non
 
 
 def _configure_litellm_compatibility() -> None:
-    """Enable LiteLLM's permissive param handling and disable its callbacks."""
+    """Apply LiteLLM compatibility, privacy, and callback settings."""
     import litellm
 
     litellm.drop_params = True
     litellm.modify_params = True
     litellm.turn_off_message_logging = True
-    litellm.disable_streaming_logging = True
+    # Strix uses LiteLLM's success callback to capture provider-reported cost.
+    # Disabling streaming logging also disables that callback for streamed calls.
+    litellm.disable_streaming_logging = False
     litellm.suppress_debug_info = True
 
     _register_litellm_cost_callback()

--- a/strix/report/state.py
+++ b/strix/report/state.py
@@ -3,7 +3,7 @@ import logging
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, cast
 from uuid import uuid4
 
 from agents.usage import Usage
@@ -382,6 +382,18 @@ def litellm_cost_callback(
                 value = None
             if value is not None and value > 0:
                 cost = value
+
+    if cost is None:
+        usage: Any = getattr(completion_response, "usage", None)
+        if usage is None and isinstance(completion_response, dict):
+            usage = cast("dict[str, Any]", completion_response).get("usage")
+        usage_cost: Any
+        if isinstance(usage, dict):
+            usage_cost = cast("dict[str, Any]", usage).get("cost")
+        else:
+            usage_cost = getattr(usage, "cost", None)
+        if isinstance(usage_cost, int | float) and usage_cost > 0:
+            cost = float(usage_cost)
 
     if cost is None or cost <= 0:
         return

--- a/tests/test_cost_tracking.py
+++ b/tests/test_cost_tracking.py
@@ -1,0 +1,44 @@
+"""Tests for provider-reported LLM cost capture."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import litellm
+
+from strix.config.models import _configure_litellm_compatibility
+from strix.report.state import litellm_cost_callback
+
+
+def test_streaming_logging_stays_enabled_for_cost_callback() -> None:
+    with (
+        patch.object(litellm, "disable_streaming_logging", new=True),
+        patch("strix.config.models._register_litellm_cost_callback") as register,
+    ):
+        _configure_litellm_compatibility()
+        assert litellm.disable_streaming_logging is False
+        register.assert_called_once_with()
+
+
+def test_cost_callback_reads_openrouter_stream_usage_cost() -> None:
+    report_state = MagicMock()
+    response = SimpleNamespace(
+        usage=SimpleNamespace(cost=1.2345),
+        _hidden_params={},
+    )
+
+    with patch("strix.report.state.get_global_report_state", return_value=report_state):
+        litellm_cost_callback({"response_cost": None}, response)
+
+    report_state.record_observed_llm_cost.assert_called_once_with(1.2345)
+
+
+def test_cost_callback_reads_usage_cost_from_mapping_response() -> None:
+    report_state = MagicMock()
+    response = {"usage": {"cost": 0.125}}
+
+    with patch("strix.report.state.get_global_report_state", return_value=report_state):
+        litellm_cost_callback({}, response)
+
+    report_state.record_observed_llm_cost.assert_called_once_with(0.125)


### PR DESCRIPTION
## Summary

- keep LiteLLM streaming success callbacks enabled so Strix receives observed request costs
- capture OpenRouter's provider-reported `usage.cost` from the final streamed response
- add regression coverage for streamed object and mapping response shapes

## Root cause

Strix registered a LiteLLM success callback for routed-model costs, but also set `disable_streaming_logging = True`. LiteLLM uses that switch to skip success callbacks for streamed calls, which is the path used by the Agents SDK. Routed models intentionally skip Strix's local cost estimation, so no callback meant the displayed total remained `$0.0000`.

OpenRouter returns authoritative cost data in `usage.cost` on the final SSE chunk. The callback now uses that value when LiteLLM has no derived or header-based cost, which also covers models newer than LiteLLM's local pricing map.

Closes #619.

## Validation

- `pytest -q tests/test_cost_tracking.py` - 3 passed
- full suite excluding two Windows-incompatible tests - 60 passed, 1 skipped, 2 deselected
- Ruff format and lint - passed on changed files
- mypy - passed on changed source files
- Bandit - passed on changed source files

Current upstream `main` at `5ee3448` has an unrelated indentation error in `strix/report/writer.py:72`; the full-suite results above used a local-only correction that is not part of this PR. The two deselected tests require POSIX chmod semantics and Windows symlink privileges, respectively.