### PR TITLE
fix: skip Unix permission test on Windows (#648)

### DIFF
--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -199,6 +200,7 @@ def test_persist_current_writes_env_block(tmp_path: Path, monkeypatch: pytest.Mo
     }
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Unix file permissions not supported on Windows")
 def test_persist_current_sets_0600_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("STRIX_LLM", "persisted-model")
     target = tmp_path / "cli-config.json"


### PR DESCRIPTION
## Summary
Skips `test_persist_current_sets_0600_mode` on Windows because Unix file permissions (`0o600`) are not supported on Windows.

## Problem
On Windows, `target.stat().st_mode & 0o777` returns `33206` (regular file), causing the assertion `== 0o600` to fail. This blocks Windows contributors from running the test suite cleanly.

## Fix
Added `@pytest.mark.skipif(os.name == 'nt', ...)` decorator to skip this test on Windows.

## Testing
- [x] `uv run pytest tests/test_config_loader.py::test_persist_current_sets_0600_mode -v` -> `SKIPPED` on Windows
- [x] `make check-all` (ruff, mypy, pre-commit) passes

Fixes #648