### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -35,6 +35,7 @@
               "llm-providers/openai",
               "llm-providers/anthropic",
               "llm-providers/openrouter",
+              "llm-providers/astraflow",
               "llm-providers/vertex",
               "llm-providers/bedrock",
               "llm-providers/azure",

--- a/docs/llm-providers/astraflow.mdx
+++ b/docs/llm-providers/astraflow.mdx
@@ -1,0 +1,57 @@
+---
+title: "Astraflow"
+description: "Configure Strix with Astraflow models"
+---
+
+[Astraflow](https://astraflow.ucloud-global.com) by UCloud is an OpenAI-compatible AI model aggregation platform supporting 200+ models.
+
+## Setup
+
+### Global Endpoint
+
+```bash
+export STRIX_LLM="gpt-5.4"
+export LLM_API_KEY="your-astraflow-api-key"
+export LLM_API_BASE="https://api-us-ca.umodelverse.ai/v1"
+```
+
+### China Endpoint
+
+```bash
+export STRIX_LLM="gpt-5.4"
+export LLM_API_KEY="your-astraflow-api-key"
+export LLM_API_BASE="https://api.modelverse.cn/v1"
+```
+
+## Available Models
+
+Astraflow provides access to 200+ models from multiple providers. Use standard model names:
+
+| Model | Configuration |
+|-------|---------------|
+| GPT-5.4 | `gpt-5.4` |
+| Claude Sonnet 4.6 | `claude-sonnet-4.6` |
+| Gemini 3 Pro | `gemini-3-pro-preview` |
+| GLM-4.7 | `glm-4.7` |
+| DeepSeek V3 | `deepseek-chat` |
+
+## Get API Key
+
+### Global
+
+1. Go to [astraflow.ucloud-global.com](https://astraflow.ucloud-global.com)
+2. Sign up and navigate to API Keys
+3. Create a new API key
+
+### China
+
+1. Go to [astraflow.ucloud.cn](https://astraflow.ucloud.cn)
+2. Sign up and navigate to API Keys
+3. Create a new API key
+
+## Benefits
+
+- **200+ models** — Access models from OpenAI, Anthropic, Google, Meta, DeepSeek, and more
+- **OpenAI-compatible** — Drop-in replacement for OpenAI API
+- **Global & China endpoints** — Choose the endpoint closest to your location
+- **Cost-effective** — Competitive pricing across all models

--- a/docs/llm-providers/astraflow.mdx
+++ b/docs/llm-providers/astraflow.mdx
@@ -10,7 +10,7 @@ description: "Configure Strix with Astraflow models"
 ### Global Endpoint
 
 ```bash
-export STRIX_LLM="gpt-5.4"
+export STRIX_LLM="openai/gpt-5.4"
 export LLM_API_KEY="your-astraflow-api-key"
 export LLM_API_BASE="https://api-us-ca.umodelverse.ai/v1"
 ```
@@ -18,7 +18,7 @@ export LLM_API_BASE="https://api-us-ca.umodelverse.ai/v1"
 ### China Endpoint
 
 ```bash
-export STRIX_LLM="gpt-5.4"
+export STRIX_LLM="openai/gpt-5.4"
 export LLM_API_KEY="your-astraflow-api-key"
 export LLM_API_BASE="https://api.modelverse.cn/v1"
 ```
@@ -29,11 +29,11 @@ Astraflow provides access to 200+ models from multiple providers. Use standard m
 
 | Model | Configuration |
 |-------|---------------|
-| GPT-5.4 | `gpt-5.4` |
-| Claude Sonnet 4.6 | `claude-sonnet-4.6` |
-| Gemini 3 Pro | `gemini-3-pro-preview` |
-| GLM-4.7 | `glm-4.7` |
-| DeepSeek V3 | `deepseek-chat` |
+| GPT-5.4 | `openai/gpt-5.4` |
+| Claude Sonnet 4.6 | `openai/claude-sonnet-4.6` |
+| Gemini 3 Pro | `openai/gemini-3-pro-preview` |
+| GLM-4.7 | `openai/glm-4.7` |
+| DeepSeek V3 | `openai/deepseek-chat` |
 
 ## Get API Key
 

--- a/docs/llm-providers/overview.mdx
+++ b/docs/llm-providers/overview.mdx
@@ -43,6 +43,9 @@ See the [Local Models guide](/llm-providers/local) for setup instructions and re
   <Card title="OpenRouter" href="/llm-providers/openrouter">
     Access 100+ models through a single API.
   </Card>
+  <Card title="Astraflow" href="/llm-providers/astraflow">
+    200+ models via UCloud (global & China).
+  </Card>
   <Card title="Google Vertex AI" href="/llm-providers/vertex">
     Gemini 3 models via Google Cloud.
   </Card>


### PR DESCRIPTION
## Summary

Adds Astraflow (by UCloud) as a supported LLM provider to Strix documentation.

## Changes

- Added Astraflow provider documentation (`docs/llm-providers/astraflow.mdx`)
- Added Astraflow card to provider overview page
- Added Astraflow to navigation in `docs.json`

## About Astraflow

Astraflow is an OpenAI-compatible AI model aggregation platform by UCloud supporting 200+ models. It provides both global and China endpoints:

- **Global endpoint**: `https://api-us-ca.umodelverse.ai/v1`
- **China endpoint**: `https://api.modelverse.cn/v1`
- **Website**: https://astraflow.ucloud-global.com (global) / https://astraflow.ucloud.cn (China)

Since Astraflow is OpenAI-compatible, it works through Strix's existing LiteLLM integration without requiring code changes—users just need to configure the base URL and API key.