### PR TITLE
fix(report): keep ReDoS distinct from generic DoS in SARIF class hash

### DIFF
--- a/strix/report/sarif.py
+++ b/strix/report/sarif.py
@@ -716,8 +716,12 @@ _VULN_CLASS_KEYWORDS = (
     "insecure random",
     "tls verification",
     "certificate verification",
-    "denial of service",
+    # "regex denial of service" MUST precede "denial of service": it is the
+    # more specific class and "denial of service" is a substring of it, so
+    # (first-match-wins) the generic entry would otherwise shadow it and
+    # collapse ReDoS findings into the generic DoS class hash.
     "regex denial of service",
+    "denial of service",
     "redos",
     "supply chain",
 )

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
-from strix.report.sarif import write_sarif
+from strix.report.sarif import _class_keyword, write_sarif
 
 
 if TYPE_CHECKING:
@@ -176,6 +176,43 @@ def test_write_sarif_adds_logical_location_for_endpoint(tmp_path: Path) -> None:
         if entry.get("kind") == "endpoint"
     ]
     assert logical == [{"fullyQualifiedName": "GET /api/users/{id}", "kind": "endpoint"}]
+
+
+def test_class_keyword_prefers_specific_regex_dos_over_generic_dos() -> None:
+    # "regex denial of service" is the more specific class and *contains* the
+    # substring "denial of service"; first-match-wins keyword selection must
+    # return the specific class rather than let the generic entry shadow it.
+    assert _class_keyword("Regex Denial of Service in email validator") == "regex denial of service"
+    # A genuinely generic DoS finding still resolves to the generic class.
+    assert _class_keyword("Denial of Service via unbounded upload") == "denial of service"
+
+
+def test_write_sarif_regex_dos_not_merged_into_generic_dos(tmp_path: Path) -> None:
+    # Two locationless findings on the same CWE are separated only by their
+    # vuln-class keyword (the synth_class component of the primary fingerprint).
+    # If ReDoS is misclassified as generic DoS the two collapse to one
+    # fingerprint and a SARIF consumer silently dedups a real finding away.
+    write_sarif(
+        tmp_path,
+        [
+            _finding(
+                id="vuln-redos",
+                title="Regex Denial of Service in email validator",
+                cwe="CWE-400",
+                code_locations=None,
+            ),
+            _finding(
+                id="vuln-dos",
+                title="Denial of Service via unbounded upload",
+                cwe="CWE-400",
+                code_locations=None,
+            ),
+        ],
+    )
+    results = _read(tmp_path)["runs"][0]["results"]
+    assert len(results) == 2
+    fingerprints = {r["partialFingerprints"]["primaryLocationLineHash"] for r in results}
+    assert len(fingerprints) == 2
 
 
 def test_write_sarif_synthetic_finding_falls_back_to_resource_logical_location(


### PR DESCRIPTION
Closes #669

## What

`_class_keyword` (in `strix/report/sarif.py`) scans `_VULN_CLASS_KEYWORDS` in order and returns the **first** substring match. The comment above the list documents the resulting invariant:

> Order matters — first match wins, so precise terms come before fuzzy ones … a future maintainer adding sloppy entries could collapse distinct findings to the same class hash.

But `"denial of service"` was listed **before** `"regex denial of service"`. Since `"denial of service"` is a substring of `"regex denial of service"`, any finding titled `"…Regex Denial of Service…"` matched the generic entry first and resolved to class `"denial of service"` — the exact "collapse distinct findings" failure the comment warns against.

## Why it matters

For locationless findings (anchored synthetically to `SECURITY.md`), the class keyword is the **only** differentiator in `_primary_fingerprint` — it's appended as the `synth_class:` component. So a **ReDoS** finding and a **generic DoS** finding on the same CWE end up with the *same* `partialFingerprints.primaryLocationLineHash`. A SARIF consumer such as GitHub code-scanning keys alert identity on `partialFingerprints`, so one of the two genuine findings gets silently deduplicated away.

## Fix

Reorder so `"regex denial of service"` precedes `"denial of service"` (with a comment explaining why the order is load-bearing). One-line data change — no logic change.

I also audited the rest of `_VULN_CLASS_KEYWORDS` for the same substring-shadowing hazard; this was the only violation (e.g. `"rate limiting"` is already correctly ordered before `"rate limit"`).

## Tests

Added two regression tests to `tests/test_sarif.py`:

- `test_class_keyword_prefers_specific_regex_dos_over_generic_dos` — unit-level: the specific class is returned, and a genuine generic DoS still maps to `"denial of service"`.
- `test_write_sarif_regex_dos_not_merged_into_generic_dos` — end-to-end: two locationless same-CWE findings (ReDoS + generic DoS) get **distinct** fingerprints.

Verified RED→GREEN: with the reorder reverted, the end-to-end test fails with `assert 1 == 2` (both findings collapse to a single fingerprint); with the fix it passes. Full suite: `82 passed` (the 2 pre-existing Windows-only failures in `test_config_loader`/`test_local_sources` are unrelated to this change). `ruff format`, `ruff check`, and `mypy strix/report/sarif.py` all clean.
