### PR TITLE
Fix Bedrock/Claude startup crash from forced parallel_tool_calls (#644) + ruff lint cleanup

### DIFF
--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -164,3 +164,23 @@ def is_known_openai_bare_model(model_name: str) -> bool:
         return False
     entry = litellm.model_cost.get(name)
     return bool(entry and entry.get("litellm_provider") == "openai")
+
+
+def is_bedrock_anthropic_model(model_name: str) -> bool:
+    """Return whether the model routes to Anthropic Claude on AWS Bedrock.
+
+    For Claude on Bedrock, LiteLLM translates ``parallel_tool_calls=False`` into
+    a ``tool_choice`` object that omits the required ``type`` discriminator, so
+    Bedrock rejects the request with ``tool_choice.type: Field required`` and the
+    agent never starts. Callers use this to avoid forcing that flag on the
+    affected route (see issue #644).
+    """
+    name = model_name.strip().lower()
+    for prefix in ("litellm/", "any-llm/"):
+        if name.startswith(prefix):
+            name = name[len(prefix) :]
+            break
+    if not name.startswith("bedrock/"):
+        return False
+    return "anthropic" in name or "claude" in name
+    

--- a/strix/core/hooks.py
+++ b/strix/core/hooks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import TYPE_CHECKING, Any
 
 from agents.lifecycle import RunHooks
@@ -27,8 +28,9 @@ class ReportUsageHooks(RunHooks[dict[str, Any]]):
     """Persist SDK-native usage after every model response."""
 
     def __init__(self, *, model: str, max_budget_usd: float | None = None) -> None:
-        import math
-        if max_budget_usd is not None and (not math.isfinite(max_budget_usd) or max_budget_usd <= 0):
+        if max_budget_usd is not None and (
+            not math.isfinite(max_budget_usd) or max_budget_usd <= 0
+        ):
             raise ValueError("max_budget_usd must be a finite number greater than 0")
         self._model = model
         self._max_budget_usd = max_budget_usd

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any
 from agents.model_settings import ModelSettings
 from openai.types.shared import Reasoning
 
-from strix.config.models import DEFAULT_MODEL_RETRY, model_supports_reasoning
+from strix.config.models import (
+    DEFAULT_MODEL_RETRY,
+    is_bedrock_anthropic_model,
+    model_supports_reasoning,
+)
 
 
 if TYPE_CHECKING:
@@ -112,8 +116,14 @@ def make_model_settings(
     *,
     model_name: str,
 ) -> ModelSettings:
+    # Claude on Bedrock rejects a forced ``parallel_tool_calls=False`` because
+    # LiteLLM turns it into a ``tool_choice`` without the required ``type`` field
+    # ("tool_choice.type: Field required"), so the agent never starts (#644).
+    # Omit the flag on that route; every other provider keeps single-tool-call
+    # behavior.
+    parallel_tool_calls = None if is_bedrock_anthropic_model(model_name) else False
     model_settings = ModelSettings(
-        parallel_tool_calls=False,
+        parallel_tool_calls=parallel_tool_calls,
         retry=DEFAULT_MODEL_RETRY,
         include_usage=True,
     )

--- a/strix/runtime/docker_client.py
+++ b/strix/runtime/docker_client.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import uuid
-from typing import Any
+from typing import Any, ClassVar
 
 from agents.sandbox.manifest import Manifest
 from agents.sandbox.sandboxes.docker import (
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 class StrixDockerSandboxClient(DockerSandboxClient):
     # Host directories to bind-mount into the container, set by the docker
     # backend before ``create()``. Each item is ``{source, target, read_only}``.
-    strix_bind_mounts: list[dict[str, Any]] = []  # overridden per-instance in backends.py
+    strix_bind_mounts: ClassVar[list[dict[str, Any]]] = []  # overridden per-instance in backends.py
 
     async def _create_container(
         self,

--- a/strix/telemetry/logging.py
+++ b/strix/telemetry/logging.py
@@ -67,7 +67,7 @@ _TRACKED_ROOTS: tuple[str, ...] = ("strix", "openai.agents")
 def configure_dependency_logging() -> None:
     """Quiet dependency logging/warnings that obscure Strix scan logs."""
     with contextlib.suppress(Exception):
-        import litellm
+        import litellm  # noqa: PLC0415
 
         litellm_logging = litellm._logging
         litellm_logging._disable_debugging()  # type: ignore[no-untyped-call]

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from strix.core.inputs import build_root_task, child_initial_input
+from strix.core.inputs import build_root_task, child_initial_input, make_model_settings
 
 
 def _child_kwargs(parent_history: list[Any]) -> dict[str, Any]:
@@ -112,3 +112,34 @@ def test_build_root_task_diff_scope() -> None:
     assert "Scope Constraints:" in task
     assert "3 changed file(s)" in task
     assert "2 deleted file(s)" in task
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "litellm/bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "any-llm/bedrock/converse/us.anthropic.claude-opus-4-5-v1:0",
+    ],
+)
+def test_make_model_settings_omits_parallel_flag_for_bedrock_claude(model_name: str) -> None:
+    # Regression for #644: forcing parallel_tool_calls=False makes LiteLLM emit a
+    # tool_choice without a `type`, which Bedrock rejects and the scan never starts.
+    settings = make_model_settings(None, model_name=model_name)
+
+    assert settings.parallel_tool_calls is None
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "openai/gpt-5.4",
+        "anthropic/claude-sonnet-4-6",  # direct Anthropic API, not Bedrock
+        "bedrock/meta.llama3-1-70b-instruct-v1:0",  # non-Claude Bedrock model
+        "vertex_ai/gemini-3-pro-preview",
+    ],
+)
+def test_make_model_settings_forces_single_tool_call_elsewhere(model_name: str) -> None:
+    settings = make_model_settings(None, model_name=model_name)
+
+    assert settings.parallel_tool_calls is False


### PR DESCRIPTION
## Summary

This PR contains two changes:

### 1. Fix Bedrock/Claude failing to start with `tool_choice.type: Field required` — fixes #644

`make_model_settings()` forced `parallel_tool_calls=False` for every model. For
Anthropic Claude on AWS Bedrock, LiteLLM translates that flag into a `tool_choice`
object that omits the required `type` discriminator, so Bedrock rejects the very
first request with `tool_choice.type: Field required` and the agent never starts.

**Fix:** a new `is_bedrock_anthropic_model()` predicate in `strix/config/models.py`;
`make_model_settings()` now omits the flag (passes `None`) only on the Bedrock-Claude
route, so LiteLLM builds no `tool_choice` at all. Every other provider keeps the
existing single-tool-call behavior.

Added regression tests in `tests/test_inputs.py` covering the Bedrock-Claude route
(including `litellm/` and `any-llm/` prefixes) and the unchanged behavior for OpenAI,
direct Anthropic, non-Claude Bedrock, and Vertex.

### 2. Resolve ruff lint violations (PLC0415 / RUF012)

- `strix/core/hooks.py` — moved `import math` to module top-level (PLC0415).
- `strix/runtime/docker_client.py` — annotated the `strix_bind_mounts` class default
  as `ClassVar` (RUF012).
- `strix/telemetry/logging.py` — added `# noqa: PLC0415` to the deliberately-lazy
  `import litellm` inside `contextlib.suppress` (moving it would change behavior).

## Testing

- `uv run pytest tests/test_inputs.py tests/test_hooks.py` — passes
- `uv run ruff check strix/ tests/` — passes

## Note

This bundles two logical changes. Happy to split #644 and the lint cleanup into
separate PRs if you'd prefer.