### PR TITLE
fix(core): Graceful handling of NFE loops and incremental SARIF flushing

### DIFF
--- a/strix/core/execution.py
+++ b/strix/core/execution.py
@@ -284,7 +284,7 @@ async def _run_noninteractive_until_lifecycle(
     result: RunResultBase | None = None
     input_data: Any = initial_input
     invalid_final_outputs = 0
-    invalid_final_output_limit = max(1, max_turns)
+    invalid_final_output_limit = min(5, max(1, max_turns))
 
     while True:
         if coordinator.budget_stopped:
@@ -581,6 +581,10 @@ async def _start_child_runner(
             )
         except BudgetExceededError:
             logger.info("child %s stopped after reaching the scan budget limit", child_id)
+        except MaxTurnsExceeded as exc:
+            logger.warning("child %s crashed due to MaxTurnsExceeded: %s", child_id, exc)
+        except Exception:
+            logger.exception("child %s crashed with unhandled exception", child_id)
 
     task_handle = asyncio.create_task(_child_loop(), name=f"agent-{name}-{child_id}")
     await coordinator.attach_runtime(child_id, task=task_handle)

--- a/strix/core/execution.py
+++ b/strix/core/execution.py
@@ -583,8 +583,14 @@ async def _start_child_runner(
             logger.info("child %s stopped after reaching the scan budget limit", child_id)
         except MaxTurnsExceeded as exc:
             logger.warning("child %s crashed due to MaxTurnsExceeded: %s", child_id, exc)
+            with contextlib.suppress(Exception):
+                await coordinator.set_status(child_id, "crashed")
+                await _notify_parent_on_crash(coordinator, child_id, "crashed")
         except Exception:
             logger.exception("child %s crashed with unhandled exception", child_id)
+            with contextlib.suppress(Exception):
+                await coordinator.set_status(child_id, "crashed")
+                await _notify_parent_on_crash(coordinator, child_id, "crashed")
 
     task_handle = asyncio.create_task(_child_loop(), name=f"agent-{name}-{child_id}")
     await coordinator.attach_runtime(child_id, task=task_handle)

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -30,6 +30,7 @@ from strix.core.execution import (
     spawn_child_agent as start_child_agent,
 )
 from strix.core.hooks import BudgetExceededError, ReportUsageHooks
+from agents.exceptions import MaxTurnsExceeded
 from strix.core.inputs import (
     DEFAULT_MAX_TURNS,
     build_root_task,
@@ -390,6 +391,17 @@ async def run_strix_scan(
             await coordinator.cancel_descendants(root_id)
             with contextlib.suppress(Exception):
                 await coordinator.set_status(root_id, "stopped")
+        return None
+    except MaxTurnsExceeded as exc:
+        logger.warning(
+            "Scan %s stopped: MaxTurnsExceeded (%s).",
+            scan_id,
+            exc,
+        )
+        if root_id is not None:
+            await coordinator.cancel_descendants(root_id)
+            with contextlib.suppress(Exception):
+                await coordinator.set_status(root_id, "failed")
         return None
     except BaseException:
         logger.exception("Strix scan %s failed", scan_id)

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from agents import RunConfig
 from agents.sandbox import SandboxRunConfig
+from agents.exceptions import MaxTurnsExceeded
 from openai import RateLimitError
 
 from strix.agents.factory import build_strix_agent, make_child_factory
@@ -30,7 +31,6 @@ from strix.core.execution import (
     spawn_child_agent as start_child_agent,
 )
 from strix.core.hooks import BudgetExceededError, ReportUsageHooks
-from agents.exceptions import MaxTurnsExceeded
 from strix.core.inputs import (
     DEFAULT_MAX_TURNS,
     build_root_task,

--- a/strix/tools/agents_graph/tools.py
+++ b/strix/tools/agents_graph/tools.py
@@ -574,6 +574,10 @@ async def agent_finish(
     )
     await coordinator.set_status(me, "completed")
 
+    from strix.report.state import get_global_report_state
+    if report_state := get_global_report_state():
+        report_state.save_run_data()
+
     return json.dumps(
         {
             "success": True,

--- a/strix/tools/agents_graph/tools.py
+++ b/strix/tools/agents_graph/tools.py
@@ -13,6 +13,7 @@ from typing import Any, Literal, get_args
 from agents import RunContextWrapper, function_tool
 
 from strix.core.agents import Status, coordinator_from_context
+from strix.report.state import get_global_report_state
 from strix.skills import validate_requested_skills
 
 
@@ -574,7 +575,6 @@ async def agent_finish(
     )
     await coordinator.set_status(me, "completed")
 
-    from strix.report.state import get_global_report_state
     if report_state := get_global_report_state():
         report_state.save_run_data()
 


### PR DESCRIPTION
🎯 **What:** Catch `MaxTurnsExceeded` unhandled exception to prevent scan crashes and flush SARIF incrementally.
💡 **Why:** When child agents get stuck in Non-Lifecycle Final Output (NFE) loops in non-interactive scans, they raise a `MaxTurnsExceeded` exception. Previously, this exception went unhandled in the `_child_loop` task, crashing the root `run_strix_scan` process without saving the SARIF report for agents that already successfully completed their work.
✅ **Verification:** Verified locally that Strix system tests pass without regressions, and verified via test execution that `MaxTurnsExceeded` is gracefully handled with incremental SARIF flushing on agent completion.
✨ **Result:** Scans no longer hard-crash on NFE loops. Findings are safely persisted, ensuring partial scan success is not lost. Fixes #797.