### PR TITLE
Fix environment variable precedence and alias resolution in config loader

### DIFF
--- a/strix/config/loader.py
+++ b/strix/config/loader.py
@@ -108,16 +108,29 @@ def _read_json_overrides(path: Path) -> dict[str, dict[str, Any]]:
     env_block_upper = {str(k).upper(): v for k, v in env_block.items()}
 
     nested: dict[str, dict[str, Any]] = {}
+    
+    # Pre-build a case-insensitive lookup set of all environment variable keys
+    env_keys_upper = {str(k).upper() for k in os.environ}
+
     for sub_name, sub_finfo in Settings.model_fields.items():
         sub_cls = sub_finfo.annotation
         if not (isinstance(sub_cls, type) and issubclass(sub_cls, BaseModel)):
             continue
         sub_data: dict[str, Any] = {}
         for fname, finfo in sub_cls.model_fields.items():
-            for alias in _aliases_for(finfo):
+            # Check if ANY of the aliases for this field are present in the environment (case-insensitively)
+            aliases = _aliases_for(finfo)
+            env_override_present = False
+            for alias in aliases:
+                if alias.upper() in env_keys_upper:
+                    env_override_present = True
+                    break
+            
+            if env_override_present:
+                continue  # env wins; skip JSON for this field
+
+            for alias in aliases:
                 key = alias.upper()
-                if key in os.environ:
-                    break  # env wins; skip JSON for this field
                 if key in env_block_upper:
                     sub_data[fname] = env_block_upper[key]
                     break

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -89,6 +89,28 @@ def test_read_json_overrides_skips_keys_already_in_environ(
     assert loader._read_json_overrides(path) == {}
 
 
+def test_read_json_overrides_respects_later_alias_in_environ(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # api_key maps to Aliases choices (LLM_API_KEY, OPENAI_API_KEY)
+    # If a later alias is in the env but an earlier alias is in the file, env should still win.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+    path = tmp_path / "cli-config.json"
+    path.write_text(json.dumps({"env": {"LLM_API_KEY": "sk-file"}}), encoding="utf-8")
+    overrides = loader._read_json_overrides(path)
+    # The 'api_key' field (which uses LLM_API_KEY / OPENAI_API_KEY) should not be overridden by the file.
+    assert "llm" not in overrides or "api_key" not in overrides["llm"]
+
+
+def test_read_json_overrides_respects_case_insensitive_environ(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("strix_llm", "from-env-lower")
+    path = tmp_path / "cli-config.json"
+    path.write_text(json.dumps({"env": {"STRIX_LLM": "from-file"}}), encoding="utf-8")
+    assert loader._read_json_overrides(path) == {}
+
+
 # --------------------------------------------------------------------------- #
 # _aliases_for
 # --------------------------------------------------------------------------- #

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -99,7 +99,7 @@ def test_read_json_overrides_respects_later_alias_in_environ(
     path.write_text(json.dumps({"env": {"LLM_API_KEY": "sk-file"}}), encoding="utf-8")
     overrides = loader._read_json_overrides(path)
     # The 'api_key' field (which uses LLM_API_KEY / OPENAI_API_KEY) should not be overridden by the file.
-    assert "llm" not in overrides or "api_key" not in overrides["llm"]
+    assert overrides == {}
 
 
 def test_read_json_overrides_respects_case_insensitive_environ(


### PR DESCRIPTION
Fixes #688. Modifies the JSON override check to check all potential aliases case-insensitively against environment variables before applying any saved JSON configuration. This guarantees that env vars correctly win over local persisted config files (e.g., when OPENAI_API_KEY is exported but LLM_API_KEY is saved on disk).