### PR TITLE
fix(logging): keep verbose openai.agents DEBUG off sandbox stdout

### DIFF
--- a/strix/telemetry/logging.py
+++ b/strix/telemetry/logging.py
@@ -122,10 +122,17 @@ def setup_scan_logging(run_dir: Path, *, debug: bool | None = None) -> Callable[
     setattr(stream_handler, _HANDLER_TAG, True)
 
     tracked_loggers = [logging.getLogger(name) for name in _TRACKED_ROOTS]
-    for tracked in tracked_loggers:
+    for name, tracked in zip(_TRACKED_ROOTS, tracked_loggers):
         tracked.setLevel(logging.DEBUG)
         tracked.addHandler(file_handler)
-        tracked.addHandler(stream_handler)
+        # The openai-agents SDK emits one DEBUG record per span / function-call
+        # / reasoning-item. Routing that to stdout -- which Docker's json-file
+        # driver captures without rotation -- can grow the sandbox container log
+        # to tens of GB and exhaust the host disk on long runs. Keep its verbose
+        # DEBUG in the per-scan strix.log file only; stdout stays on Strix's own
+        # logger.
+        if name != "openai.agents":
+            tracked.addHandler(stream_handler)
         tracked.propagate = False
 
     for name in _NOISY_LIBS:

--- a/strix/telemetry/logging.py
+++ b/strix/telemetry/logging.py
@@ -63,6 +63,18 @@ _HANDLER_TAG = "_strix_scan_handler"
 # ``openai.agents`` is the openai-agents SDK's canonical logger root.
 _TRACKED_ROOTS: tuple[str, ...] = ("strix", "openai.agents")
 
+_STDOUT_QUIET_ROOTS: frozenset[str] = frozenset({"openai.agents"})
+
+
+class _StdoutQuietFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno >= logging.WARNING:
+            return True
+        return not any(
+            record.name == root or record.name.startswith(root + ".")
+            for root in _STDOUT_QUIET_ROOTS
+        )
+
 
 def configure_dependency_logging() -> None:
     """Quiet dependency logging/warnings that obscure Strix scan logs."""
@@ -119,20 +131,14 @@ def setup_scan_logging(run_dir: Path, *, debug: bool | None = None) -> Callable[
     stream_handler.setLevel(logging.DEBUG if debug else logging.ERROR)
     stream_handler.setFormatter(formatter)
     stream_handler.addFilter(context_filter)
+    stream_handler.addFilter(_StdoutQuietFilter())
     setattr(stream_handler, _HANDLER_TAG, True)
 
     tracked_loggers = [logging.getLogger(name) for name in _TRACKED_ROOTS]
-    for name, tracked in zip(_TRACKED_ROOTS, tracked_loggers):
+    for tracked in tracked_loggers:
         tracked.setLevel(logging.DEBUG)
         tracked.addHandler(file_handler)
-        # The openai-agents SDK emits one DEBUG record per span / function-call
-        # / reasoning-item. Routing that to stdout -- which Docker's json-file
-        # driver captures without rotation -- can grow the sandbox container log
-        # to tens of GB and exhaust the host disk on long runs. Keep its verbose
-        # DEBUG in the per-scan strix.log file only; stdout stays on Strix's own
-        # logger.
-        if name != "openai.agents":
-            tracked.addHandler(stream_handler)
+        tracked.addHandler(stream_handler)
         tracked.propagate = False
 
     for name in _NOISY_LIBS:


### PR DESCRIPTION
## What
Keep the very verbose `openai.agents` SDK DEBUG output in the per-scan `strix.log` file only, and stop routing it to **stdout**.

## Why
`openai.agents` is in `_TRACKED_ROOTS` and `setup_scan_logging` attaches both the file handler and the stdout stream handler to it at DEBUG. The SDK logs one DEBUG record per span / function-call / reasoning-item. The sandbox runs in Docker with the default `json-file` driver (no rotation), so stdout accumulates without bound — on a long run the container log grew to **80 GB+** and filled the host disk (details in #703).

## Change
In `setup_scan_logging`, attach the stdout `stream_handler` to every tracked root **except** `openai.agents`. Its DEBUG stays in `strix.log` (bounded per-scan file); the `strix` logger keeps stdout. Minimal and behavior-preserving for Strix's own logs. Does not address the separate fd-leak (`Errno 24`) noted in the issue.

Fixes #703
