### PR TITLE
fix(tui): remove double space after numbered-list marker

### DIFF
--- a/strix/interface/tui/renderers/agent_message_renderer.py
+++ b/strix/interface/tui/renderers/agent_message_renderer.py
@@ -104,7 +104,7 @@ def _apply_markdown_styles(text: str) -> Text:  # noqa: PLR0912
             result.append_text(_process_inline_formatting(line[2:]))
         elif len(line) > 2 and line[0].isdigit() and line[1:3] in (". ", ") "):
             result.append(line[0] + ". ", style="#22c55e")
-            result.append_text(_process_inline_formatting(line[2:]))
+            result.append_text(_process_inline_formatting(line[3:]))
         elif line.strip() in ("---", "***", "___"):
             result.append("─" * 40, style="#22c55e")
         else:

--- a/tests/test_agent_message_renderer.py
+++ b/tests/test_agent_message_renderer.py
@@ -1,0 +1,23 @@
+"""Tests for markdown styling in the agent-message TUI renderer."""
+
+from __future__ import annotations
+
+from strix.interface.tui.renderers.agent_message_renderer import _apply_markdown_styles
+
+
+def test_numbered_list_has_single_space_after_marker() -> None:
+    result = _apply_markdown_styles("1. Hello").plain
+
+    assert result == "1. Hello"
+    assert "1.  Hello" not in result
+
+
+def test_numbered_list_paren_marker_normalized_single_space() -> None:
+    result = _apply_markdown_styles("2) World").plain
+
+    assert result == "2. World"
+    assert "2.  World" not in result
+
+
+def test_bullet_list_marker_unaffected() -> None:
+    assert _apply_markdown_styles("- Item").plain == "• Item"


### PR DESCRIPTION
Closes #684

## What
In `strix/interface/tui/renderers/agent_message_renderer.py`, `_apply_markdown_styles()` renders an ordered-list line by emitting its own `"N. "` prefix and then re-rendering the remainder starting at `line[2:]`. A numbered marker (`"1. "`) is **3** characters, so `line[2:]` still contains the marker's trailing space — producing a doubled space.

**Before**
```
1.  Hello      # two spaces
```
**After**
```
1. Hello       # one space
```

## Why
The sibling bullet branch uses `line[2:]` correctly because `"- "` is exactly 2 chars. The numbered branch needs `line[3:]` to skip the full 3-char marker.

## Change
One character: `line[2:]` → `line[3:]`, confined to the numbered-list branch. Blockquote/bullet branches are unchanged (still `line[2:]`, verified).

## Tests
Added `tests/test_agent_message_renderer.py`:
- `"1. Hello"` → `"1. Hello"` (single space)
- `"2) World"` → `"2. World"`
- bullet unaffected: `"- Item"` → `"• Item"`

These fail on the old `line[2:]` (double space) and pass with the fix. Full suite: **86 passed**; `ruff check`/`format` clean; `mypy` adds no new errors.