### PR TITLE
Default sandbox exec commands to Bash

### DIFF
--- a/strix/agents/factory.py
+++ b/strix/agents/factory.py
@@ -209,10 +209,6 @@ def _wrap_exec_command(tool: FunctionTool) -> FunctionTool:
     invoke_tool = tool.on_invoke_tool
 
     async def invoke(ctx: Any, raw_input: str) -> Any:
-        # Default the shell to bash when the model doesn't specify one. The SDK
-        # otherwise falls back to the sandbox user's default shell (dash/sh in
-        # the image), which lacks common builtins like `source` and prints
-        # "source: not found". Explicit `shell` values are left untouched.
         try:
             parsed = json.loads(raw_input)
         except (json.JSONDecodeError, TypeError):

--- a/strix/agents/factory.py
+++ b/strix/agents/factory.py
@@ -209,6 +209,17 @@ def _wrap_exec_command(tool: FunctionTool) -> FunctionTool:
     invoke_tool = tool.on_invoke_tool
 
     async def invoke(ctx: Any, raw_input: str) -> Any:
+        # Default the shell to bash when the model doesn't specify one. The SDK
+        # otherwise falls back to the sandbox user's default shell (dash/sh in
+        # the image), which lacks common builtins like `source` and prints
+        # "source: not found". Explicit `shell` values are left untouched.
+        try:
+            parsed = json.loads(raw_input)
+        except (json.JSONDecodeError, TypeError):
+            parsed = None
+        if isinstance(parsed, dict) and not parsed.get("shell"):
+            parsed["shell"] = "bash"
+            raw_input = json.dumps(parsed)
         try:
             return await invoke_tool(ctx, raw_input)
         except ValidationError as exc:

--- a/strix/agents/factory.py
+++ b/strix/agents/factory.py
@@ -217,7 +217,7 @@ def _wrap_exec_command(tool: FunctionTool) -> FunctionTool:
             parsed = json.loads(raw_input)
         except (json.JSONDecodeError, TypeError):
             parsed = None
-        if isinstance(parsed, dict) and not parsed.get("shell"):
+        if isinstance(parsed, dict) and "shell" not in parsed:
             parsed["shell"] = "bash"
             raw_input = json.dumps(parsed)
         try:

--- a/tests/test_agent_factory_shell.py
+++ b/tests/test_agent_factory_shell.py
@@ -1,0 +1,50 @@
+"""Tests for the shell tool adapters in the agent factory."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+import pytest
+from agents.tool import FunctionTool
+
+from strix.agents import factory
+
+
+def _capturing_exec_tool(captured: dict[str, str]) -> FunctionTool:
+    async def invoke(_ctx: Any, raw_input: str) -> str:
+        captured["raw_input"] = raw_input
+        return "ok"
+
+    return FunctionTool(
+        name="exec_command",
+        description="test tool",
+        params_json_schema={"type": "object", "properties": {}},
+        on_invoke_tool=invoke,
+    )
+
+
+@pytest.mark.asyncio
+async def test_wrap_exec_command_defaults_shell_to_bash() -> None:
+    captured: dict[str, str] = {}
+    wrapped = factory._wrap_exec_command(_capturing_exec_tool(captured))
+
+    result = await wrapped.on_invoke_tool(cast("Any", None), json.dumps({"cmd": "source /tmp/env"}))
+
+    assert result == "ok"
+    assert json.loads(captured["raw_input"]) == {
+        "cmd": "source /tmp/env",
+        "shell": "bash",
+    }
+
+
+@pytest.mark.asyncio
+async def test_wrap_exec_command_preserves_explicit_shell() -> None:
+    captured: dict[str, str] = {}
+    wrapped = factory._wrap_exec_command(_capturing_exec_tool(captured))
+
+    await wrapped.on_invoke_tool(
+        cast("Any", None), json.dumps({"cmd": "echo test", "shell": "/bin/zsh"})
+    )
+
+    assert json.loads(captured["raw_input"])["shell"] == "/bin/zsh"

--- a/tests/test_agent_factory_shell.py
+++ b/tests/test_agent_factory_shell.py
@@ -39,12 +39,13 @@ async def test_wrap_exec_command_defaults_shell_to_bash() -> None:
 
 
 @pytest.mark.asyncio
-async def test_wrap_exec_command_preserves_explicit_shell() -> None:
+@pytest.mark.parametrize("shell", ["/bin/zsh", ""])
+async def test_wrap_exec_command_preserves_explicit_shell(shell: str) -> None:
     captured: dict[str, str] = {}
     wrapped = factory._wrap_exec_command(_capturing_exec_tool(captured))
 
     await wrapped.on_invoke_tool(
-        cast("Any", None), json.dumps({"cmd": "echo test", "shell": "/bin/zsh"})
+        cast("Any", None), json.dumps({"cmd": "echo test", "shell": shell})
     )
 
-    assert json.loads(captured["raw_input"])["shell"] == "/bin/zsh"
+    assert json.loads(captured["raw_input"])["shell"] == shell


### PR DESCRIPTION
## Summary

- default `exec_command` payloads to Bash when the model omits a shell
- preserve nonempty explicit shell selections
- add focused regression tests for both behaviors

## Why

The SDK otherwise falls back to the sandbox user's default shell, which is `dash`/`sh` in the image. Model-generated commands that use common Bash builtins such as `source` can therefore fail with `source: not found`. Applying the default in Strix fixes the behavior without requiring an upstream SDK change.

## Impact

Sandbox commands use Bash by default, while callers can still select another shell explicitly.

## Validation

- `uv run pytest -q` — 234 passed
- `uv run ruff check strix/agents/factory.py tests/test_agent_factory_shell.py`
- `uv run ruff format --check strix/agents/factory.py tests/test_agent_factory_shell.py`
