### PR TITLE
feat: add opt-in completion nudge

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,12 @@ strix --target api.your-app.com --instruction-file ./instruction.md
 
 # Force PR diff-scope against a specific base branch
 strix -n --target ./ --scan-mode quick --scope-mode diff --diff-base origin/main
+
+# Treat the first valid report as a draft and continue testing underexplored areas
+strix --completion-nudge --target https://your-app.com
 ```
+
+`--completion-nudge` gives the root agent one more pass before finalizing the scan. The first valid report becomes a draft and the interface shows `Completion nudged`. The same agent follows up on leads it found and checks remaining untested areas, using tools or subordinate agents when useful. Its next valid report completes the scan. This can be useful for smaller or weaker models, but it can increase model/tool cost and runtime.
 
 ### Headless Mode
 

--- a/docs/usage/cli.mdx
+++ b/docs/usage/cli.mdx
@@ -57,6 +57,12 @@ strix (--target <target> | --target-list <path> | --mount <path>) [options]
   Run in headless mode without TUI. Ideal for CI/CD.
 </ParamField>
 
+<ParamField path="--completion-nudge" type="boolean">
+  Before accepting the final report, continue the same root agent once to investigate promising leads it encountered but did not pursue deeply, then sweep plausible untested scope. The first valid report is treated as a draft and the interface shows `Completion nudged`; only the revised comprehensive report completes the scan.
+
+  This may increase model/tool cost and runtime. It is not a blind duplicate scan or a fixed extra model turn: the existing agent session continues and may use tools or focused subordinate agents.
+</ParamField>
+
 <ParamField path="--config" type="string">
   Path to a custom config file (JSON) to use instead of `~/.strix/cli-config.json`.
 </ParamField>
@@ -101,6 +107,9 @@ strix -n --target ./ --scan-mode quick
 
 # Force diff-scope against a specific base ref
 strix -n --target ./ --scan-mode quick --scope-mode diff --diff-base origin/main
+
+# Continue the same agent past its first valid report to test underexplored areas
+strix -n --completion-nudge --target ./app-directory
 
 # Multi-target white-box testing
 strix -t https://github.com/org/app -t https://staging.example.com

--- a/strix/core/agents.py
+++ b/strix/core/agents.py
@@ -119,6 +119,16 @@ class AgentCoordinator:
             runtime.wake.set()
         logger.info("agent.status %s=%s", agent_id, status)
         await self._maybe_snapshot()
+    async def claim_completion_nudge(self, agent_id: str) -> bool:
+        async with self._lock:
+            if agent_id not in self.metadata:
+                return False
+            if self.metadata[agent_id].get("completion_nudge_started"):
+                return False
+            self.metadata[agent_id]["completion_nudge_started"] = True
+        await self._maybe_snapshot()
+        return True
+
 
     async def send(self, target_agent_id: str, message: dict[str, Any]) -> bool:
         """Deliver a user/peer message by appending it to the target SDK session."""

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -219,6 +219,7 @@ async def run_strix_scan(
             "agent_id": root_id,
             "parent_id": None,
             "interactive": interactive,
+            "completion_nudge": bool(scan_config.get("completion_nudge", False)),
             "spawn_child_agent": spawn_child_agent,
         }
 

--- a/strix/interface/cli.py
+++ b/strix/interface/cli.py
@@ -90,6 +90,7 @@ async def run_cli(args: Any) -> None:  # noqa: PLR0915
         "diff_scope": getattr(args, "diff_scope", {"active": False}),
         "scan_mode": scan_mode,
         "non_interactive": bool(getattr(args, "non_interactive", False)),
+        "completion_nudge": bool(getattr(args, "completion_nudge", False)),
         "local_sources": getattr(args, "local_sources", None) or [],
         "scope_mode": getattr(args, "scope_mode", "auto"),
         "diff_base": getattr(args, "diff_base", None),
@@ -118,6 +119,26 @@ async def run_cli(args: Any) -> None:  # noqa: PLR0915
         console.print()
 
     report_state.vulnerability_found_callback = display_vulnerability
+    def display_completion_nudge() -> None:
+        nudge_text = Text()
+        nudge_text.append("Completion nudged", style="bold #eab308")
+        nudge_text.append("\n\n")
+        nudge_text.append(
+            "The agent is investigating underexplored areas before finalizing the report."
+        )
+        console.print(
+            Panel(
+                nudge_text,
+                title="[bold white]STRIX",
+                title_align="left",
+                border_style="#eab308",
+                padding=(1, 2),
+            )
+        )
+        console.print()
+
+    report_state.completion_nudge_callback = display_completion_nudge
+
 
     def cleanup_on_exit() -> None:
         report_state.cleanup()

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -473,6 +473,15 @@ Examples:
             "Default is interactive mode with TUI."
         ),
     )
+    parser.add_argument(
+        "--completion-nudge",
+        action="store_true",
+        help=(
+            "Before accepting the final report, nudge the agent once to investigate "
+            "promising leads and other underexplored areas."
+        ),
+    )
+
 
     parser.add_argument(
         "-m",
@@ -639,6 +648,7 @@ def _persist_run_record(args: argparse.Namespace) -> None:
         "scan_mode": args.scan_mode,
         "instruction": args.instruction,
         "non_interactive": args.non_interactive,
+        "completion_nudge": bool(getattr(args, "completion_nudge", False)),
         "local_sources": getattr(args, "local_sources", []),
         "diff_scope": getattr(args, "diff_scope", {"active": False}),
         "scope_mode": args.scope_mode,
@@ -683,6 +693,9 @@ def _load_resume_state(args: argparse.Namespace, parser: argparse.ArgumentParser
 
     if args.instruction is None:
         args.instruction = state.get("instruction")
+    args.completion_nudge = bool(
+        args.completion_nudge or state.get("completion_nudge", False)
+    )
     if state.get("local_sources"):
         args.local_sources = state.get("local_sources")
     if state.get("diff_scope"):

--- a/strix/interface/tui/app.py
+++ b/strix/interface/tui/app.py
@@ -742,6 +742,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
             "diff_scope": getattr(args, "diff_scope", {"active": False}),
             "scan_mode": getattr(args, "scan_mode", "deep"),
             "non_interactive": bool(getattr(args, "non_interactive", False)),
+            "completion_nudge": bool(getattr(args, "completion_nudge", False)),
             "local_sources": getattr(args, "local_sources", None) or [],
             "scope_mode": getattr(args, "scope_mode", "auto"),
             "diff_base": getattr(args, "diff_base", None),

--- a/strix/interface/tui/renderers/finish_renderer.py
+++ b/strix/interface/tui/renderers/finish_renderer.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from rich.text import Text
 from textual.widgets import Static
@@ -17,49 +17,57 @@ class FinishScanRenderer(BaseToolRenderer):
 
     @classmethod
     def render(cls, tool_data: dict[str, Any]) -> Static:
-        args = tool_data.get("args", {})
-
-        executive_summary = args.get("executive_summary", "")
-        methodology = args.get("methodology", "")
-        technical_analysis = args.get("technical_analysis", "")
-        recommendations = args.get("recommendations", "")
-
+        raw_result = tool_data.get("result")
+        result = cast("dict[str, Any]", raw_result) if isinstance(raw_result, dict) else None
         text = Text()
-        text.append("◆ ", style="#22c55e")
-        text.append("Penetration test completed", style="bold #22c55e")
 
-        if executive_summary:
-            text.append("\n\n")
-            text.append("Executive Summary", style=FIELD_STYLE)
+        if result is None:
+            text.append("◆ ", style="#eab308")
+            text.append("Generating final report...", style="bold #eab308")
+            render_status = "running"
+        elif result.get("completion_nudge") is True:
+            text.append("◆ ", style="#eab308")
+            text.append("Completion nudged", style="bold #eab308")
             text.append("\n")
-            text.append(executive_summary)
+            text.append(
+                "Testing continues while the agent investigates underexplored areas."
+            )
+            render_status = "completed"
+        elif result.get("success") is False:
+            text.append("◆ ", style="#ef4444")
+            text.append("Final report not accepted", style="bold #ef4444")
+            error = result.get("error")
+            if error:
+                text.append("\n")
+                text.append(str(error))
+            render_status = "error"
+        elif result.get("scan_completed") is True:
+            raw_args = tool_data.get("args", {})
+            args = cast("dict[str, Any]", raw_args) if isinstance(raw_args, dict) else {}
+            text.append("◆ ", style="#22c55e")
+            text.append("Penetration test completed", style="bold #22c55e")
 
-        if methodology:
-            text.append("\n\n")
-            text.append("Methodology", style=FIELD_STYLE)
-            text.append("\n")
-            text.append(methodology)
-
-        if technical_analysis:
-            text.append("\n\n")
-            text.append("Technical Analysis", style=FIELD_STYLE)
-            text.append("\n")
-            text.append(technical_analysis)
-
-        if recommendations:
-            text.append("\n\n")
-            text.append("Recommendations", style=FIELD_STYLE)
-            text.append("\n")
-            text.append(recommendations)
-
-        if not (executive_summary or methodology or technical_analysis or recommendations):
-            text.append("\n  ")
-            text.append("Generating final report...", style="dim")
+            fields = (
+                ("Executive Summary", args.get("executive_summary", "")),
+                ("Methodology", args.get("methodology", "")),
+                ("Technical Analysis", args.get("technical_analysis", "")),
+                ("Recommendations", args.get("recommendations", "")),
+            )
+            for heading, value in fields:
+                if value:
+                    text.append("\n\n")
+                    text.append(heading, style=FIELD_STYLE)
+                    text.append("\n")
+                    text.append(str(value))
+            render_status = "completed"
+        else:
+            text.append("◆ ", style="#eab308")
+            text.append("Generating final report...", style="bold #eab308")
+            render_status = "running"
 
         padded = Text()
         padded.append("\n\n")
         padded.append_text(text)
         padded.append("\n\n")
 
-        css_classes = cls.get_css_classes("completed")
-        return Static(padded, classes=css_classes)
+        return Static(padded, classes=cls.get_css_classes(render_status))

--- a/strix/report/state.py
+++ b/strix/report/state.py
@@ -131,6 +131,7 @@ class ReportState:
 
         self.caido_url: str | None = None
         self.vulnerability_found_callback: Callable[[dict[str, Any]], None] | None = None
+        self.completion_nudge_callback: Callable[[], None] | None = None
 
         self._sarif_repo_ctx: dict[str, Any] | None = None
         self._sarif_repo_ctx_ready: bool = False
@@ -329,6 +330,10 @@ class ReportState:
         posthog.end(self, exit_reason="finished_by_tool")
         scarf.end(self, exit_reason="finished_by_tool")
 
+    def notify_completion_nudge(self) -> None:
+        if self.completion_nudge_callback:
+            self.completion_nudge_callback()
+
     def set_scan_config(self, config: dict[str, Any]) -> None:
         self.scan_config = config
         self.run_record["status"] = "running"
@@ -344,6 +349,7 @@ class ReportState:
                 "scan_mode": config.get("scan_mode", "deep"),
                 "diff_scope": config.get("diff_scope", {"active": False}),
                 "non_interactive": bool(config.get("non_interactive", False)),
+                "completion_nudge": bool(config.get("completion_nudge", False)),
                 "local_sources": config.get("local_sources", []),
                 "scope_mode": config.get("scope_mode", "auto"),
                 "diff_base": config.get("diff_base"),

--- a/strix/tools/finish/tool.py
+++ b/strix/tools/finish/tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import Any
+from typing import Any, cast
 
 from agents import RunContextWrapper, function_tool
 
@@ -13,6 +13,36 @@ from strix.core.agents import coordinator_from_context
 
 
 logger = logging.getLogger(__name__)
+
+
+_COMPLETION_NUDGE_INSTRUCTION = (
+    "The report is a strong draft, but do not finish yet. First, identify concrete leads, "
+    "endpoints, behaviors, trust boundaries, or anomalies you already encountered but did "
+    "not investigate deeply enough, and actively test the most promising ones. Then review "
+    "the remaining scope for plausible areas you have not examined. Use tools and create "
+    "focused subordinate agents when useful, validate findings with evidence, avoid duplicate "
+    "vulnerability reports, and file every newly validated vulnerability with "
+    "create_vulnerability_report. When no worthwhile avenue remains, call finish_scan again "
+    "with a revised comprehensive report covering all prior and new findings."
+)
+
+
+def _finish_validation_errors(
+    executive_summary: str,
+    methodology: str,
+    technical_analysis: str,
+    recommendations: str,
+) -> list[str]:
+    errors: list[str] = []
+    if not executive_summary.strip():
+        errors.append("Executive summary cannot be empty")
+    if not methodology.strip():
+        errors.append("Methodology cannot be empty")
+    if not technical_analysis.strip():
+        errors.append("Technical analysis cannot be empty")
+    if not recommendations.strip():
+        errors.append("Recommendations cannot be empty")
+    return errors
 
 
 def _do_finish(
@@ -32,15 +62,12 @@ def _do_finish(
             ),
         }
 
-    errors: list[str] = []
-    if not executive_summary.strip():
-        errors.append("Executive summary cannot be empty")
-    if not methodology.strip():
-        errors.append("Methodology cannot be empty")
-    if not technical_analysis.strip():
-        errors.append("Technical analysis cannot be empty")
-    if not recommendations.strip():
-        errors.append("Recommendations cannot be empty")
+    errors = _finish_validation_errors(
+        executive_summary,
+        methodology,
+        technical_analysis,
+        recommendations,
+    )
     if errors:
         return {"success": False, "error": "Validation failed", "errors": errors}
 
@@ -146,10 +173,13 @@ async def finish_scan(
         technical_analysis: Consolidated findings + systemic themes.
         recommendations: Prioritized, actionable remediation.
     """
-    inner = ctx.context if isinstance(ctx.context, dict) else {}
+    raw_context: Any = ctx.context
+    inner = cast("dict[str, Any]", raw_context) if isinstance(raw_context, dict) else {}
     coordinator = coordinator_from_context(inner)
-    me = inner.get("agent_id")
-    parent_id = inner.get("parent_id")
+    raw_agent_id = inner.get("agent_id")
+    me = raw_agent_id if isinstance(raw_agent_id, str) else None
+    raw_parent_id = inner.get("parent_id")
+    parent_id = raw_parent_id if isinstance(raw_parent_id, str) else None
     if coordinator is not None and parent_id is None and me is not None:
         active_agents = await coordinator.active_agents_except(me)
     else:
@@ -169,6 +199,40 @@ async def finish_scan(
             ensure_ascii=False,
             default=str,
         )
+
+    validation_errors = _finish_validation_errors(
+        executive_summary,
+        methodology,
+        technical_analysis,
+        recommendations,
+    )
+    if parent_id is None and bool(inner.get("completion_nudge", False)) and not validation_errors:
+        claimed = False
+        if coordinator is not None and isinstance(me, str):
+            claimed = await coordinator.claim_completion_nudge(me)
+        elif not inner.get("completion_nudge_started"):
+            inner["completion_nudge_started"] = True
+            claimed = True
+
+        if claimed:
+            try:
+                from strix.report.state import get_global_report_state
+
+                report_state = get_global_report_state()
+                if report_state is not None:
+                    report_state.notify_completion_nudge()
+            except Exception:
+                logger.exception("finish_scan completion nudge notification failed")
+            return json.dumps(
+                {
+                    "success": True,
+                    "scan_completed": False,
+                    "completion_nudge": True,
+                    "message": _COMPLETION_NUDGE_INSTRUCTION,
+                },
+                ensure_ascii=False,
+                default=str,
+            )
 
     result = await asyncio.to_thread(
         _do_finish,

--- a/tests/test_cli_target_list.py
+++ b/tests/test_cli_target_list.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import sys
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
@@ -88,3 +89,63 @@ def test_parse_arguments_rejects_resume_with_target_list(
         "Cannot combine --resume with --target/--target-list/--mount"
         in capsys.readouterr().err
     )
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected"),
+    [([], False), (["--completion-nudge"], True)],
+)
+def test_parse_arguments_completion_nudge_flag(
+    extra_args: list[str],
+    expected: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_settings(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["strix", "--target", "https://test.example", *extra_args],
+    )
+
+    args = cli_main.parse_arguments()
+
+    assert args.completion_nudge is expected
+
+
+@pytest.mark.parametrize(
+    ("persisted", "extra_args"),
+    [(True, []), (False, ["--completion-nudge"])],
+)
+def test_parse_arguments_resume_enables_completion_nudge(
+    tmp_path: Path,
+    persisted: bool,
+    extra_args: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "run.json").write_text(
+        json.dumps(
+            {
+                "targets_info": [
+                    {
+                        "type": "web_application",
+                        "details": {"target": "https://test.example"},
+                        "original": "https://test.example",
+                    }
+                ],
+                "completion_nudge": persisted,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "agents.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli_main, "run_dir_for", lambda _run_name: tmp_path)
+    monkeypatch.setattr(cli_main, "runtime_state_dir", lambda _run_dir: tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["strix", "--resume", "existing-run", *extra_args],
+    )
+
+    args = cli_main.parse_arguments()
+
+    assert args.completion_nudge is True

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -42,3 +42,19 @@ async def test_wait_for_message_returns_immediately_after_budget_stop() -> None:
 
     # No pending messages, but the stop flag short-circuits the wait.
     await asyncio.wait_for(coordinator.wait_for_message("agent"), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_completion_nudge_claim_survives_restore() -> None:
+    coordinator = AgentCoordinator()
+    await coordinator.register("root", "strix", parent_id=None)
+
+    assert await coordinator.claim_completion_nudge("root") is True
+    assert await coordinator.claim_completion_nudge("root") is False
+
+    snapshot = await coordinator.snapshot()
+    assert snapshot["metadata"]["root"]["completion_nudge_started"] is True
+
+    restored = AgentCoordinator()
+    await restored.restore(snapshot)
+    assert await restored.claim_completion_nudge("root") is False

--- a/tests/test_finish_renderer.py
+++ b/tests/test_finish_renderer.py
@@ -1,0 +1,83 @@
+"""Tests for finish_scan TUI result states."""
+
+from __future__ import annotations
+
+from rich.text import Text
+
+from strix.interface.tui.renderers.finish_renderer import FinishScanRenderer
+
+
+def _plain(tool_data: dict[str, object]) -> str:
+    static = FinishScanRenderer.render(tool_data)
+    content = static.content
+    return content.plain if isinstance(content, Text) else str(content)
+
+
+def test_pending_finish_renders_generation_status_only() -> None:
+    rendered = _plain({"args": {"executive_summary": "Draft section"}})
+
+    assert "Generating final report..." in rendered
+    assert "Penetration test completed" not in rendered
+    assert "Draft section" not in rendered
+
+
+def test_completion_nudge_renders_continued_testing_without_draft() -> None:
+    rendered = _plain(
+        {
+            "args": {
+                "executive_summary": "Draft executive section",
+                "methodology": "Draft methodology section",
+                "technical_analysis": "Draft technical section",
+                "recommendations": "Draft recommendations section",
+            },
+            "result": {
+                "success": True,
+                "scan_completed": False,
+                "completion_nudge": True,
+            },
+        }
+    )
+
+    assert "Completion nudged" in rendered
+    assert "Testing continues" in rendered
+    assert "Penetration test completed" not in rendered
+    assert "Draft executive section" not in rendered
+    assert "Draft methodology section" not in rendered
+    assert "Draft technical section" not in rendered
+    assert "Draft recommendations section" not in rendered
+
+
+def test_failed_finish_renders_error_without_completion() -> None:
+    rendered = _plain(
+        {
+            "result": {
+                "success": False,
+                "scan_completed": False,
+                "error": "Validation failed",
+            }
+        }
+    )
+
+    assert "Final report not accepted" in rendered
+    assert "Validation failed" in rendered
+    assert "Penetration test completed" not in rendered
+
+
+def test_completed_finish_renders_accepted_sections() -> None:
+    rendered = _plain(
+        {
+            "args": {
+                "executive_summary": "Accepted executive section",
+                "methodology": "Accepted methodology section",
+                "technical_analysis": "Accepted technical section",
+                "recommendations": "Accepted recommendations section",
+            },
+            "result": {"success": True, "scan_completed": True},
+        }
+    )
+
+    assert "Penetration test completed" in rendered
+    assert "Accepted executive section" in rendered
+    assert "Accepted methodology section" in rendered
+    assert "Accepted technical section" in rendered
+    assert "Accepted recommendations section" in rendered

--- a/tests/test_finish_tool.py
+++ b/tests/test_finish_tool.py
@@ -1,0 +1,216 @@
+"""Tests for root scan completion and the opt-in completion nudge."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from agents.run_context import RunContextWrapper
+from agents.tool import FunctionToolResult
+from agents.tool_context import ToolContext
+
+from strix.agents.factory import _finish_tool_use_behavior
+from strix.core.agents import AgentCoordinator
+from strix.report.state import ReportState, set_global_report_state
+from strix.tools.finish.tool import finish_scan
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+DRAFT = {
+    "executive_summary": "Draft executive summary",
+    "methodology": "Draft methodology",
+    "technical_analysis": "Draft-only technical analysis",
+    "recommendations": "Draft recommendations",
+}
+REVISED = {
+    "executive_summary": "Revised executive summary",
+    "methodology": "Revised methodology",
+    "technical_analysis": "Revised technical analysis",
+    "recommendations": "Revised recommendations",
+}
+
+
+def _tool_context(context: dict[str, Any], payload: dict[str, str]) -> ToolContext[dict[str, Any]]:
+    arguments = json.dumps(payload)
+    return ToolContext(
+        context,
+        tool_name="finish_scan",
+        tool_call_id="finish-call",
+        tool_arguments=arguments,
+    )
+
+
+async def _invoke(context: dict[str, Any], payload: dict[str, str]) -> dict[str, Any]:
+    result = await finish_scan.on_invoke_tool(
+        _tool_context(context, payload),
+        json.dumps(payload),
+    )
+    return json.loads(result)
+
+
+def _report_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ReportState:
+    monkeypatch.setattr("strix.report.state.run_dir_for", lambda _run_name: tmp_path)
+    state = ReportState("finish-test")
+    set_global_report_state(state)
+    return state
+
+
+@pytest.mark.asyncio
+async def test_flag_disabled_completes_first_valid_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = _report_state(tmp_path, monkeypatch)
+    coordinator = AgentCoordinator()
+    await coordinator.register("root", "strix", parent_id=None)
+    context = {
+        "coordinator": coordinator,
+        "agent_id": "root",
+        "parent_id": None,
+        "completion_nudge": False,
+    }
+
+    result = await _invoke(context, DRAFT)
+
+    assert result["scan_completed"] is True
+    assert state.scan_results == {**DRAFT, "success": True, "scan_completed": True}
+    assert coordinator.statuses["root"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_enabled_nudge_then_persists_only_revised_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = _report_state(tmp_path, monkeypatch)
+    callback_count = 0
+
+    def on_nudge() -> None:
+        nonlocal callback_count
+        callback_count += 1
+
+    state.completion_nudge_callback = on_nudge
+    coordinator = AgentCoordinator()
+    await coordinator.register("root", "strix", parent_id=None)
+    context = {
+        "coordinator": coordinator,
+        "agent_id": "root",
+        "parent_id": None,
+        "completion_nudge": True,
+    }
+
+    first = await _invoke(context, DRAFT)
+
+    assert first["success"] is True
+    assert first["scan_completed"] is False
+    assert first["completion_nudge"] is True
+    assert "identify concrete leads" in first["message"]
+    assert callback_count == 1
+    assert state.scan_results is None
+    assert coordinator.statuses["root"] == "running"
+    assert not (tmp_path / "penetration_test_report.md").exists()
+
+    second = await _invoke(context, REVISED)
+
+    assert second["scan_completed"] is True
+    assert callback_count == 1
+    assert state.scan_results == {**REVISED, "success": True, "scan_completed": True}
+    assert coordinator.statuses["root"] == "completed"
+    report = (tmp_path / "penetration_test_report.md").read_text(encoding="utf-8")
+    assert "Revised technical analysis" in report
+    assert "Draft-only technical analysis" not in report
+
+
+@pytest.mark.asyncio
+async def test_invalid_first_report_does_not_consume_nudge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _report_state(tmp_path, monkeypatch)
+    coordinator = AgentCoordinator()
+    await coordinator.register("root", "strix", parent_id=None)
+    context = {
+        "coordinator": coordinator,
+        "agent_id": "root",
+        "parent_id": None,
+        "completion_nudge": True,
+    }
+
+    invalid = await _invoke(context, {**DRAFT, "executive_summary": ""})
+    assert "completion_nudge_started" not in coordinator.metadata["root"]
+    valid = await _invoke(context, DRAFT)
+
+    assert invalid == {
+        "success": False,
+        "error": "Validation failed",
+        "errors": ["Executive summary cannot be empty"],
+    }
+    assert valid["completion_nudge"] is True
+
+
+@pytest.mark.asyncio
+async def test_active_child_does_not_consume_nudge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _report_state(tmp_path, monkeypatch)
+    coordinator = AgentCoordinator()
+    await coordinator.register("root", "strix", parent_id=None)
+    await coordinator.register("child", "recon", parent_id="root")
+    context = {
+        "coordinator": coordinator,
+        "agent_id": "root",
+        "parent_id": None,
+        "completion_nudge": True,
+    }
+
+    blocked = await _invoke(context, DRAFT)
+    await coordinator.set_status("child", "completed")
+    valid = await _invoke(context, DRAFT)
+
+    assert blocked["success"] is False
+    assert blocked["scan_completed"] is False
+    assert "child agents are still active" in blocked["error"]
+    assert valid["completion_nudge"] is True
+
+
+@pytest.mark.asyncio
+async def test_context_fallback_nudges_once_then_completes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state = _report_state(tmp_path, monkeypatch)
+    context = {"parent_id": None, "completion_nudge": True}
+
+    first = await _invoke(context, DRAFT)
+    second = await _invoke(context, REVISED)
+
+    assert first["completion_nudge"] is True
+    assert context["completion_nudge_started"] is True
+    assert second["scan_completed"] is True
+    assert state.scan_results == {**REVISED, "success": True, "scan_completed": True}
+
+
+def test_completion_nudge_is_nonterminal_but_completion_is_terminal() -> None:
+    context = RunContextWrapper({"interactive": False})
+    nudge = FunctionToolResult(
+        tool=finish_scan,
+        output=json.dumps(
+            {
+                "success": True,
+                "scan_completed": False,
+                "completion_nudge": True,
+            }
+        ),
+        run_item=None,
+    )
+    completed = FunctionToolResult(
+        tool=finish_scan,
+        output=json.dumps({"success": True, "scan_completed": True}),
+        run_item=None,
+    )
+
+    nudge_result = _finish_tool_use_behavior(context, [nudge])
+    completed_result = _finish_tool_use_behavior(context, [completed])
+
+    assert nudge_result.is_final_output is False
+    assert completed_result.is_final_output is True


### PR DESCRIPTION
## Summary

`--completion-nudge` gives the root agent one more pass before it finalizes a scan.

Some models, especially OSS models like Hy3, can spot a promising lead and then finish the report before they really poke at it. With this flag, the first `finish_scan` becomes a draft. The same agent gets a single prompt to follow up on leads it found and check remaining untested areas. Its next valid report finishes the scan.

## Details

- Off by default.
- Saved in `run.json` and preserved by `--resume`.
- The coordinator records the nudge, so a resumed scan cannot receive it twice.
- The first draft is not written as the final report.
- The agent keeps its current session. It is not restarted or given a second user prompt.
- The CLI and TUI show `Completion nudged` while the scan continues.

## Tests

Added coverage for the flag, resume behavior, the one-time coordinator state, first and second `finish_scan` calls, invalid reports, active children, coordinator-less calls, and CLI/TUI rendering.

The focused feature and regression suite passed with 30 tests. Ruff and focused mypy/pyright checks also passed.

## Live run

I ran it against OWASP Juice Shop with `--completion-nudge`.

The agent submitted its first report, got the nudge, and continued in the same session. It followed up on the leads it had left open, filed one more validated finding, then completed normally with 13 findings.