### PR TITLE
fix: join root task sections with newlines

### DIFF
--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -73,7 +73,7 @@ def build_root_task(scan_config: dict[str, Any]) -> str:
             if deleted:
                 parts.append(f"- {label}: {deleted} deleted file(s) are context-only")
 
-    task = " ".join(parts)
+    task = "\n".join(parts)
     if user_instructions:
         task = f"{task}\n\nSpecial instructions: {user_instructions}"
     return task

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -93,6 +93,20 @@ def test_build_root_task_web_application_with_instructions() -> None:
     assert "Special instructions: Focus on auth." in task
 
 
+def test_build_root_task_multiple_targets_are_newline_separated() -> None:
+    config = {
+        "targets": [
+            {"type": "web_application", "details": {"target_url": "https://a.example.com"}},
+            {"type": "web_application", "details": {"target_url": "https://b.example.com"}},
+        ],
+    }
+    task = build_root_task(config)
+
+    assert "\n- https://a.example.com" in task
+    assert "\n- https://b.example.com" in task
+    assert "https://a.example.com - https://b.example.com" not in task
+
+
 def test_build_root_task_diff_scope() -> None:
     config = {
         "targets": [],


### PR DESCRIPTION
Closes #682

## What
`build_root_task()` in `strix/core/inputs.py` joined the `parts` list with a single space. Because section headers (e.g. `"\n\nURLs:"`) and per-item bullets (e.g. `"- https://a"`) are separate list elements, every bullet after a header was concatenated with spaces instead of newlines.

## Why
A scan with **more than one target** (or diff-scope constraints) rendered a run-on line in the root task prompt:

**Before**
```
URLs: - https://a.example.com - https://b.example.com
```

**After**
```
URLs:
- https://a.example.com
- https://b.example.com
```

The section headers already embed `\n\n`, and the sibling builder `child_initial_input()` in the same file joins its parts with newlines — confirming newline is the intended separator.

## Change
One line: `" ".join(parts)` → `"\n".join(parts)`.

## Tests
Added `test_build_root_task_multiple_targets_are_newline_separated`, which fails on the old space-join (both URLs collapse onto one line) and passes with the fix. Full suite green:

- `uv run pytest` → 84 passed
- `uv run ruff check` / `ruff format --check` → clean
- `uv run mypy strix/core/inputs.py` → no issues