### PR TITLE
fix(tests): skip symlink test gracefully when creation is unavailable on Windows

### DIFF
--- a/tests/test_local_sources.py
+++ b/tests/test_local_sources.py
@@ -47,7 +47,12 @@ def test_directory_size_sums_flat_and_nested_files(tmp_path: Path) -> None:
 
 def test_directory_size_skips_symlinks(tmp_path: Path) -> None:
     _write_file(tmp_path / "real.txt", 100)
-    (tmp_path / "link.txt").symlink_to(tmp_path / "real.txt")
+    try:
+        (tmp_path / "link.txt").symlink_to(tmp_path / "real.txt")
+    except OSError:
+        pytest.skip(
+            "symlink creation unavailable; on Windows run as Administrator or enable Developer Mode"
+        )
     # The symlink target is counted once via the real file, not doubled.
     assert directory_size_bytes(tmp_path) == 100
 


### PR DESCRIPTION
## Problem

`test_directory_size_skips_symlinks` in `tests/test_local_sources.py` crashes on Windows for standard users (non-Administrator, Developer Mode off) because `Path.symlink_to()` raises `OSError: [WinError 1314] A required privilege is not held by the client`.

Fixes #650

## Fix

Wrap the symlink creation in a `try/except OSError` and call `pytest.skip()` if it fails. This is better than a blanket `skipif(sys.platform == "win32")` because the test still runs on Windows when symlinks are available (Developer Mode enabled or running as Administrator), and skips cleanly only when they are not.

## Changes

`tests/test_local_sources.py`: 5-line change — wrap `symlink_to()` in try/except, skip with an explanatory message on failure.

## Before / After

Before: test crashes with `OSError: [WinError 1314]` on Windows standard users, blocking the entire test suite.

After: test skips with `"symlink creation unavailable; on Windows run as Administrator or enable Developer Mode"` and the suite continues.
