### PR TITLE
fix(core): ensure tool_choice maps to structured object for AWS Bedrock compliance

### DIFF
--- a/strix/core/execution.py
+++ b/strix/core/execution.py
@@ -354,7 +354,7 @@ async def _run_cycle(  # noqa: PLR0912, PLR0915
             if hasattr(run_config, "extra_body") and isinstance(run_config.extra_body, dict):
                 if "tool_choice" in run_config.extra_body:
                     run_config.extra_body["tool_choice"] = {"type": "auto"}
-            elif hasattr(run_config, "tool_choice") and (run_config.tool_choice == "auto" or isinstance(run_config.tool_choice, str)):
+            if hasattr(run_config, "tool_choice") and (run_config.tool_choice == "auto" or isinstance(run_config.tool_choice, str)):
                 run_config.tool_choice = {"type": "auto"}
             # -------------------------------------------------------------
 

--- a/strix/core/execution.py
+++ b/strix/core/execution.py
@@ -349,6 +349,15 @@ async def _run_cycle(  # noqa: PLR0912, PLR0915
     while True:
         try:
             await coordinator.mark_running(agent_id)
+
+            # --- PRODUCTION FIX FOR AWS BEDROCK TOOL_CHOICE COMPLIANCE ---
+            if hasattr(run_config, "extra_body") and isinstance(run_config.extra_body, dict):
+                if "tool_choice" in run_config.extra_body:
+                    run_config.extra_body["tool_choice"] = {"type": "auto"}
+            elif hasattr(run_config, "tool_choice") and (run_config.tool_choice == "auto" or isinstance(run_config.tool_choice, str)):
+                run_config.tool_choice = {"type": "auto"}
+            # -------------------------------------------------------------
+
             stream = Runner.run_streamed(
                 agent,
                 input=input_data,


### PR DESCRIPTION
### Description
Ensures that `tool_choice` is formatted as a structured object (`{"type": "auto"}`) rather than a raw string when communicating via LiteLLM/Bedrock. This fixes an API validation failure where AWS Bedrock rejects requests with a 400 Bad Request.

### Error Log
litellm.exceptions.BadRequestError: BedrockException - {"message":"The model returned the following errors: tool_choice.type: Field required"}