### PR TITLE
Add non-mutating quality check target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Skills are specialized knowledge packages that enhance agent capabilities. See [
 2. **Fork and branch** - Work from the `main` branch
 3. **Make your changes** - Follow existing code style
 4. **Write/update tests** - Ensure coverage for new features
-5. **Run quality checks** - `make check-all` should pass
+5. **Run quality checks** - `make check` should pass
 6. **Submit PR** - Link to issue and provide context
 
 ### PR Guidelines

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev-install format lint type-check security check-all clean pre-commit setup-dev dev
+.PHONY: help install dev-install format format-check lint lint-check type-check security check check-all clean pre-commit setup-dev dev
 
 help:
 	@echo "Available commands:"
@@ -8,9 +8,12 @@ help:
 	@echo ""
 	@echo "Code Quality:"
 	@echo "  format        - Format code with ruff"
+	@echo "  format-check  - Check formatting without writing changes"
 	@echo "  lint          - Lint code with ruff"
+	@echo "  lint-check    - Lint code without writing changes"
 	@echo "  type-check    - Run type checking with mypy and pyright"
 	@echo "  security      - Run security checks with bandit"
+	@echo "  check         - Run non-mutating code quality checks"
 	@echo "  check-all     - Run all code quality checks"
 	@echo ""
 	@echo "Development:"
@@ -33,10 +36,20 @@ format:
 	uv run ruff format .
 	@echo "✅ Code formatting complete!"
 
+format-check:
+	@echo "🎨 Checking code formatting with ruff..."
+	uv run ruff format --check .
+	@echo "✅ Code formatting check complete!"
+
 lint:
 	@echo "🔍 Linting code with ruff..."
 	uv run ruff check . --fix
 	@echo "✅ Linting complete!"
+
+lint-check:
+	@echo "🔍 Checking code with ruff..."
+	uv run ruff check .
+	@echo "✅ Lint check complete!"
 
 type-check:
 	@echo "🔍 Type checking with mypy..."
@@ -49,6 +62,9 @@ security:
 	@echo "🔒 Running security checks with bandit..."
 	uv run bandit -r strix/ -c pyproject.toml
 	@echo "✅ Security checks complete!"
+
+check: format-check lint-check type-check security
+	@echo "✅ Non-mutating code quality checks passed!"
 
 check-all: format lint type-check security
 	@echo "✅ All code quality checks passed!"

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -63,7 +63,7 @@ Skills are specialized knowledge packages that enhance agent capabilities. They 
 2. **Fork and branch** — Work from `main`
 3. **Make changes** — Follow existing code style
 4. **Write tests** — Ensure coverage for new features
-5. **Run checks** — `make check-all` should pass
+5. **Run checks** — `make check` should pass
 6. **Submit PR** — Link to issue and provide context
 
 ### Code Style


### PR DESCRIPTION
## Summary
- add `format-check`, `lint-check`, and `check` Makefile targets that do not write changes
- point contributor docs at `make check` for pre-PR validation
- keep existing `make check-all` behavior unchanged for auto-fix workflows

## Validation
- `make -n check`
- `make -n check-all`
- `git diff --check`

Note: I could not run the full `make check` locally because this environment does not have `uv` or Python 3.12 installed.