### PR TITLE
fix: strip chatgpt transcript tags from agent messages

### DIFF
--- a/strix/core/agents.py
+++ b/strix/core/agents.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -28,6 +29,22 @@ Status = Literal["running", "waiting", "completed", "stopped", "crashed", "faile
 # position in the tree - decides whether waiting is bounded: only an agent waiting
 # on other agents is re-checked on a timer.
 WaitKind = Literal["user", "agents", "stalled"]
+
+_CHATGPT_TRANSCRIPT_TAGS = (
+    "analysis",
+    "assistant",
+    "channel",
+    "final",
+    "user",
+)
+_CHATGPT_TRANSCRIPT_TAG_RE = re.compile(
+    rf"</?(?:{'|'.join(_CHATGPT_TRANSCRIPT_TAGS)})\s*>",
+    flags=re.IGNORECASE,
+)
+
+
+def _strip_chatgpt_transcript_tags(content: str) -> str:
+    return _CHATGPT_TRANSCRIPT_TAG_RE.sub("", content)
 
 
 @dataclass(slots=True)
@@ -372,7 +389,7 @@ class AgentCoordinator:
         await self._maybe_snapshot()
 
     async def cancel_descendants(self, agent_id: str) -> None:
-        tasks = []
+        tasks: list[asyncio.Task[Any]] = []
         async with self._lock:
             for aid in reversed(self._subtree_order_locked(agent_id)):
                 task = self.runtimes.get(aid, AgentRuntime()).task
@@ -437,7 +454,7 @@ class AgentCoordinator:
 
     def _message_to_session_item(self, message: dict[str, Any]) -> TResponseInputItem:
         sender = str(message.get("from", "unknown"))
-        content = str(message.get("content", ""))
+        content = _strip_chatgpt_transcript_tags(str(message.get("content", "")))
         if sender == "user":
             return cast("TResponseInputItem", {"role": "user", "content": content})
         sender_name = self.names.get(sender, sender)

--- a/strix/core/agents.py
+++ b/strix/core/agents.py
@@ -37,8 +37,10 @@ _CHATGPT_TRANSCRIPT_TAGS = (
     "final",
     "user",
 )
+_CHATGPT_TRANSCRIPT_TAG_ALTERNATION = "|".join(re.escape(tag) for tag in _CHATGPT_TRANSCRIPT_TAGS)
+_OPTIONAL_TAG_ATTRIBUTES_PATTERN = r"(?:\s+[^>]*)?"
 _CHATGPT_TRANSCRIPT_TAG_RE = re.compile(
-    rf"</?(?:{'|'.join(_CHATGPT_TRANSCRIPT_TAGS)})\s*>",
+    rf"</?(?:{_CHATGPT_TRANSCRIPT_TAG_ALTERNATION}){_OPTIONAL_TAG_ATTRIBUTES_PATTERN}\s*/?>",
     flags=re.IGNORECASE,
 )
 
@@ -454,9 +456,10 @@ class AgentCoordinator:
 
     def _message_to_session_item(self, message: dict[str, Any]) -> TResponseInputItem:
         sender = str(message.get("from", "unknown"))
-        content = _strip_chatgpt_transcript_tags(str(message.get("content", "")))
+        content = str(message.get("content", ""))
         if sender == "user":
             return cast("TResponseInputItem", {"role": "user", "content": content})
+        content = _strip_chatgpt_transcript_tags(content)
         sender_name = self.names.get(sender, sender)
         msg_type = message.get("type", "information")
         priority = message.get("priority", "normal")

--- a/tests/test_agent_messages.py
+++ b/tests/test_agent_messages.py
@@ -8,6 +8,16 @@ from strix.core.agents import AgentCoordinator
 CHATGPT_TRANSCRIPT_CONTENT = (
     "<analysis>checked target</analysis>\n<channel>final</channel>\n<final>done</final>"
 )
+CHATGPT_TRANSCRIPT_CONTENT_WITH_ATTRIBUTES = (
+    '<analysis trace="true">checked target</analysis>\n'
+    '<channel name="final">final</channel>\n'
+    '<final reason="done">done</final>\n'
+    "<assistant/>"
+)
+USER_LITERAL_TAG_CONTENT = (
+    "Please preserve this XML-like snippet: "
+    '<analysis>literal user content</analysis> and <final reason="example">done</final>'
+)
 
 
 def test_message_to_session_item_strips_chatgpt_transcript_tags() -> None:
@@ -31,5 +41,41 @@ def test_message_to_session_item_strips_chatgpt_transcript_tags() -> None:
     assert "</channel>" not in content
     assert "<final>" not in content
     assert "</final>" not in content
+    assert "checked target" in content
+    assert "done" in content
+
+
+def test_message_to_session_item_preserves_user_literal_tags() -> None:
+    coordinator = AgentCoordinator()
+
+    item = coordinator._message_to_session_item(
+        {
+            "from": "user",
+            "content": USER_LITERAL_TAG_CONTENT,
+        }
+    )
+
+    assert item["content"] == USER_LITERAL_TAG_CONTENT
+
+
+def test_message_to_session_item_strips_attributed_chatgpt_transcript_tags() -> None:
+    coordinator = AgentCoordinator()
+    coordinator.names["child"] = "Researcher"
+
+    item = coordinator._message_to_session_item(
+        {
+            "from": "child",
+            "type": "information",
+            "priority": "normal",
+            "content": CHATGPT_TRANSCRIPT_CONTENT_WITH_ATTRIBUTES,
+        }
+    )
+
+    content = str(item["content"])
+
+    assert '<analysis trace="true">' not in content
+    assert '<channel name="final">' not in content
+    assert '<final reason="done">' not in content
+    assert "<assistant/>" not in content
     assert "checked target" in content
     assert "done" in content

--- a/tests/test_agent_messages.py
+++ b/tests/test_agent_messages.py
@@ -1,0 +1,35 @@
+"""Tests for agent-to-session message conversion."""
+
+from __future__ import annotations
+
+from strix.core.agents import AgentCoordinator
+
+
+CHATGPT_TRANSCRIPT_CONTENT = (
+    "<analysis>checked target</analysis>\n<channel>final</channel>\n<final>done</final>"
+)
+
+
+def test_message_to_session_item_strips_chatgpt_transcript_tags() -> None:
+    coordinator = AgentCoordinator()
+    coordinator.names["child"] = "Researcher"
+
+    item = coordinator._message_to_session_item(
+        {
+            "from": "child",
+            "type": "information",
+            "priority": "normal",
+            "content": CHATGPT_TRANSCRIPT_CONTENT,
+        }
+    )
+
+    content = str(item["content"])
+
+    assert "<analysis>" not in content
+    assert "</analysis>" not in content
+    assert "<channel>" not in content
+    assert "</channel>" not in content
+    assert "<final>" not in content
+    assert "</final>" not in content
+    assert "checked target" in content
+    assert "done" in content


### PR DESCRIPTION
## Summary

Fix #118

Strip ChatGPT-style transcript tags from messages before appending them to the SDK session, so agent-originated content cannot be resent to OpenAI-compatible providers with rejected tags like `<analysis>`, `<channel>`, or `<final>`.

Follow-up review fixes:

- Preserve literal transcript-like tags in user prompts instead of sanitizing user-provided content.
- Strip attributed and self-closing transcript tags such as `<final reason="done">` and `<analysis/>` from non-user messages.

Also annotates the descendant task list in the same module so the touched file passes pyright.

## Test verification (RED -> GREEN)

RED with the follow-up production fix reverted, while keeping the new regression tests:

```text
uv run pytest tests/test_agent_messages.py -q
FAILED tests/test_agent_messages.py::test_message_to_session_item_preserves_user_literal_tags
FAILED tests/test_agent_messages.py::test_message_to_session_item_strips_attributed_chatgpt_transcript_tags
2 failed, 1 passed
```

GREEN with the follow-up fix applied:

```text
uv run pytest tests/test_agent_messages.py -q
3 passed
```

Full suite:

```text
uv run pytest -q
145 passed, 2 warnings
```

Additional targeted validation:

```text
uv run ruff check strix/core/agents.py tests/test_agent_messages.py
All checks passed!

uv run ruff format --check strix/core/agents.py tests/test_agent_messages.py
2 files already formatted

uv run mypy strix/core/agents.py
Success: no issues found in 1 source file

uv run pyright strix/core/agents.py
0 errors, 0 warnings, 0 informations
```

Global quality baseline notes, not introduced by this PR:

```text
uv run ruff format --check .
Would reformat: strix/core/hooks.py, strix/interface/utils.py, tests/test_cli_target_list.py, tests/test_local_sources.py

uv run ruff check .
4 existing errors in strix/core/hooks.py, strix/runtime/docker_client.py, strix/telemetry/logging.py

uv run mypy strix/
69 existing errors in TUI/Pygments-related files
```