### PR TITLE
Support routed OpenAI required tool choice

### DIFF
--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -24,6 +24,10 @@ DEFAULT_MAX_TURNS = 500
 
 def _accepts_required_tool_choice(model_name: str | None) -> bool:
     name = (model_name or "").strip().lower()
+    for prefix in ("litellm/", "any-llm/"):
+        if name.startswith(prefix):
+            name = name[len(prefix) :]
+            break
     return name.startswith("openai/") or is_known_openai_bare_model(name)
 
 

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -135,3 +135,23 @@ def test_make_model_settings_skips_required_tool_choice_for_non_openai_models() 
     )
 
     assert settings.tool_choice is None
+
+
+def test_make_model_settings_forces_required_for_routed_openai_model() -> None:
+    settings = make_model_settings(
+        None,
+        model_name="litellm/openai/gpt-4o",
+        force_required_tool_choice=True,
+    )
+
+    assert settings.tool_choice == "required"
+
+
+def test_make_model_settings_forces_required_for_anyllm_routed_openai_model() -> None:
+    settings = make_model_settings(
+        None,
+        model_name="any-llm/openai/gpt-4o",
+        force_required_tool_choice=True,
+    )
+
+    assert settings.tool_choice == "required"


### PR DESCRIPTION
## Summary

- Strip `litellm/` and `any-llm/` routing prefixes before checking whether required `tool_choice` is accepted.
- Add coverage for routed OpenAI model names through both LiteLLM and Any-LLM prefixes.

## Validation

- `uv run pytest tests/test_inputs.py`
- `uv run ruff check strix/core/inputs.py tests/test_inputs.py`