### PR TITLE
fix: tolerate string-encoded skills param for LLM provider compatibility

### DIFF
--- a/strix/tools/agents_graph/tools.py
+++ b/strix/tools/agents_graph/tools.py
@@ -350,13 +350,13 @@ async def wait_for_message(  # noqa: PLR0911
     )
 
 
-@function_tool(timeout=120)
+@function_tool(timeout=120, strict_mode=False)
 async def create_agent(
     ctx: RunContextWrapper,
     name: str,
     task: str,
     inherit_context: bool = True,
-    skills: list[str] | None = None,
+    skills: str | list[str] | None = None,
 ) -> str:
     """Spawn a specialist child agent to run in parallel.
 
@@ -419,6 +419,12 @@ async def create_agent(
             default=str,
         )
 
+    # Tolerate LLM providers that pass array params as JSON-encoded strings
+    if isinstance(skills, str):
+        try:
+            skills = json.loads(skills)
+        except json.JSONDecodeError:
+            skills = [s.strip() for s in skills.split(",") if s.strip()]
     skill_list = list(skills or [])
     skill_error = validate_requested_skills(skill_list)
     if skill_error:

--- a/strix/tools/agents_graph/tools.py
+++ b/strix/tools/agents_graph/tools.py
@@ -419,12 +419,23 @@ async def create_agent(
             default=str,
         )
 
-    # Tolerate LLM providers that pass array params as JSON-encoded strings
+    # Tolerate LLM providers that pass array params as JSON-encoded strings.
+    # Validate decoded shape: reject anything that isn't a list of strings.
     if isinstance(skills, str):
+        original_skills = skills
         try:
-            skills = json.loads(skills)
+            decoded_skills = json.loads(skills)
         except json.JSONDecodeError:
             skills = [s.strip() for s in skills.split(",") if s.strip()]
+        else:
+            if isinstance(decoded_skills, str):
+                skills = [decoded_skills]
+            elif isinstance(decoded_skills, list) and all(
+                isinstance(skill, str) for skill in decoded_skills
+            ):
+                skills = decoded_skills
+            else:
+                skills = [original_skills]
     skill_list = list(skills or [])
     skill_error = validate_requested_skills(skill_list)
     if skill_error:

--- a/strix/tools/load_skill/tool.py
+++ b/strix/tools/load_skill/tool.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import json
+
 from agents import RunContextWrapper, function_tool
 
 from strix.skills import load_skills, validate_requested_skills
 
 
-@function_tool(timeout=10)
-async def load_skill(ctx: RunContextWrapper, skills: list[str]) -> str:
+@function_tool(timeout=10, strict_mode=False)
+async def load_skill(ctx: RunContextWrapper, skills: str | list[str]) -> str:
     """Return the markdown body of one or more skills as reference material.
 
     Use this when you need exact syntax / workflow / payload guidance
@@ -25,6 +27,12 @@ async def load_skill(ctx: RunContextWrapper, skills: list[str]) -> str:
             ``strix/skills/<category>/<name>.md``.
     """
     del ctx
+    # Tolerate LLM providers that pass array params as JSON-encoded strings
+    if isinstance(skills, str):
+        try:
+            skills = json.loads(skills)
+        except json.JSONDecodeError:
+            skills = [s.strip() for s in skills.split(",") if s.strip()]
     requested = list(skills or [])
     err = validate_requested_skills(requested)
     if err:

--- a/strix/tools/load_skill/tool.py
+++ b/strix/tools/load_skill/tool.py
@@ -27,12 +27,23 @@ async def load_skill(ctx: RunContextWrapper, skills: str | list[str]) -> str:
             ``strix/skills/<category>/<name>.md``.
     """
     del ctx
-    # Tolerate LLM providers that pass array params as JSON-encoded strings
+    # Tolerate LLM providers that pass array params as JSON-encoded strings.
+    # Validate decoded shape: reject anything that isn't a list of strings.
     if isinstance(skills, str):
+        original_skills = skills
         try:
-            skills = json.loads(skills)
+            decoded_skills = json.loads(skills)
         except json.JSONDecodeError:
             skills = [s.strip() for s in skills.split(",") if s.strip()]
+        else:
+            if isinstance(decoded_skills, str):
+                skills = [decoded_skills]
+            elif isinstance(decoded_skills, list) and all(
+                isinstance(skill, str) for skill in decoded_skills
+            ):
+                skills = decoded_skills
+            else:
+                skills = [original_skills]
     requested = list(skills or [])
     err = validate_requested_skills(requested)
     if err:


### PR DESCRIPTION
## Summary

Some LLM providers (notably **qwen3.7-max via Alibaba DashScope OpenAI-compatible endpoint**) serialize array-typed function call parameters as JSON-encoded strings (`'["sql_injection"]'`) instead of native JSON arrays (`["sql_injection"]`). This causes Pydantic validation to reject the `skills` parameter before the function body executes, making **every** `create_agent` and `load_skill` call fail.

This completely breaks multi-agent orchestration — the agent cannot spawn specialist child agents and falls back to serial execution with severely reduced test coverage.

## Root Cause

The `skills` parameter is typed as `list[str]` in both `create_agent` and `load_skill`. When an LLM provider passes it as a string, Pydantic's strict validation rejects it:

```
Invalid JSON input for tool create_agent: 1 validation error for create_agent_args
skills
  Input should be a valid list [type=list_type, input_value='["sql_injection"]', input_type=str]
```

## Fix

Three changes per tool (`create_agent` + `load_skill`):

1. **Widen type annotation**: `list[str]` → `str | list[str]` — allows Pydantic to accept string input
2. **Add `strict_mode=False`** to `@function_tool` — relaxes schema validation
3. **Parse string in function body**:
   ```python
   if isinstance(skills, str):
       try:
           skills = json.loads(skills)
       except json.JSONDecodeError:
           skills = [s.strip() for s in skills.split(",") if s.strip()]
   ```

The fallback comma-split handles edge cases where the model passes a bare comma-separated string like `"xss,sqli"`.

## Testing

- **Before fix**: 6 consecutive `create_agent` calls all failed with Pydantic validation error. Agent could not spawn any child agents.
- **After fix**: `create_agent` successfully spawns child agents. Verified with a quick-mode scan where the child agent executed 23 `exec_command` calls (curl + Python SQL injection scripts) and completed normally.

No regressions for providers that correctly pass arrays (OpenAI, Anthropic) — `isinstance(skills, str)` is `False` for native lists, so the tolerance code is skipped.

## Files Changed

- `strix/tools/agents_graph/tools.py` — `create_agent` function
- `strix/tools/load_skill/tool.py` — `load_skill` function

Closes #770