### PR TITLE
fix(providers): show vertex extra hint for wrapped import errors

### DIFF
--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -62,7 +62,7 @@ BEDROCK_EXTRA_HINT = (
     'Bedrock support is optional. Install it with: pipx install "strix-agent[bedrock]"'
 )
 VERTEX_MODEL_MARKER = "vertex"
-VERTEX_MISSING_MODULE_ERROR = "No module named 'google'"
+VERTEX_MISSING_MODULE_ERROR = "No module named 'google"
 VERTEX_EXTRA_HINT = (
     'Vertex AI support is optional. Install it with: pipx install "strix-agent[vertex]"'
 )
@@ -225,11 +225,19 @@ def check_docker_installed() -> None:
 
 
 def _exception_messages(exc: BaseException) -> tuple[str, ...]:
-    messages = [str(exc)]
-    if exc.__cause__ is not None:
-        messages.append(str(exc.__cause__))
-    if exc.__context__ is not None:
-        messages.append(str(exc.__context__))
+    messages: list[str] = []
+    seen: set[int] = set()
+    stack: list[BaseException] = [exc]
+    while stack:
+        current = stack.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        messages.append(str(current))
+        if current.__cause__ is not None:
+            stack.append(current.__cause__)
+        if current.__context__ is not None:
+            stack.append(current.__context__)
     return tuple(messages)
 
 

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -56,6 +56,16 @@ from strix.telemetry.logging import configure_dependency_logging
 
 
 HOST_GATEWAY_HOSTNAME = "host.docker.internal"
+BEDROCK_MODEL_PREFIX = "bedrock/"
+BEDROCK_MISSING_MODULE_ERROR = "No module named 'boto3'"
+BEDROCK_EXTRA_HINT = (
+    'Bedrock support is optional. Install it with: pipx install "strix-agent[bedrock]"'
+)
+VERTEX_MODEL_MARKER = "vertex"
+VERTEX_MISSING_MODULE_ERROR = "No module named 'google'"
+VERTEX_EXTRA_HINT = (
+    'Vertex AI support is optional. Install it with: pipx install "strix-agent[vertex]"'
+)
 
 
 import logging  # noqa: E402
@@ -214,23 +224,35 @@ def check_docker_installed() -> None:
     logger.debug("Docker CLI present")
 
 
+def _exception_messages(exc: BaseException) -> tuple[str, ...]:
+    messages = [str(exc)]
+    if exc.__cause__ is not None:
+        messages.append(str(exc.__cause__))
+    if exc.__context__ is not None:
+        messages.append(str(exc.__context__))
+    return tuple(messages)
+
+
 def _provider_import_hint(exc: BaseException, model: str) -> str | None:
     """Return an install hint when *exc* is a missing provider dependency.
 
     Bedrock and Vertex AI ship as optional extras: Bedrock needs ``boto3`` and
-    Vertex AI needs ``google-auth``. When either is absent, litellm raises an
-    ``ImportError``/``ModuleNotFoundError`` naming the missing package. Map that
-    back to the matching extra so the user knows what to install. Returns
-    ``None`` for any unrelated error.
+    Vertex AI needs ``google-auth``. When either is absent, litellm may raise an
+    ``ImportError``/``ModuleNotFoundError`` directly or wrap it in a connection
+    error. Map the missing module back to the matching extra so the user knows
+    what to install. Returns ``None`` for any unrelated error.
     """
-    if not isinstance(exc, ImportError):
-        return None
-    message = str(exc)
     model_name = model.lower()
-    if "boto3" in message and model_name.startswith("bedrock/"):
-        return 'Bedrock support is optional. Install it with: pipx install "strix-agent[bedrock]"'
-    if "google" in message and "vertex" in model_name:
-        return 'Vertex AI support is optional. Install it with: pipx install "strix-agent[vertex]"'
+    messages = _exception_messages(exc)
+    if any(
+        BEDROCK_MISSING_MODULE_ERROR in message for message in messages
+    ) and model_name.startswith(BEDROCK_MODEL_PREFIX):
+        return BEDROCK_EXTRA_HINT
+    if (
+        any(VERTEX_MISSING_MODULE_ERROR in message for message in messages)
+        and VERTEX_MODEL_MARKER in model_name
+    ):
+        return VERTEX_EXTRA_HINT
     return None
 
 

--- a/strix/interface/tui/renderers/shell_renderer.py
+++ b/strix/interface/tui/renderers/shell_renderer.py
@@ -71,7 +71,7 @@ def _truncate_line(line: str) -> str:
 
 
 def _clean_output(output: str) -> str:
-    cleaned = Text.from_ansi(output).plain.translate(_CONTROL_BYTES_TO_DROP)
+    cleaned: str = Text.from_ansi(output).plain.translate(_CONTROL_BYTES_TO_DROP)
     for pattern in STRIP_PATTERNS:
         cleaned = re.sub(pattern, "", cleaned, flags=re.MULTILINE)
 

--- a/tests/test_provider_hints.py
+++ b/tests/test_provider_hints.py
@@ -11,6 +11,7 @@ VERTEX_EXTRA_NAME = "vertex"
 BEDROCK_EXTRA_NAME = "bedrock"
 INSTALL_EXTRA_COMMAND_FRAGMENT = 'pipx install "strix-agent['
 WRAPPED_VERTEX_GOOGLE_ERROR = "litellm.APIConnectionError: No module named 'google'"
+WRAPPED_BEDROCK_BOTO3_ERROR = "litellm.APIConnectionError: No module named 'boto3'"
 
 
 def test_bedrock_boto3_hint() -> None:
