### PR TITLE
fix: propagate sandbox proxy environment aliases

### DIFF
--- a/strix/runtime/session_manager.py
+++ b/strix/runtime/session_manager.py
@@ -26,6 +26,11 @@ logger = logging.getLogger(__name__)
 
 # In-container Caido sidecar port (matches the image's caido-cli bind).
 _CONTAINER_CAIDO_PORT = 48080
+_CONTAINER_CAIDO_SCHEME = "http"
+_CONTAINER_CAIDO_HOST = "127.0.0.1"
+_HOST_GATEWAY_NAME = "host.docker.internal"
+_NO_PROXY_VALUE = "localhost,127.0.0.1"
+_CA_BUNDLE_PATH = "/etc/ssl/certs/ca-certificates.crt"
 
 
 _SESSION_CACHE: dict[str, dict[str, Any]] = {}
@@ -34,6 +39,28 @@ _SESSION_CACHE: dict[str, dict[str, Any]] = {}
 _WORKSPACE_ROOT = "/workspace"
 
 _PROTECTED_METADATA_NAMES = (".git", ".agents", ".codex")
+
+def _container_caido_url() -> str:
+    return f"{_CONTAINER_CAIDO_SCHEME}://{_CONTAINER_CAIDO_HOST}:{_CONTAINER_CAIDO_PORT}"
+
+
+def build_sandbox_environment() -> dict[str, str]:
+    """Return environment variables inherited by sandbox subprocesses."""
+    container_caido_url = _container_caido_url()
+    return {
+        "PYTHONUNBUFFERED": "1",
+        "HOST_GATEWAY": _HOST_GATEWAY_NAME,
+        "http_proxy": container_caido_url,
+        "https_proxy": container_caido_url,
+        "HTTP_PROXY": container_caido_url,
+        "HTTPS_PROXY": container_caido_url,
+        "ALL_PROXY": container_caido_url,
+        "all_proxy": container_caido_url,
+        "NO_PROXY": _NO_PROXY_VALUE,
+        "no_proxy": _NO_PROXY_VALUE,
+        "REQUESTS_CA_BUNDLE": _CA_BUNDLE_PATH,
+        "SSL_CERT_FILE": _CA_BUNDLE_PATH,
+    }
 
 
 def _host_identity_env() -> dict[str, str]:
