### PR TITLE
fix(notes): use retry loop for 6-char UUID to prevent collision

### DIFF
--- a/strix/tools/notes/tools.py
+++ b/strix/tools/notes/tools.py
@@ -153,10 +153,16 @@ def _create_note_impl(
                     "note_id": None,
                 }
 
-            while True:
+            for _ in range(100):
                 note_id = str(uuid.uuid4())[:6]
                 if note_id not in _notes_storage:
                     break
+            else:
+                return {
+                    "success": False,
+                    "error": "Failed to generate a unique note ID after 100 attempts",
+                    "note_id": None,
+                }
 
             timestamp = datetime.now(UTC).isoformat()
             note = {

--- a/strix/tools/notes/tools.py
+++ b/strix/tools/notes/tools.py
@@ -153,7 +153,10 @@ def _create_note_impl(
                     "note_id": None,
                 }
 
-            note_id = str(uuid.uuid4())[:6]
+            while True:
+                note_id = str(uuid.uuid4())[:6]
+                if note_id not in _notes_storage:
+                    break
 
             timestamp = datetime.now(UTC).isoformat()
             note = {


### PR DESCRIPTION
## Description
This PR fixes issue #629 where the 6-character truncated UUID used for `note_id` could silently overwrite existing notes if a collision occurred. 

As suggested in the issue (Option 1), this fix wraps the ID generation in a simple retry loop that checks `_notes_storage`. This keeps the IDs short and agent-friendly while eliminating the risk of collisions during long scans with multiple agents.

## Changes Made
- Added a `while True:` retry loop in `_create_note_impl` (`strix/tools/notes/tools.py`) to regenerate the 6-character UUID if it already exists in `_notes_storage`.

Fixes #629