### PR TITLE
fix(runtime): cap sandbox container logs to prevent host disk exhaustion

### DIFF
--- a/strix/runtime/docker_client.py
+++ b/strix/runtime/docker_client.py
@@ -42,6 +42,7 @@ from agents.sandbox.session.sandbox_session import SandboxSession
 from agents.sandbox.types import ExposedPortEndpoint
 from docker import errors as docker_errors  # type: ignore[import-untyped, unused-ignore]
 from docker.models.containers import Container  # type: ignore[import-untyped, unused-ignore]
+from docker.types import LogConfig  # type: ignore[import-untyped, unused-ignore]
 from docker.types import Mount as DockerSDKMount  # type: ignore[import-untyped, unused-ignore]
 from docker.utils import parse_repository_tag  # type: ignore[import-untyped, unused-ignore]
 from requests.exceptions import RequestException
@@ -87,6 +88,26 @@ def _apply_resource_limits(create_kwargs: dict[str, Any]) -> None:
     if pids_limit:
         with contextlib.suppress(ValueError):
             create_kwargs["pids_limit"] = int(pids_limit)
+
+
+def _apply_log_limits(create_kwargs: dict[str, Any]) -> None:
+    """Bound the container's json-file log so a runaway process in the sandbox
+    (e.g. a tool that busy-loops writing to stdout) cannot fill the host disk
+    and take the Docker daemon down with it.
+
+    Unlike the cgroup caps above, this defaults **on** — docker's own default
+    is an unbounded json-file, which is unsafe for an autonomous agent that
+    executes arbitrary commands. ``max-file`` rotation means the on-disk cap is
+    ``max-size * max-file``. Set ``STRIX_SANDBOX_LOG_MAX_SIZE`` to ``0``/``off``
+    to opt back out to docker's default."""
+    max_size = os.environ.get("STRIX_SANDBOX_LOG_MAX_SIZE", "50m").strip()
+    if max_size.lower() in ("0", "off", "none", "unlimited"):
+        return
+    max_file = os.environ.get("STRIX_SANDBOX_LOG_MAX_FILE", "3").strip() or "3"
+    create_kwargs["log_config"] = LogConfig(
+        type=LogConfig.types.JSON,
+        config={"max-size": max_size, "max-file": max_file},
+    )
 
 
 class StrixDockerSandboxSession(DockerSandboxSession):
@@ -200,6 +221,7 @@ class StrixDockerSandboxClient(DockerSandboxClient):
 
         _apply_sandbox_network(create_kwargs)
         _apply_resource_limits(create_kwargs)
+        _apply_log_limits(create_kwargs)
 
         # Strix injection: host bind mounts (e.g. large repos passed via --mount)
         # that bypass the SDK's file-by-file LocalDir copy.


### PR DESCRIPTION
## Problem

Sandbox containers are created in `StrixDockerSandboxClient._create_container` with **no `log_config`**, so Docker's default **unbounded `json-file`** driver applies (only mem/cpu/pids caps exist today — nothing bounds log growth).

A runaway process in the sandbox can then fill the host disk. Observed: an agent ran an interactive command (`su`) through a **no-TTY exec**; `su` couldn't open a controlling terminal and busy-looped on stderr:

```
Error opening input terminal for read
Invalid password.  Try again.
```

...at ~750k lines/sec, writing **55 GB in ~15 minutes** into the container's json-file log. That filled the host disk and Docker Desktop then crashed on startup ("no space left on device" writing its own `init.log`). `docker system df` never surfaced it, because it does not count container log files.

## Fix

Add `_apply_log_limits`, applied on every sandbox container create alongside the existing network/resource-limit injections. Unlike the cgroup caps (opt-in), this defaults **on** — an unbounded log is unsafe for an autonomous agent that executes arbitrary commands.

- Default `max-size=50m`, `max-file=3` → **150 MB** on-disk cap per container (rotation).
- Overridable via `STRIX_SANDBOX_LOG_MAX_SIZE` / `STRIX_SANDBOX_LOG_MAX_FILE`.
- Opt-out to Docker's default with `STRIX_SANDBOX_LOG_MAX_SIZE=off`.

## Verification

- Unit: default / override / opt-out paths produce the expected `LogConfig`.
- End-to-end: a real container created via `containers.create(log_config=...)` reports `HostConfig.LogConfig {Type: json-file, Config: {max-size: 50m, max-file: 3}}` from the daemon.
- pre-commit (ruff-lint, ruff-format, mypy, bandit, …) all pass.

## Scope / follow-up

Bounds the blast radius (a runaway can no longer fill the host disk) but does **not** stop the underlying busy-loop. The no-TTY interactive-command handling in the shell tool (`exec_command` running a TTY-requiring command like `su`, retrying without backoff) is a separate, deeper fix worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)