### PR TITLE
feat(dedupe): add dedicated deduplication model

### DIFF
--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -50,6 +50,11 @@ affecting the agents that do the actual testing.
   Optional provider key for the deduplication model.
 </ParamField>
 
+<ParamField path="DEDUPE_LLM_API_BASE" type="string">
+  Optional custom API base URL for the deduplication model. Use when the dedupe
+  model runs on a different endpoint than the main model.
+</ParamField>
+
 <ParamField path="STRIX_DEDUPE_REASONING_EFFORT" type="string">
   Reasoning effort for the deduplication model. Defaults to the model's own
   baseline when unset.

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -35,6 +35,26 @@ Configure Strix using environment variables or a config file.
   Timeout in seconds for memory compression operations (context summarization).
 </ParamField>
 
+### Dedicated deduplication model
+
+Finding deduplication is a cheap, structured classification task. By default it
+runs on the main model, but you can route it to a smaller/cheaper model without
+affecting the agents that do the actual testing.
+
+<ParamField path="STRIX_DEDUPE_MODEL" type="string">
+  Model used to judge whether a candidate finding duplicates an existing report.
+  Falls back to `STRIX_LLM` when unset.
+</ParamField>
+
+<ParamField path="DEDUPE_LLM_API_KEY" type="string">
+  Optional provider key for the deduplication model.
+</ParamField>
+
+<ParamField path="STRIX_DEDUPE_REASONING_EFFORT" type="string">
+  Reasoning effort for the deduplication model. Defaults to the model's own
+  baseline when unset.
+</ParamField>
+
 ## Optional Features
 
 <ParamField path="PERPLEXITY_API_KEY" type="string">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,6 +259,9 @@ ignore = [
 # a runtime ``Callable`` annotation on ``vulnerability_found_callback``.
 "strix/report/state.py" = ["TC003", "PLR0912", "PLR0915", "E501", "PERF401", "PLC0415"]
 "strix/report/usage.py" = ["PLC0415"]
+# Lazy import of strix.config.models avoids a circular dependency between the
+# report pipeline and the config layer.
+"strix/report/dedupe.py" = ["PLC0415"]
 "strix/telemetry/logging.py" = ["PLC0415"]
 "strix/config/models.py" = ["PLC0415"]
 # Heavy inference deps (httpx, openai) imported lazily so auth-status checks

--- a/strix/config/__init__.py
+++ b/strix/config/__init__.py
@@ -17,6 +17,7 @@ from strix.config.loader import (
     persist_current,
 )
 from strix.config.settings import (
+    DedupeSettings,
     IntegrationSettings,
     LlmSettings,
     RuntimeSettings,
@@ -26,6 +27,7 @@ from strix.config.settings import (
 
 
 __all__ = [
+    "DedupeSettings",
     "IntegrationSettings",
     "LlmSettings",
     "RuntimeSettings",

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -43,6 +43,17 @@ class LlmSettings(BaseSettings):
     timeout: int = Field(default=300, alias="LLM_TIMEOUT")
 
 
+class DedupeSettings(BaseSettings):
+    model_config = _BASE_CONFIG
+
+    model: str | None = Field(default=None, alias="STRIX_DEDUPE_MODEL")
+    reasoning_effort: ReasoningEffort | None = Field(
+        default=None,
+        alias="STRIX_DEDUPE_REASONING_EFFORT",
+    )
+    api_key: str | None = Field(default=None, alias="DEDUPE_LLM_API_KEY")
+
+
 class RuntimeSettings(BaseSettings):
     model_config = _BASE_CONFIG
 
@@ -85,6 +96,7 @@ class Settings(BaseSettings):
     model_config = _BASE_CONFIG
 
     llm: LlmSettings = Field(default_factory=LlmSettings)
+    dedupe: DedupeSettings = Field(default_factory=DedupeSettings)
     runtime: RuntimeSettings = Field(default_factory=RuntimeSettings)
     telemetry: TelemetrySettings = Field(default_factory=TelemetrySettings)
     integrations: IntegrationSettings = Field(default_factory=IntegrationSettings)

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -52,6 +52,7 @@ class DedupeSettings(BaseSettings):
         alias="STRIX_DEDUPE_REASONING_EFFORT",
     )
     api_key: str | None = Field(default=None, alias="DEDUPE_LLM_API_KEY")
+    api_base: str | None = Field(default=None, alias="DEDUPE_LLM_API_BASE")
 
 
 class RuntimeSettings(BaseSettings):

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -398,11 +398,18 @@ async def warm_up_llm(show_model_warning: bool = True) -> None:
             dedupe_model = settings.dedupe.model.strip()
             raw_model = dedupe_model
             deduper = StrixProvider().get_model(dedupe_model)
+            deduper_settings = ModelSettings()
+            if settings.dedupe.api_key and settings.dedupe.api_key.strip():
+                # Match the runtime path: send the dedupe key per call so a
+                # separate-provider dedupe model authenticates during warm-up too.
+                deduper_settings = ModelSettings(
+                    extra_args={"api_key": settings.dedupe.api_key.strip()}
+                )
             await asyncio.wait_for(
                 deduper.get_response(
                     system_instructions="You are a helpful assistant.",
                     input="Reply with just 'OK'.",
-                    model_settings=ModelSettings(),
+                    model_settings=deduper_settings,
                     tools=[],
                     output_schema=None,
                     handoffs=[],

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -394,6 +394,27 @@ async def warm_up_llm(show_model_warning: bool = True) -> None:
         )
         logger.info("LLM warm-up succeeded for model %s", (llm.model or "").strip())
 
+        if settings.dedupe.model:
+            dedupe_model = settings.dedupe.model.strip()
+            raw_model = dedupe_model
+            deduper = StrixProvider().get_model(dedupe_model)
+            await asyncio.wait_for(
+                deduper.get_response(
+                    system_instructions="You are a helpful assistant.",
+                    input="Reply with just 'OK'.",
+                    model_settings=ModelSettings(),
+                    tools=[],
+                    output_schema=None,
+                    handoffs=[],
+                    tracing=ModelTracing.DISABLED,
+                    previous_response_id=None,
+                    conversation_id=None,
+                    prompt=None,
+                ),
+                timeout=llm.timeout,
+            )
+            logger.info("LLM warm-up succeeded for dedupe model %s", dedupe_model)
+
     except Exception as e:
         logger.exception("LLM warm-up failed")
         error_text = Text()

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -395,16 +395,15 @@ async def warm_up_llm(show_model_warning: bool = True) -> None:
         logger.info("LLM warm-up succeeded for model %s", (llm.model or "").strip())
 
         if settings.dedupe.model:
+            from strix.report.dedupe import _dedupe_extra_args
+
             dedupe_model = settings.dedupe.model.strip()
             raw_model = dedupe_model
             deduper = StrixProvider().get_model(dedupe_model)
-            deduper_settings = ModelSettings()
-            if settings.dedupe.api_key and settings.dedupe.api_key.strip():
-                # Match the runtime path: send the dedupe key per call so a
-                # separate-provider dedupe model authenticates during warm-up too.
-                deduper_settings = ModelSettings(
-                    extra_args={"api_key": settings.dedupe.api_key.strip()}
-                )
+            # Match the runtime path: send the dedupe key/endpoint per call so a
+            # separate-provider dedupe model authenticates during warm-up too.
+            deduper_extra = _dedupe_extra_args(settings.dedupe)
+            deduper_settings = ModelSettings(extra_args=deduper_extra or None)
             await asyncio.wait_for(
                 deduper.get_response(
                     system_instructions="You are a helpful assistant.",

--- a/strix/report/dedupe.py
+++ b/strix/report/dedupe.py
@@ -7,17 +7,15 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any
 
-from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
 from openai.types.responses import ResponseOutputMessage
 
 from strix.config import load_settings
 from strix.config.models import (
-    DEFAULT_MODEL_RETRY,
     StrixProvider,
     configure_sdk_model_defaults,
-    request_timeout_extra_args,
 )
+from strix.core.inputs import make_model_settings
 from strix.report.state import get_global_report_state
 
 
@@ -286,13 +284,14 @@ async def check_duplicate(
 
     try:
         settings = load_settings()
-        model_name = settings.llm.model
+        dedupe = settings.dedupe
+        model_name = (dedupe.model or "").strip() or settings.llm.model
         if not model_name:
             return {
                 "is_duplicate": False,
                 "duplicate_id": "",
                 "confidence": 0.0,
-                "reason": "STRIX_LLM not configured; skipping dedupe check",
+                "reason": "No LLM model configured; skipping dedupe check",
             }
 
         candidate_cleaned = _prepare_report_for_comparison(candidate)
@@ -307,14 +306,19 @@ async def check_duplicate(
 
         configure_sdk_model_defaults(settings)
         resolved_model = model_name.strip()
+        if dedupe.model and dedupe.api_key:
+            from strix.config.models import _mirror_api_key_to_provider_env
+
+            _mirror_api_key_to_provider_env(resolved_model, dedupe.api_key)
         model = StrixProvider().get_model(resolved_model)
         response = await model.get_response(
             system_instructions=DEDUPE_SYSTEM_PROMPT,
             input=user_msg,
-            model_settings=ModelSettings(
-                retry=DEFAULT_MODEL_RETRY,
-                include_usage=True,
-                extra_args=request_timeout_extra_args(settings.llm.timeout),
+            model_settings=make_model_settings(
+                dedupe.reasoning_effort,
+                model_name=resolved_model,
+                force_required_tool_choice=False,
+                request_timeout=settings.llm.timeout,
             ),
             tools=[],
             output_schema=None,

--- a/strix/report/dedupe.py
+++ b/strix/report/dedupe.py
@@ -29,25 +29,37 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _dedupe_extra_args(dedupe: DedupeSettings) -> dict[str, str]:
+    """Per-call credential + endpoint for the dedupe model.
+
+    Provider env vars and the global base URL are process-wide, so a
+    shared-provider dedupe key or a distinct dedupe endpoint can't be installed
+    globally without clobbering (or being clobbered by) the main model's
+    config. Passing them per call keeps the two apart. Only applies when a
+    dedicated dedupe model is configured.
+    """
+    if not dedupe.model:
+        return {}
+    extra: dict[str, str] = {}
+    if dedupe.api_key and dedupe.api_key.strip():
+        extra["api_key"] = dedupe.api_key.strip()
+    if dedupe.api_base and dedupe.api_base.strip():
+        extra["api_base"] = dedupe.api_base.strip()
+    return extra
+
+
 def _dedupe_model_settings(
     dedupe: DedupeSettings, model_name: str, request_timeout: float | None
 ) -> ModelSettings:
-    """Build dedupe model settings, sending the dedupe key per call.
-
-    Provider env vars are global, so a shared-provider dedupe key can't be
-    installed via the environment without clobbering (or being clobbered by)
-    the main key. Passing it as a per-call ``api_key`` keeps the two apart.
-    """
     settings = make_model_settings(
         dedupe.reasoning_effort,
         model_name=model_name,
         force_required_tool_choice=False,
         request_timeout=request_timeout,
     )
-    if dedupe.model and dedupe.api_key and dedupe.api_key.strip():
-        settings = settings.resolve(
-            ModelSettings(extra_args={"api_key": dedupe.api_key.strip()})
-        )
+    extra = _dedupe_extra_args(dedupe)
+    if extra:
+        settings = settings.resolve(ModelSettings(extra_args=extra))
     return settings
 
 DEDUPE_SYSTEM_PROMPT = """You are an expert vulnerability report deduplication judge.

--- a/strix/report/dedupe.py
+++ b/strix/report/dedupe.py
@@ -7,6 +7,7 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any
 
+from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
 from openai.types.responses import ResponseOutputMessage
 
@@ -22,8 +23,32 @@ from strix.report.state import get_global_report_state
 if TYPE_CHECKING:
     from agents.items import ModelResponse
 
+    from strix.config.settings import DedupeSettings
+
 
 logger = logging.getLogger(__name__)
+
+
+def _dedupe_model_settings(
+    dedupe: DedupeSettings, model_name: str, request_timeout: float | None
+) -> ModelSettings:
+    """Build dedupe model settings, sending the dedupe key per call.
+
+    Provider env vars are global, so a shared-provider dedupe key can't be
+    installed via the environment without clobbering (or being clobbered by)
+    the main key. Passing it as a per-call ``api_key`` keeps the two apart.
+    """
+    settings = make_model_settings(
+        dedupe.reasoning_effort,
+        model_name=model_name,
+        force_required_tool_choice=False,
+        request_timeout=request_timeout,
+    )
+    if dedupe.model and dedupe.api_key and dedupe.api_key.strip():
+        settings = settings.resolve(
+            ModelSettings(extra_args={"api_key": dedupe.api_key.strip()})
+        )
+    return settings
 
 DEDUPE_SYSTEM_PROMPT = """You are an expert vulnerability report deduplication judge.
 Your task is to determine if a candidate vulnerability report describes the SAME vulnerability
@@ -306,19 +331,12 @@ async def check_duplicate(
 
         configure_sdk_model_defaults(settings)
         resolved_model = model_name.strip()
-        if dedupe.model and dedupe.api_key:
-            from strix.config.models import _mirror_api_key_to_provider_env
-
-            _mirror_api_key_to_provider_env(resolved_model, dedupe.api_key)
         model = StrixProvider().get_model(resolved_model)
         response = await model.get_response(
             system_instructions=DEDUPE_SYSTEM_PROMPT,
             input=user_msg,
-            model_settings=make_model_settings(
-                dedupe.reasoning_effort,
-                model_name=resolved_model,
-                force_required_tool_choice=False,
-                request_timeout=settings.llm.timeout,
+            model_settings=_dedupe_model_settings(
+                dedupe, resolved_model, settings.llm.timeout
             ),
             tools=[],
             output_schema=None,

--- a/tests/test_dedupe_model.py
+++ b/tests/test_dedupe_model.py
@@ -17,15 +17,15 @@ if TYPE_CHECKING:
 
 
 def test_dedupe_key_sent_per_call_not_via_global_env() -> None:
-    dedupe = DedupeSettings(model="deepseek/cheap", api_key="dedupe-key")
+    dedupe = DedupeSettings(STRIX_DEDUPE_MODEL="deepseek/cheap", DEDUPE_LLM_API_KEY="dedupe-key")
     settings = _dedupe_model_settings(dedupe, "deepseek/cheap", 300)
     # The key rides on the request, so a shared-provider main key can't clobber
     # it (and vice versa) through the global provider env var.
-    assert settings.extra_args["api_key"] == "dedupe-key"
+    assert (settings.extra_args or {})["api_key"] == "dedupe-key"
 
 
 def test_dedupe_settings_omit_api_key_when_unset() -> None:
-    dedupe = DedupeSettings(model="deepseek/cheap")
+    dedupe = DedupeSettings(STRIX_DEDUPE_MODEL="deepseek/cheap")
     settings = _dedupe_model_settings(dedupe, "deepseek/cheap", 300)
     assert "api_key" not in (settings.extra_args or {})
     assert "api_base" not in (settings.extra_args or {})
@@ -33,15 +33,15 @@ def test_dedupe_settings_omit_api_key_when_unset() -> None:
 
 def test_dedupe_endpoint_sent_per_call() -> None:
     dedupe = DedupeSettings(
-        model="openai/cheap",
-        api_key="dedupe-key",
-        api_base="https://dedupe.example/v1",
+        STRIX_DEDUPE_MODEL="openai/cheap",
+        DEDUPE_LLM_API_KEY="dedupe-key",
+        DEDUPE_LLM_API_BASE="https://dedupe.example/v1",
     )
     settings = _dedupe_model_settings(dedupe, "openai/cheap", 300)
     # A distinct dedupe endpoint rides on the request instead of the
     # process-wide base URL, so it can't clobber the main model's endpoint.
-    assert settings.extra_args["api_base"] == "https://dedupe.example/v1"
-    assert settings.extra_args["api_key"] == "dedupe-key"
+    assert (settings.extra_args or {})["api_base"] == "https://dedupe.example/v1"
+    assert (settings.extra_args or {})["api_key"] == "dedupe-key"
 
 
 def test_dedupe_defaults_are_empty() -> None:

--- a/tests/test_dedupe_model.py
+++ b/tests/test_dedupe_model.py
@@ -28,6 +28,20 @@ def test_dedupe_settings_omit_api_key_when_unset() -> None:
     dedupe = DedupeSettings(model="deepseek/cheap")
     settings = _dedupe_model_settings(dedupe, "deepseek/cheap", 300)
     assert "api_key" not in (settings.extra_args or {})
+    assert "api_base" not in (settings.extra_args or {})
+
+
+def test_dedupe_endpoint_sent_per_call() -> None:
+    dedupe = DedupeSettings(
+        model="openai/cheap",
+        api_key="dedupe-key",
+        api_base="https://dedupe.example/v1",
+    )
+    settings = _dedupe_model_settings(dedupe, "openai/cheap", 300)
+    # A distinct dedupe endpoint rides on the request instead of the
+    # process-wide base URL, so it can't clobber the main model's endpoint.
+    assert settings.extra_args["api_base"] == "https://dedupe.example/v1"
+    assert settings.extra_args["api_key"] == "dedupe-key"
 
 
 def test_dedupe_defaults_are_empty() -> None:

--- a/tests/test_dedupe_model.py
+++ b/tests/test_dedupe_model.py
@@ -1,0 +1,65 @@
+"""Tests for the dedicated deduplication model configuration."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from strix.config import loader
+from strix.config.settings import DedupeSettings
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_dedupe_defaults_are_empty() -> None:
+    settings = DedupeSettings()
+    assert settings.model is None
+    assert settings.reasoning_effort is None
+    assert settings.api_key is None
+
+
+def test_dedupe_model_read_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIX_DEDUPE_MODEL", "deepseek/deepseek-v4-flash")
+    monkeypatch.setenv("STRIX_DEDUPE_REASONING_EFFORT", "low")
+
+    settings = DedupeSettings()
+
+    assert settings.model == "deepseek/deepseek-v4-flash"
+    assert settings.reasoning_effort == "low"
+
+
+def test_config_file_loads_dedupe_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for key in ("STRIX_LLM", "STRIX_DEDUPE_MODEL", "STRIX_DEDUPE_REASONING_EFFORT"):
+        monkeypatch.delenv(key, raising=False)
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "STRIX_LLM": "openai/root",
+                    "STRIX_DEDUPE_MODEL": "deepseek/cheap",
+                    "STRIX_DEDUPE_REASONING_EFFORT": "minimal",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    loader._cached = None
+    loader._override = path
+    try:
+        settings = loader.load_settings()
+    finally:
+        loader._cached = None
+        loader._override = None
+
+    assert settings.dedupe.model == "deepseek/cheap"
+    assert settings.dedupe.reasoning_effort == "minimal"
+    # Main model stays independent of the dedupe override.
+    assert settings.llm.model == "openai/root"

--- a/tests/test_dedupe_model.py
+++ b/tests/test_dedupe_model.py
@@ -7,12 +7,27 @@ from typing import TYPE_CHECKING
 
 from strix.config import loader
 from strix.config.settings import DedupeSettings
+from strix.report.dedupe import _dedupe_model_settings
 
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     import pytest
+
+
+def test_dedupe_key_sent_per_call_not_via_global_env() -> None:
+    dedupe = DedupeSettings(model="deepseek/cheap", api_key="dedupe-key")
+    settings = _dedupe_model_settings(dedupe, "deepseek/cheap", 300)
+    # The key rides on the request, so a shared-provider main key can't clobber
+    # it (and vice versa) through the global provider env var.
+    assert settings.extra_args["api_key"] == "dedupe-key"
+
+
+def test_dedupe_settings_omit_api_key_when_unset() -> None:
+    dedupe = DedupeSettings(model="deepseek/cheap")
+    settings = _dedupe_model_settings(dedupe, "deepseek/cheap", 300)
+    assert "api_key" not in (settings.extra_args or {})
 
 
 def test_dedupe_defaults_are_empty() -> None:


### PR DESCRIPTION
## Summary

Lets finding **deduplication** run on its own (typically smaller/cheaper) model instead of always using the main scan model.

This is one of several split-out PRs for fine-grained model control. It is **fully self-contained** and targets `main` directly.

## Motivation

Deduplication is a cheap, structured "is this candidate a duplicate of an existing report?" classification. Today it always runs on the main model (`STRIX_LLM`) — the most expensive model in the scan. Routing it to a small model cuts cost with no impact on the agents doing the actual testing.

## Behavior
- **No change by default.** When `STRIX_DEDUPE_MODEL` is unset, dedupe falls back to `STRIX_LLM` exactly as before.
- Dedupe usage is still recorded in the `llm_usage` ledger and counts toward `--max-budget-usd`.
- When set, the dedupe model is validated at startup warm-up so a bad name/key fails fast.

## Config
| Env var | Meaning |
|---|---|
| `STRIX_DEDUPE_MODEL` | Model for dedupe (falls back to `STRIX_LLM`) |
| `DEDUPE_LLM_API_KEY` | Optional provider key for the dedupe model |
| `STRIX_DEDUPE_REASONING_EFFORT` | Reasoning effort for the dedupe model |

## Changes
- `strix/config/settings.py` — `DedupeSettings`.
- `strix/report/dedupe.py` — resolve the dedupe model with fallback; use reasoning-aware `make_model_settings`; mirror the dedupe API key to the provider env when set.
- Startup warm-up now also pings the dedupe model when configured.

## Test plan
- `pytest tests/test_dedupe_model.py` — defaults, env var, and config-file loading.
- `ruff` + `mypy` clean.

_Note: `tests/test_runner_root_prompt.py` currently fails on `main` (its settings mock lacks `runtime` while the runner reads `settings.runtime.max_context_images`). Pre-existing upstream issue, unrelated to this PR._