### PR TITLE
fix(tui): show 'more content available' for view_request over 15 lines

### DIFF
--- a/strix/interface/tui/renderers/proxy_renderer.py
+++ b/strix/interface/tui/renderers/proxy_renderer.py
@@ -191,7 +191,7 @@ class ViewRequestRenderer(BaseToolRenderer):
                         if i < len(lines) - 1:
                             text.append("\n")
 
-                    if has_more or len(lines) > 15:
+                    if has_more or len(content.split("\n")) > 15:
                         text.append("\n")
                         text.append("  ... more content available", style="dim italic")
 

--- a/tests/test_proxy_renderer.py
+++ b/tests/test_proxy_renderer.py
@@ -1,0 +1,46 @@
+"""Tests for the proxy tool TUI renderers."""
+
+from __future__ import annotations
+
+from rich.text import Text
+
+from strix.interface.tui.renderers.proxy_renderer import ViewRequestRenderer
+
+
+def _plain(static: object) -> str:
+    content = static.content  # type: ignore[attr-defined]
+    return content.plain if isinstance(content, Text) else str(content)
+
+
+def _render(content: str, *, has_more: bool) -> str:
+    tool_data = {
+        "status": "completed",
+        "result": {
+            "content": content,
+            "has_more": has_more,
+            "page": 1,
+            "total_lines": len(content.split("\n")),
+        },
+    }
+    return _plain(ViewRequestRenderer.render(tool_data))
+
+
+_MARKER = "... more content available"
+
+
+def test_more_content_hint_shown_when_over_fifteen_lines() -> None:
+    content = "\n".join(f"line{i}" for i in range(30))
+
+    assert _MARKER in _render(content, has_more=False)
+
+
+def test_no_more_content_hint_within_fifteen_lines() -> None:
+    content = "\n".join(f"line{i}" for i in range(5))
+
+    assert _MARKER not in _render(content, has_more=False)
+
+
+def test_more_content_hint_shown_when_has_more_flag_set() -> None:
+    content = "\n".join(f"line{i}" for i in range(3))
+
+    assert _MARKER in _render(content, has_more=True)


### PR DESCRIPTION
Closes #685

## What
In `strix/interface/tui/renderers/proxy_renderer.py`, `ViewRequestRenderer.render()` slices content to 15 lines and then guards the truncation hint with a condition that can never be true:

```python
lines = content.split("\n")[:15]
...
if has_more or len(lines) > 15:   # len(lines) is at most 15 after the slice
    ...
    text.append("  ... more content available", ...)
```

Because `lines` is already capped at 15, `len(lines) > 15` is always `False`. When a result has **more than 15 lines** but `has_more` is falsy, the first 15 are shown and the rest are dropped **with no "more content available" indicator** — the reader thinks they saw everything.

## Why
The sibling `RepeatRequestRenderer.render()` in the same file measures the **original** line count correctly:

```python
if body_truncated or len(body.split("\n")) > 5:
```

## Change
Measure the original content length: `len(lines) > 15` → `len(content.split("\n")) > 15`. One expression, confined to `ViewRequestRenderer.render`.

## Tests
Added `tests/test_proxy_renderer.py`:
- 30-line content, `has_more=False` → hint **shown** (fails on old code, passes with fix)
- 5-line content → hint not shown
- `has_more=True` → hint shown

Full suite: **86 passed**; `ruff check`/`format` clean; `mypy` clean on the new test.