@@ -297,20 +324,10 @@ async def create_or_reuse(
     # picks up these env vars automatically. ``NO_PROXY`` keeps the
     # agent-browser CDP daemon's localhost traffic from looping back
     # through Caido.
-    container_caido_url = f"http://127.0.0.1:{_CONTAINER_CAIDO_PORT}"
+    container_caido_url = _container_caido_url()
     manifest = Manifest(
         entries=entries,
-        environment=Environment(
-            value={
-                "PYTHONUNBUFFERED": "1",
-                "HOST_GATEWAY": "host.docker.internal",
-                **_host_identity_env(),
-                "http_proxy": container_caido_url,
-                "https_proxy": container_caido_url,
-                "ALL_PROXY": container_caido_url,
-                "NO_PROXY": "localhost,127.0.0.1",
-            },
-        ),
+        environment=Environment(value={**build_sandbox_environment(), **_host_identity_env()}),
     )
 
     logger.info(

--- a/strix/runtime/session_manager.py
+++ b/strix/runtime/session_manager.py
@@ -29,6 +29,12 @@ logger = logging.getLogger(__name__)
 
 # In-container Caido sidecar port (matches the image's caido-cli bind).
 _CONTAINER_CAIDO_PORT = 48080
+_CONTAINER_CAIDO_SCHEME = "http"
+_CONTAINER_CAIDO_HOST = "127.0.0.1"
+_HOST_GATEWAY_NAME = "host.docker.internal"
+_NO_PROXY_VALUE = "localhost,127.0.0.1"
+_CA_BUNDLE_PATH = "/etc/ssl/certs/ca-certificates.crt"
+_PYTHONUNBUFFERED_VALUE = "1"
 
 
 _SESSION_CACHE: dict[str, dict[str, Any]] = {}
@@ -37,6 +43,29 @@ _SESSION_CACHE: dict[str, dict[str, Any]] = {}
 _WORKSPACE_ROOT = "/workspace"
 
 _PROTECTED_METADATA_NAMES = (".git", ".agents", ".codex")
+
+
+def _container_caido_url() -> str:
+    return f"{_CONTAINER_CAIDO_SCHEME}://{_CONTAINER_CAIDO_HOST}:{_CONTAINER_CAIDO_PORT}"
+
+
+def build_sandbox_environment() -> dict[str, str]:
+    """Return environment variables inherited by sandbox subprocesses."""
+    container_caido_url = _container_caido_url()
+    return {
+        "PYTHONUNBUFFERED": _PYTHONUNBUFFERED_VALUE,
+        "HOST_GATEWAY": _HOST_GATEWAY_NAME,
+        "http_proxy": container_caido_url,
+        "https_proxy": container_caido_url,
+        "HTTP_PROXY": container_caido_url,
+        "HTTPS_PROXY": container_caido_url,
+        "ALL_PROXY": container_caido_url,
+        "all_proxy": container_caido_url,
+        "NO_PROXY": _NO_PROXY_VALUE,
+        "no_proxy": _NO_PROXY_VALUE,
+        "REQUESTS_CA_BUNDLE": _CA_BUNDLE_PATH,
+        "SSL_CERT_FILE": _CA_BUNDLE_PATH,
+    }
 
 
 def _host_identity_env() -> dict[str, str]:
@@ -312,20 +341,10 @@ async def create_or_reuse(
     # picks up these env vars automatically. ``NO_PROXY`` keeps the
     # agent-browser CDP daemon's localhost traffic from looping back
     # through Caido.
-    container_caido_url = f"http://127.0.0.1:{_CONTAINER_CAIDO_PORT}"
+    container_caido_url = _container_caido_url()
     manifest = Manifest(
         entries=entries,
-        environment=Environment(
-            value={
-                "PYTHONUNBUFFERED": "1",
-                "HOST_GATEWAY": "host.docker.internal",
-                **_host_identity_env(),
-                "http_proxy": container_caido_url,
-                "https_proxy": container_caido_url,
-                "ALL_PROXY": container_caido_url,
-                "NO_PROXY": "localhost,127.0.0.1",
-            },
-        ),
+        environment=Environment(value={**build_sandbox_environment(), **_host_identity_env()}),
     )
 
     logger.info(

--- a/tests/test_session_entries.py
+++ b/tests/test_session_entries.py
@@ -18,7 +18,13 @@ from strix.runtime.session_manager import (
     build_extra_file_bind_mounts,
     build_extra_file_entries,
     build_manifest_entries,
+    build_sandbox_environment,
 )
+
+
+EXPECTED_CAIDO_URL = "http://127.0.0.1:48080"
+EXPECTED_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+EXPECTED_NO_PROXY = "localhost,127.0.0.1"
 
 
 def _source(subdir: str, path: str, *, protect_metadata: bool = False) -> dict[str, Any]:
@@ -334,3 +340,18 @@ def test_only_bind_mount_capable_backends_are_registered_as_such() -> None:
     finally:
         _BACKENDS.pop("e2b", None)
         _BIND_MOUNT_BACKENDS.discard("e2b")
+
+
+def test_sandbox_environment_exports_proxy_and_ca_aliases() -> None:
+    env = build_sandbox_environment()
+
+    assert env["http_proxy"] == EXPECTED_CAIDO_URL
+    assert env["https_proxy"] == EXPECTED_CAIDO_URL
+    assert env["HTTP_PROXY"] == EXPECTED_CAIDO_URL
+    assert env["HTTPS_PROXY"] == EXPECTED_CAIDO_URL
+    assert env["ALL_PROXY"] == EXPECTED_CAIDO_URL
+    assert env["all_proxy"] == EXPECTED_CAIDO_URL
+    assert env["NO_PROXY"] == EXPECTED_NO_PROXY
+    assert env["no_proxy"] == EXPECTED_NO_PROXY
+    assert env["REQUESTS_CA_BUNDLE"] == EXPECTED_CA_BUNDLE
+    assert env["SSL_CERT_FILE"] == EXPECTED_CA_BUNDLE

--- a/tests/test_session_entries.py
+++ b/tests/test_session_entries.py
@@ -21,8 +21,14 @@ from strix.runtime.session_manager import (
     build_extra_file_bind_mounts,
     build_extra_file_entries,
     build_manifest_entries,
+    build_sandbox_environment,
     extra_file_staging_dir,
 )
+
+
+EXPECTED_CAIDO_URL = "http://127.0.0.1:48080"
+EXPECTED_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+EXPECTED_NO_PROXY = "localhost,127.0.0.1"
 
 
 def _source(subdir: str, path: str, *, protect_metadata: bool = False) -> dict[str, Any]:
@@ -375,3 +381,18 @@ def test_only_bind_mount_capable_backends_are_registered_as_such() -> None:
     finally:
         _BACKENDS.pop("e2b", None)
         _BIND_MOUNT_BACKENDS.discard("e2b")
+
+
+def test_sandbox_environment_exports_proxy_and_ca_aliases() -> None:
+    env = build_sandbox_environment()
+
+    assert env["http_proxy"] == EXPECTED_CAIDO_URL
+    assert env["https_proxy"] == EXPECTED_CAIDO_URL
+    assert env["HTTP_PROXY"] == EXPECTED_CAIDO_URL
+    assert env["HTTPS_PROXY"] == EXPECTED_CAIDO_URL
+    assert env["ALL_PROXY"] == EXPECTED_CAIDO_URL
+    assert env["all_proxy"] == EXPECTED_CAIDO_URL
+    assert env["NO_PROXY"] == EXPECTED_NO_PROXY
+    assert env["no_proxy"] == EXPECTED_NO_PROXY
+    assert env["REQUESTS_CA_BUNDLE"] == EXPECTED_CA_BUNDLE
+    assert env["SSL_CERT_FILE"] == EXPECTED_CA_BUNDLE


### PR DESCRIPTION
## Summary

Fix #430

Build the sandbox environment in one helper (`build_sandbox_environment()`) and propagate proxy settings through lowercase and uppercase aliases, including `all_proxy` and `no_proxy`, plus the CA bundle variables (`REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`) used by common Python and TLS tooling.

This keeps subprocesses spawned inside the sandbox on the same Caido proxy and trust configuration while preserving localhost bypass behavior for tools that only read lowercase proxy variables.

## Test verification (RED -> GREEN)

RED — the new test imports `build_sandbox_environment`, which does not exist on the base branch:

```text
uv run pytest tests/test_session_entries.py::test_sandbox_environment_exports_proxy_and_ca_aliases -q
ImportError: cannot import name 'build_sandbox_environment' from 'strix.runtime.session_manager'
1 error
```

GREEN — with the fix applied:

```text
uv run pytest tests/test_session_entries.py -q
30 passed
```

Full suite (rebased onto current `main` @ 52b1923):

```text
uv run pytest -q
1 failed, 1741 passed
```

The single failure is the pre-existing, unrelated `tests/test_pricing.py::test_resolves_common_bare_model_names`, which fails identically on unmodified `upstream/main` (`openrouter/x-ai/grok-4.5` != `xai/grok-4.5`). No new failure is introduced by this branch.

Quality gate on the touched files:

```text
uv run ruff format --check strix/runtime/session_manager.py tests/test_session_entries.py  # already formatted
uv run ruff check      strix/runtime/session_manager.py tests/test_session_entries.py       # All checks passed!
uv run mypy            strix/runtime/session_manager.py                                      # Success: no issues found
uv run pyright         strix/runtime/session_manager.py                                      # 0 errors
uv run bandit -q -c pyproject.toml strix/runtime/session_manager.py                          # exit 0
```