@@ -35,6 +36,14 @@ def test_vertex_google_hint_for_litellm_wrapped_connection_error() -> None:
     assert hint is not None
     assert INSTALL_EXTRA_COMMAND_FRAGMENT in hint
     assert VERTEX_EXTRA_NAME in hint
+
+
+def test_bedrock_boto3_hint_for_litellm_wrapped_connection_error() -> None:
+    exc = ConnectionError(WRAPPED_BEDROCK_BOTO3_ERROR)
+    hint = _provider_import_hint(exc, BEDROCK_MODEL)
+    assert hint is not None
+    assert INSTALL_EXTRA_COMMAND_FRAGMENT in hint
+    assert BEDROCK_EXTRA_NAME in hint
 
 
 def test_non_import_error_returns_none() -> None:

--- a/tests/test_provider_hints.py
+++ b/tests/test_provider_hints.py
@@ -46,6 +46,25 @@ def test_bedrock_boto3_hint_for_litellm_wrapped_connection_error() -> None:
     assert BEDROCK_EXTRA_NAME in hint
 
 
+def test_vertex_google_submodule_hint() -> None:
+    exc = ModuleNotFoundError("No module named 'google.auth'")
+    hint = _provider_import_hint(exc, VERTEX_MODEL)
+    assert hint is not None
+    assert INSTALL_EXTRA_COMMAND_FRAGMENT in hint
+    assert VERTEX_EXTRA_NAME in hint
+
+
+def test_vertex_google_hint_for_deeply_chained_error() -> None:
+    root = ModuleNotFoundError("No module named 'google.auth'")
+    middle = RuntimeError("provider init failed")
+    middle.__cause__ = root
+    exc = ConnectionError("litellm.APIConnectionError: request failed")
+    exc.__cause__ = middle
+    hint = _provider_import_hint(exc, VERTEX_MODEL)
+    assert hint is not None
+    assert VERTEX_EXTRA_NAME in hint
+
+
 def test_non_import_error_returns_none() -> None:
     assert _provider_import_hint(ConnectionError("boom"), "bedrock/whatever") is None
 

--- a/tests/test_provider_hints.py
+++ b/tests/test_provider_hints.py
@@ -5,20 +5,36 @@ from __future__ import annotations
 from strix.interface.main import _provider_import_hint
 
 
+VERTEX_MODEL = "vertex_ai/gemini-3-pro-preview"
+BEDROCK_MODEL = "bedrock/anthropic.claude-4-5-sonnet"
+VERTEX_EXTRA_NAME = "vertex"
+BEDROCK_EXTRA_NAME = "bedrock"
+INSTALL_EXTRA_COMMAND_FRAGMENT = 'pipx install "strix-agent['
+WRAPPED_VERTEX_GOOGLE_ERROR = "litellm.APIConnectionError: No module named 'google'"
+
+
 def test_bedrock_boto3_hint() -> None:
     exc = ModuleNotFoundError("No module named 'boto3'")
-    hint = _provider_import_hint(exc, "bedrock/anthropic.claude-4-5-sonnet")
+    hint = _provider_import_hint(exc, BEDROCK_MODEL)
     assert hint is not None
-    assert 'pipx install "strix-agent[' in hint
-    assert "bedrock" in hint
+    assert INSTALL_EXTRA_COMMAND_FRAGMENT in hint
+    assert BEDROCK_EXTRA_NAME in hint
 
 
 def test_vertex_google_hint() -> None:
     exc = ImportError("No module named 'google'")
-    hint = _provider_import_hint(exc, "vertex_ai/gemini-3-pro-preview")
+    hint = _provider_import_hint(exc, VERTEX_MODEL)
     assert hint is not None
-    assert 'pipx install "strix-agent[' in hint
-    assert "vertex" in hint
+    assert INSTALL_EXTRA_COMMAND_FRAGMENT in hint
+    assert VERTEX_EXTRA_NAME in hint
+
+
+def test_vertex_google_hint_for_litellm_wrapped_connection_error() -> None:
+    exc = ConnectionError(WRAPPED_VERTEX_GOOGLE_ERROR)
+    hint = _provider_import_hint(exc, VERTEX_MODEL)
+    assert hint is not None
+    assert INSTALL_EXTRA_COMMAND_FRAGMENT in hint
+    assert VERTEX_EXTRA_NAME in hint
 
 
 def test_non_import_error_returns_none() -> None:


### PR DESCRIPTION
## Summary

Fix #701

- Detect missing Vertex optional dependencies when LiteLLM wraps the import failure in a connection error.
- Keep the hint scoped to the exact missing-module message for Vertex and Bedrock provider extras.
- Add regression coverage for the wrapped Vertex `google` import error.

## Test verification (RED -> GREEN)

- RED check with production helper reverted:
  `uv run pytest tests/test_provider_hints.py -q`
  Result: `1 failed, 4 passed`; `test_vertex_google_hint_for_litellm_wrapped_connection_error` returned `None`.

- GREEN check with fix applied:
  `uv run pytest tests/test_provider_hints.py tests/test_optional_deps.py -q`
  Result: `7 passed`.

## Additional checks

- `uv run ruff check strix/interface/main.py tests/test_provider_hints.py tests/test_optional_deps.py`
- `uv run ruff format --check strix/interface/main.py tests/test_provider_hints.py tests/test_optional_deps.py`
- `uv run mypy strix/interface/main.py`

## Notes

`uv run pyright strix/interface/main.py` still reports existing strict unknown-type issues in `strix/interface/main.py`; this patch does not add those diagnostics.

Generated by Ora Studio
Vibe coded by ousamabenyounes
