### PR TITLE
feat(routing): per-agent models and skill-based child routing

### DIFF
--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -7,8 +7,24 @@ Configure Strix using environment variables or a config file.
 
 ## LLM Configuration
 
-<ParamField path="STRIX_LLM" type="string" required>
-  Model name in LiteLLM format (e.g., `openai/gpt-5.4`, `anthropic/claude-sonnet-4-6`).
+<ParamField path="STRIX_ORCHESTRATOR_MODEL" type="string" required>
+  Model for the root/orchestrator in LiteLLM format (for example,
+  `openai/gpt-5.4`). `STRIX_LLM` remains a backward-compatible alias.
+</ParamField>
+
+<ParamField path="STRIX_SUBAGENT_MODEL" type="string">
+  Default model for child agents. If omitted, children use the orchestrator model.
+</ParamField>
+
+<ParamField path="SUBAGENT_LLM_API_KEY" type="string">
+  API key for the subagent provider. Strix mirrors it to the provider-specific
+  environment variable LiteLLM expects. It is optional when both routes use the
+  same provider/key or the provider uses ambient/local authentication.
+</ParamField>
+
+<ParamField path="STRIX_SUBAGENT_REASONING_EFFORT" type="string">
+  Reasoning effort for default and skill-routed subagents. Falls back to
+  `STRIX_REASONING_EFFORT` when omitted.
 </ParamField>
 
 <ParamField path="LLM_API_KEY" type="string">
@@ -34,6 +50,29 @@ Configure Strix using environment variables or a config file.
 <ParamField path="STRIX_MEMORY_COMPRESSOR_TIMEOUT" default="30" type="integer">
   Timeout in seconds for memory compression operations (context summarization).
 </ParamField>
+
+### Skill-based child routing
+
+Use the structured `llm.skill_model_routes` config field to select models based
+on the skills injected when a child is spawned. Rules are evaluated in order;
+the first match wins. A route accepts a concise single `skill`, or an
+`operator` of `AND`, `OR`, or `ANY`. `ANY` matches a child with any injected
+skill. An explicit model passed to `create_agent` takes precedence over routes.
+
+```json
+{
+  "llm": {
+    "model": "openai/gpt-5.4",
+    "subagent_model": "deepseek/deepseek-chat",
+    "skill_model_routes": [
+      {"skill": "business_logic", "model": "anthropic/claude-sonnet-4-6"},
+      {"operator": "AND", "skills": ["oauth", "authentication_jwt"], "model": "openai/gpt-5.4"},
+      {"operator": "OR", "skills": ["xss", "sql_injection"], "model": "dashscope/qwen-plus"},
+      {"operator": "ANY", "model": "deepseek/deepseek-chat"}
+    ]
+  }
+}
+```
 
 ## Optional Features
 
@@ -106,8 +145,10 @@ strix --target ./app --config /path/to/config.json
 ```json
 {
   "env": {
-    "STRIX_LLM": "openai/gpt-5.4",
-    "LLM_API_KEY": "sk-...",
+    "STRIX_ORCHESTRATOR_MODEL": "openai/gpt-5.4",
+    "STRIX_SUBAGENT_MODEL": "deepseek/deepseek-chat",
+    "LLM_API_KEY": "sk-main-...",
+    "SUBAGENT_LLM_API_KEY": "sk-child-...",
     "STRIX_REASONING_EFFORT": "high"
   }
 }

--- a/docs/usage/cli.mdx
+++ b/docs/usage/cli.mdx
@@ -61,6 +61,11 @@ strix (--target <target> | --target-list <path> | --mount <path>) [options]
   Path to a custom config file (JSON) to use instead of `~/.strix/cli-config.json`.
 </ParamField>
 
+<ParamField path="--subagent-model" type="string">
+  Override the config's default child-agent model for this run. Ordered
+  skill-specific routes in the config remain more specific and take precedence.
+</ParamField>
+
 <ParamField path="--max-budget-usd" type="number">
   Maximum LLM spend in USD for the whole scan, counted cumulatively across the
   root agent and every child agent. The budget is checked after each model

--- a/strix/agents/factory.py
+++ b/strix/agents/factory.py
@@ -9,6 +9,7 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from agents.agent import ToolsToFinalOutputResult
+from agents.model_settings import ModelSettings
 from agents.sandbox import SandboxAgent
 from agents.sandbox.capabilities import Filesystem, Shell
 from agents.sandbox.errors import InvalidManifestPathError
@@ -16,6 +17,8 @@ from agents.tool import CustomTool, FunctionTool, Tool
 from pydantic import ValidationError
 
 from strix.agents.prompt import render_system_prompt
+from strix.config.models import uses_chat_completions_tool_schema
+from strix.core.inputs import make_model_settings
 from strix.tools.agents_graph.tools import (
     agent_finish,
     create_agent,
@@ -59,6 +62,8 @@ if TYPE_CHECKING:
 
     from agents import RunContextWrapper
     from agents.tool import FunctionToolResult
+
+    from strix.config.settings import ReasoningEffort, Settings, SkillModelRoute
 
 
 logger = logging.getLogger(__name__)
@@ -408,6 +413,8 @@ def build_strix_agent(
     is_whitebox: bool = False,
     interactive: bool = False,
     chat_completions_tools: bool = False,
+    model: str | None = None,
+    model_settings: ModelSettings | None = None,
     system_prompt_context: dict[str, Any] | None = None,
     extra_tools: Sequence[Tool] | None = None,
     instructions_override: str | None = None,
@@ -417,6 +424,8 @@ def build_strix_agent(
     Args:
         chat_completions_tools: Wrap SDK custom tools as function tools
             when the selected backend cannot accept Responses custom tools.
+        model: Per-agent model route. When omitted, the run default is used.
+        model_settings: Settings resolved for this agent's own model.
         extra_tools: Additional tools for this scan agent only, on top of any
             registered via ``register_agent_tools``.
         instructions_override: Use this verbatim as the system prompt instead
@@ -456,7 +465,8 @@ def build_strix_agent(
         instructions=instructions,
         tools=tools,
         tool_use_behavior=_finish_tool_use_behavior,
-        model=None,
+        model=model,
+        model_settings=model_settings or ModelSettings(),
         capabilities=[
             Filesystem(
                 configure_tools=(
@@ -474,10 +484,11 @@ def build_strix_agent(
 
 def make_child_factory(
     *,
+    settings: Settings,
+    default_model: str,
     scan_mode: str = "deep",
     is_whitebox: bool = False,
     interactive: bool = False,
-    chat_completions_tools: bool = False,
     system_prompt_context: dict[str, Any] | None = None,
 ) -> Any:
     """Return the runner-owned builder used by ``spawn_child_agent``.
@@ -487,7 +498,36 @@ def make_child_factory(
     without the graph tool knowing about runner internals.
     """
 
-    def _factory(*, name: str, skills: list[str]) -> SandboxAgent[Any]:
+    llm = settings.llm
+
+    def _matching_route(skills: list[str]) -> SkillModelRoute | None:
+        return next((route for route in llm.skill_model_routes if route.matches(skills)), None)
+
+    def _factory(
+        *,
+        name: str,
+        skills: list[str],
+        model: str | None = None,
+    ) -> SandboxAgent[Any]:
+        route = _matching_route(skills) if model is None else None
+        resolved_model = (
+            model
+            or (route.model if route is not None else None)
+            or llm.subagent_model
+            or default_model
+        ).strip()
+        reasoning: ReasoningEffort | None = (
+            route.reasoning_effort
+            if route is not None and route.reasoning_effort is not None
+            else llm.subagent_reasoning_effort
+        )
+        if reasoning is None:
+            reasoning = llm.reasoning_effort
+        child_model_settings = make_model_settings(
+            reasoning,
+            model_name=resolved_model,
+            force_required_tool_choice=llm.force_required_tool_choice,
+        )
         return build_strix_agent(
             name=name,
             skills=skills,
@@ -495,7 +535,12 @@ def make_child_factory(
             scan_mode=scan_mode,
             is_whitebox=is_whitebox,
             interactive=interactive,
-            chat_completions_tools=chat_completions_tools,
+            chat_completions_tools=uses_chat_completions_tool_schema(
+                resolved_model,
+                settings,
+            ),
+            model=resolved_model,
+            model_settings=child_model_settings,
             system_prompt_context=system_prompt_context,
         )
 

--- a/strix/agents/factory.py
+++ b/strix/agents/factory.py
@@ -17,7 +17,7 @@ from agents.tool import CustomTool, FunctionTool, Tool
 from pydantic import ValidationError
 
 from strix.agents.prompt import render_system_prompt
-from strix.config.models import uses_chat_completions_tool_schema
+from strix.config.models import _same_provider, uses_chat_completions_tool_schema
 from strix.core.inputs import make_model_settings
 from strix.tools.agents_graph.tools import (
     agent_finish,
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     from agents import RunContextWrapper
     from agents.tool import FunctionToolResult
 
-    from strix.config.settings import ReasoningEffort, Settings, SkillModelRoute
+    from strix.config.settings import LlmSettings, ReasoningEffort, Settings, SkillModelRoute
 
 
 logger = logging.getLogger(__name__)
@@ -482,6 +482,22 @@ def build_strix_agent(
     )
 
 
+def _resolve_child_api_key(
+    llm: LlmSettings, resolved_model: str, default_model: str
+) -> str | None:
+    """Pick the credential a child should send as a per-call ``api_key``.
+
+    Prefer an explicit ``SUBAGENT_LLM_API_KEY``. Otherwise reuse the
+    orchestrator key only when the child shares the orchestrator's provider;
+    cross-provider children fall back to their provider's ambient env/auth.
+    """
+    if llm.subagent_api_key and llm.subagent_api_key.strip():
+        return llm.subagent_api_key.strip()
+    if llm.api_key and _same_provider(resolved_model, default_model):
+        return llm.api_key
+    return None
+
+
 def make_child_factory(
     *,
     settings: Settings,
@@ -523,10 +539,12 @@ def make_child_factory(
         )
         if reasoning is None:
             reasoning = llm.reasoning_effort
+        child_api_key = _resolve_child_api_key(llm, resolved_model, default_model)
         child_model_settings = make_model_settings(
             reasoning,
             model_name=resolved_model,
             force_required_tool_choice=llm.force_required_tool_choice,
+            api_key=child_api_key,
         )
         return build_strix_agent(
             name=name,

--- a/strix/config/__init__.py
+++ b/strix/config/__init__.py
@@ -21,6 +21,7 @@ from strix.config.settings import (
     LlmSettings,
     RuntimeSettings,
     Settings,
+    SkillModelRoute,
     TelemetrySettings,
 )
 
@@ -30,6 +31,7 @@ __all__ = [
     "LlmSettings",
     "RuntimeSettings",
     "Settings",
+    "SkillModelRoute",
     "TelemetrySettings",
     "apply_config_override",
     "load_settings",

--- a/strix/config/loader.py
+++ b/strix/config/loader.py
@@ -60,7 +60,7 @@ def persist_current() -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
 
     env_block: dict[str, str] = {}
-    for sub_name in s.model_fields:
+    for sub_name in type(s).model_fields:
         sub_model = getattr(s, sub_name)
         if not isinstance(sub_model, BaseModel):
             continue
@@ -71,7 +71,18 @@ def persist_current() -> None:
                     env_block[alias.upper()] = value
                     break
 
-    target.write_text(json.dumps({"env": env_block}, indent=2), encoding="utf-8")
+    preserved: dict[str, Any] = {}
+    if target.exists():
+        try:
+            current = json.loads(target.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            current = {}
+        if isinstance(current, dict):
+            preserved = {key: value for key, value in current.items() if key != "env"}
+    target.write_text(
+        json.dumps({**preserved, "env": env_block}, indent=2),
+        encoding="utf-8",
+    )
     with contextlib.suppress(OSError):
         target.chmod(0o600)
 
@@ -89,7 +100,7 @@ def _aliases_for(finfo: FieldInfo) -> list[str]:
     return aliases
 
 
-def _read_json_overrides(path: Path) -> dict[str, dict[str, Any]]:
+def _read_json_overrides(path: Path) -> dict[str, dict[str, Any]]:  # noqa: PLR0912
     """Read ``{"env": {...}}`` from ``path`` and remap to nested kwargs.
 
     Only includes keys whose env var is NOT already set, so env always
@@ -101,9 +112,11 @@ def _read_json_overrides(path: Path) -> dict[str, dict[str, Any]]:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return {}
-    env_block = data.get("env", {}) if isinstance(data, dict) else {}
-    if not isinstance(env_block, dict):
+    if not isinstance(data, dict):
         return {}
+    env_block = data.get("env", {})
+    if not isinstance(env_block, dict):
+        env_block = {}
 
     env_block_upper = {str(k).upper(): v for k, v in env_block.items()}
     env_present = {k.upper() for k in os.environ}
@@ -114,6 +127,10 @@ def _read_json_overrides(path: Path) -> dict[str, dict[str, Any]]:
         if not (isinstance(sub_cls, type) and issubclass(sub_cls, BaseModel)):
             continue
         sub_data: dict[str, Any] = {}
+        structured = data.get(sub_name, {})
+        if not isinstance(structured, dict):
+            structured = {}
+        structured_lower = {str(key).lower(): value for key, value in structured.items()}
         for fname, finfo in sub_cls.model_fields.items():
             aliases = [alias.upper() for alias in _aliases_for(finfo)]
             if any(alias in env_present for alias in aliases):
@@ -122,6 +139,15 @@ def _read_json_overrides(path: Path) -> dict[str, dict[str, Any]]:
                 if alias in env_block_upper:
                     sub_data[fname] = env_block_upper[alias]
                     break
+            else:
+                # Structured sections are needed for values such as ordered
+                # skill-routing rules while retaining backward-compatible
+                # {"env": {...}} files.
+                keys = [fname.lower(), *(alias.lower() for alias in _aliases_for(finfo))]
+                for key in keys:
+                    if key in structured_lower:
+                        sub_data[fname] = structured_lower[key]
+                        break
         if sub_data:
             nested[sub_name] = sub_data
     return nested

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -121,14 +121,43 @@ def configure_sdk_model_defaults(settings: Settings) -> None:
     _configure_openrouter_attribution(llm.model)
     if llm.api_key:
         set_default_openai_key(llm.api_key, use_for_tracing=False)
-        _configure_litellm_default("api_key", llm.api_key)
+        # Do not set LiteLLM's process-global ``api_key``: that would leak the
+        # orchestrator credential into differently-routed child providers.
+        # Provider-specific environment variables keep concurrent routes apart.
         _mirror_api_key_to_provider_env(llm.model, llm.api_key)
+    for model_name in _subagent_model_names(settings):
+        key = llm.subagent_api_key or (
+            llm.api_key if _same_provider(model_name, llm.model) else None
+        )
+        if key:
+            _mirror_api_key_to_provider_env(model_name, key)
     if llm.api_base:
         os.environ["OPENAI_BASE_URL"] = llm.api_base
         _configure_litellm_default("api_base", llm.api_base)
         set_default_openai_api("chat_completions")
     else:
         set_default_openai_api("responses")
+
+
+def _provider_prefix(model_name: str | None) -> str | None:
+    if not model_name:
+        return None
+    name = _normalized_model_name(model_name)
+    if "/" not in name:
+        return "openai"
+    return name.split("/", 1)[0]
+
+
+def _same_provider(first: str | None, second: str | None) -> bool:
+    return _provider_prefix(first) == _provider_prefix(second)
+
+
+def _subagent_model_names(settings: Settings) -> set[str]:
+    llm = settings.llm
+    names = {route.model for route in llm.skill_model_routes if route.model}
+    if llm.subagent_model:
+        names.add(llm.subagent_model)
+    return names
 
 
 def _mirror_api_key_to_provider_env(model_name: str | None, api_key: str) -> None:

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+SkillRouteOperator = Literal["AND", "OR", "ANY"]
 
 _BASE_CONFIG = SettingsConfigDict(
     case_sensitive=False,
@@ -17,10 +18,61 @@ _BASE_CONFIG = SettingsConfigDict(
 )
 
 
+class SkillModelRoute(BaseModel):
+    """Select a child model from its injected skills.
+
+    Rules are evaluated in config order. ``skill`` is the concise form for a
+    single-skill rule. ``ANY`` matches every child that has at least one skill.
+    """
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+    model: str
+    operator: SkillRouteOperator | None = Field(default=None, pattern="^(AND|OR|ANY)$")
+    skills: list[str] = Field(default_factory=list)
+    skill: str | None = None
+    reasoning_effort: ReasoningEffort | None = None
+
+    @model_validator(mode="after")
+    def validate_rule(self) -> SkillModelRoute:
+        self.model = self.model.strip()
+        self.skills = [skill.strip() for skill in self.skills if skill.strip()]
+        if self.skill:
+            self.skill = self.skill.strip() or None
+        if not self.model:
+            raise ValueError("skill model route requires a non-empty model")
+        if self.skill and (self.operator is not None or self.skills):
+            raise ValueError("use either 'skill' or 'operator'/'skills', not both")
+        if self.skill:
+            return self
+        if self.operator is None:
+            raise ValueError("skill model route requires 'skill' or 'operator'")
+        if self.operator != "ANY" and not self.skills:
+            raise ValueError(f"{self.operator} skill model route requires skills")
+        return self
+
+    def matches(self, injected_skills: list[str]) -> bool:
+        assigned = {skill.strip().lower() for skill in injected_skills if skill.strip()}
+        if self.skill:
+            return self.skill.lower() in assigned
+        configured = {skill.lower() for skill in self.skills}
+        if self.operator == "ANY":
+            return bool(assigned)
+        if self.operator == "AND":
+            return bool(configured) and configured <= assigned
+        return bool(configured & assigned)
+
+
 class LlmSettings(BaseSettings):
     model_config = _BASE_CONFIG
 
-    model: str | None = Field(default=None, alias="STRIX_LLM")
+    model: str | None = Field(
+        default=None,
+        alias="STRIX_ORCHESTRATOR_MODEL",
+        validation_alias=AliasChoices("STRIX_ORCHESTRATOR_MODEL", "STRIX_LLM"),
+    )
+    subagent_model: str | None = Field(default=None, alias="STRIX_SUBAGENT_MODEL")
+    skill_model_routes: list[SkillModelRoute] = Field(default_factory=list)
     api_key: str | None = Field(
         default=None,
         validation_alias=AliasChoices("LLM_API_KEY", "OPENAI_API_KEY"),
@@ -36,6 +88,11 @@ class LlmSettings(BaseSettings):
         ),
     )
     reasoning_effort: ReasoningEffort = Field(default="high", alias="STRIX_REASONING_EFFORT")
+    subagent_reasoning_effort: ReasoningEffort | None = Field(
+        default=None,
+        alias="STRIX_SUBAGENT_REASONING_EFFORT",
+    )
+    subagent_api_key: str | None = Field(default=None, alias="SUBAGENT_LLM_API_KEY")
     force_required_tool_choice: bool = Field(
         default=False,
         alias="STRIX_FORCE_REQUIRED_TOOL_CHOICE",

--- a/strix/core/agents.py
+++ b/strix/core/agents.py
@@ -72,6 +72,7 @@ class AgentCoordinator:
         *,
         task: str | None = None,
         skills: list[str] | None = None,
+        model: str | None = None,
     ) -> None:
         async with self._lock:
             self.statuses[agent_id] = "running"
@@ -81,6 +82,7 @@ class AgentCoordinator:
             self.metadata[agent_id] = {
                 "task": task or "",
                 "skills": list(skills or []),
+                "model": model,
             }
             self.runtimes.setdefault(agent_id, AgentRuntime())
         logger.info("agent.register %s (%s) parent=%s", agent_id, name, parent_id or "-")

--- a/strix/core/execution.py
+++ b/strix/core/execution.py
@@ -136,6 +136,7 @@ async def spawn_child_agent(
     task: str,
     skills: list[str],
     parent_history: list[Any],
+    model: str | None = None,
     event_sink: StreamEventSink | None = None,
     hooks: RunHooks[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
@@ -144,13 +145,19 @@ async def spawn_child_agent(
         raise TypeError("Parent agent_id missing from context")
 
     child_id = uuid.uuid4().hex[:8]
-    child_agent = factory(name=name, skills=skills)
+    if model is None:
+        child_agent = factory(name=name, skills=skills)
+    else:
+        child_agent = factory(name=name, skills=skills, model=model)
+    child_model = getattr(child_agent, "model", None)
+    resolved_child_model = child_model if isinstance(child_model, str) else model
     await coordinator.register(
         child_id,
         name,
         parent_id,
         task=task,
         skills=skills,
+        model=resolved_child_model,
     )
 
     await _start_child_runner(
@@ -235,7 +242,12 @@ async def respawn_subagents(
                 )
 
             child_skills = list(md.get("skills") or [])
-            child_agent = factory(name=name, skills=child_skills)
+            restored_model = md.get("model")
+            child_agent = factory(
+                name=name,
+                skills=child_skills,
+                model=restored_model if isinstance(restored_model, str) else None,
+            )
             await _start_child_runner(
                 parent_ctx=parent_ctx,
                 coordinator=coordinator,

--- a/strix/core/hooks.py
+++ b/strix/core/hooks.py
@@ -53,11 +53,13 @@ class ReportUsageHooks(RunHooks[dict[str, Any]]):
         if not isinstance(agent_id, str) or not agent_id:
             agent_id = agent_name or "unknown"
 
+        agent_model = getattr(agent, "model", None)
+        model = agent_model if isinstance(agent_model, str) and agent_model else self._model
         try:
             report_state.record_sdk_usage(
                 agent_id=agent_id,
                 agent_name=agent_name,
-                model=self._model,
+                model=model,
                 usage=response.usage,
             )
         except Exception:

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -128,12 +128,19 @@ def make_model_settings(
     model_name: str,
     force_required_tool_choice: bool = False,
     request_timeout: float | None = None,
+    api_key: str | None = None,
 ) -> ModelSettings:
+    extra_args: dict[str, Any] = dict(request_timeout_extra_args(request_timeout) or {})
+    # Per-call credential. Env vars are global per provider, so this is the only
+    # way to give same-provider routes (root vs. child/verifier/dedupe) distinct
+    # keys without one clobbering another.
+    if api_key and api_key.strip():
+        extra_args["api_key"] = api_key.strip()
     model_settings = ModelSettings(
         parallel_tool_calls=False,
         retry=DEFAULT_MODEL_RETRY,
         include_usage=True,
-        extra_args=request_timeout_extra_args(request_timeout),
+        extra_args=extra_args or None,
     )
     if (
         reasoning_effort is not None

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -217,10 +217,12 @@ async def run_strix_scan(
             force_required_tool_choice=settings.llm.force_required_tool_choice,
             request_timeout=settings.llm.timeout,
         )
+        # Models and reasoning settings live on each agent. Keeping these unset
+        # here is essential: RunConfig values override every per-agent route.
         run_config = RunConfig(
-            model=resolved_model,
+            model=None,
             model_provider=StrixProvider(),
-            model_settings=model_settings,
+            model_settings=None,
             sandbox=SandboxRunConfig(client=bundle["client"], session=bundle["session"]),
             trace_include_sensitive_data=False,
         )
@@ -245,6 +247,8 @@ async def run_strix_scan(
             is_whitebox=is_whitebox,
             interactive=interactive,
             chat_completions_tools=chat_completions_tools,
+            model=resolved_model,
+            model_settings=model_settings,
             system_prompt_context=root_context,
             instructions_override=root_instructions,
         )
@@ -259,10 +263,11 @@ async def run_strix_scan(
             )
 
         child_agent_builder = make_child_factory(
+            settings=settings,
+            default_model=resolved_model,
             scan_mode=scan_mode,
             is_whitebox=is_whitebox,
             interactive=interactive,
-            chat_completions_tools=chat_completions_tools,
             system_prompt_context=scope_context,
         )
 

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -266,6 +266,25 @@ def _provider_import_hint(exc: BaseException, model: str) -> str | None:
     return None
 
 
+async def _warm_up_model(model_name: str, timeout: int) -> None:
+    model = StrixProvider().get_model(model_name)
+    await asyncio.wait_for(
+        model.get_response(
+            system_instructions="You are a helpful assistant.",
+            input="Reply with just 'OK'.",
+            model_settings=ModelSettings(),
+            tools=[],
+            output_schema=None,
+            handoffs=[],
+            tracing=ModelTracing.DISABLED,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        ),
+        timeout=timeout,
+    )
+
+
 async def warm_up_llm(show_model_warning: bool = True) -> None:
     console = Console()
     logger.info("Warming up LLM connection")
@@ -334,23 +353,14 @@ async def warm_up_llm(show_model_warning: bool = True) -> None:
                 ),
             )
 
-        model = StrixProvider().get_model(raw_model)
-        await asyncio.wait_for(
-            model.get_response(
-                system_instructions="You are a helpful assistant.",
-                input="Reply with just 'OK'.",
-                model_settings=ModelSettings(),
-                tools=[],
-                output_schema=None,
-                handoffs=[],
-                tracing=ModelTracing.DISABLED,
-                previous_response_id=None,
-                conversation_id=None,
-                prompt=None,
-            ),
-            timeout=llm.timeout,
-        )
-        logger.info("LLM warm-up succeeded for model %s", (llm.model or "").strip())
+        models_to_warm = [raw_model]
+        if llm.subagent_model:
+            models_to_warm.append(llm.subagent_model.strip())
+        models_to_warm.extend(route.model for route in llm.skill_model_routes)
+        for configured_model in dict.fromkeys(models_to_warm):
+            raw_model = configured_model
+            await _warm_up_model(configured_model, llm.timeout)
+            logger.info("LLM warm-up succeeded for model %s", configured_model)
 
     except Exception as e:
         logger.exception("LLM warm-up failed")
@@ -543,6 +553,16 @@ Examples:
         "--config",
         type=str,
         help="Path to a custom config file (JSON) to use instead of ~/.strix/cli-config.json",
+    )
+
+    parser.add_argument(
+        "--subagent-model",
+        type=str,
+        default=None,
+        help=(
+            "Override the config's default model for all subagents. "
+            "Skill-specific config routes still take precedence."
+        ),
     )
 
     parser.add_argument(
@@ -850,6 +870,10 @@ def main() -> None:
 
     if args.config:
         apply_config_override(validate_config_file(args.config))
+    if args.subagent_model:
+        # CLI is an intentional one-run override. Skill routes remain more
+        # specific and are therefore evaluated before this default.
+        load_settings().llm.subagent_model = args.subagent_model.strip()
 
     check_docker_installed()
     pull_docker_image()

--- a/strix/report/usage.py
+++ b/strix/report/usage.py
@@ -18,6 +18,7 @@ class LLMUsageLedger:
         self._total_usage = Usage()
         self._agent_usage: dict[str, Usage] = {}
         self._agent_metadata: dict[str, dict[str, str]] = {}
+        self._agent_cost: dict[str, float] = {}
         self._total_cost = 0.0
 
     def record(
@@ -45,6 +46,9 @@ class LLMUsageLedger:
             estimated = _estimate_litellm_cost(usage, model)
             if estimated:
                 self._total_cost += estimated
+                self._agent_cost[normalized_agent_id] = (
+                    self._agent_cost.get(normalized_agent_id, 0.0) + estimated
+                )
 
         return True
 
@@ -62,13 +66,25 @@ class LLMUsageLedger:
         record["agents"] = []
 
         agent_tokens = {aid: _resolve_total_tokens(u) for aid, u in self._agent_usage.items()}
-        total_tokens = sum(agent_tokens.values())
+        # Native provider estimates are tied to an agent. Any remainder comes
+        # from LiteLLM callbacks, whose callback interface has no Strix agent id.
+        unassigned_cost = max(0.0, self._total_cost - sum(self._agent_cost.values()))
+        litellm_agent_tokens = sum(
+            tokens
+            for aid, tokens in agent_tokens.items()
+            if _is_litellm_routed(self._agent_metadata.get(aid, {}).get("model"))
+        )
         for agent_id in sorted(self._agent_usage):
             usage = self._agent_usage[agent_id]
             metadata = self._agent_metadata.get(agent_id, {})
-            agent_cost = (
-                self._total_cost * (agent_tokens[agent_id] / total_tokens) if total_tokens else 0.0
-            )
+            agent_cost = self._agent_cost.get(agent_id, 0.0)
+            if _is_litellm_routed(metadata.get("model")) and litellm_agent_tokens:
+                # LiteLLM's callback does not carry Strix's agent id. Allocate
+                # only callback-observed cost across LiteLLM agents by tokens;
+                # never smear it over native-provider agents.
+                agent_cost += unassigned_cost * (
+                    agent_tokens[agent_id] / litellm_agent_tokens
+                )
 
             agent_record = serialize_usage(usage)
             agent_record.update(
@@ -87,6 +103,7 @@ class LLMUsageLedger:
         self._total_usage = Usage()
         self._agent_usage.clear()
         self._agent_metadata.clear()
+        self._agent_cost.clear()
         self._total_cost = 0.0
 
         if not isinstance(raw_usage, dict):
@@ -120,6 +137,11 @@ class LLMUsageLedger:
             if isinstance(model, str) and model:
                 metadata["model"] = model
             self._agent_metadata[agent_id] = metadata
+            # Persisted per-agent costs may include proportional allocation of
+            # provider callback costs. Keep only native estimates here so a
+            # resumed run does not double-count that allocation.
+            if not _is_litellm_routed(metadata.get("model")):
+                self._agent_cost[agent_id] = _float_or_zero(raw_agent.get("cost"))
 
 
 def _resolve_total_tokens(usage: Usage) -> int:

--- a/strix/tools/agents_graph/tools.py
+++ b/strix/tools/agents_graph/tools.py
@@ -368,6 +368,7 @@ async def create_agent(
     task: str,
     inherit_context: bool = True,
     skills: list[str] | None = None,
+    model: str | None = None,
 ) -> str:
     """Spawn a specialist child agent to run in parallel.
 
@@ -408,6 +409,8 @@ async def create_agent(
             when starting a clean-slate task.
         skills: List of skill names (e.g. ``["xss", "sql_injection"]``).
             Max 5; prefer 1-3.
+        model: Optional explicit model override for this spawn. Omit it to use
+            config-driven skill routing and the default subagent model.
     """
     inner = _ctx(ctx)
     coordinator = coordinator_from_context(inner)
@@ -446,6 +449,7 @@ async def create_agent(
             name=name,
             task=task,
             skills=skill_list,
+            model=model.strip() if isinstance(model, str) and model.strip() else None,
             parent_history=parent_history,
         )
     except Exception as e:

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -1,0 +1,91 @@
+"""Per-model root, child, skill, and usage routing tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from agents.model_settings import ModelSettings
+from agents.usage import Usage
+
+from strix.agents.factory import build_strix_agent, make_child_factory
+from strix.config.settings import LlmSettings, Settings, SkillModelRoute
+from strix.core.hooks import ReportUsageHooks
+
+
+def test_build_agent_accepts_model_and_settings() -> None:
+    model_settings = ModelSettings(parallel_tool_calls=False)
+    agent = build_strix_agent(
+        is_root=True,
+        model="openai/frontier",
+        model_settings=model_settings,
+    )
+    assert agent.model == "openai/frontier"
+    assert agent.model_settings is model_settings
+
+
+def test_skill_route_matching_operators() -> None:
+    assert SkillModelRoute(skill="xss", model="one").matches(["xss"])
+    assert SkillModelRoute(operator="AND", skills=["oauth", "xss"], model="two").matches(
+        ["xss", "oauth", "nmap"]
+    )
+    assert SkillModelRoute(operator="OR", skills=["xss", "sqli"], model="three").matches(
+        ["sqli"]
+    )
+    assert SkillModelRoute(operator="ANY", model="four").matches(["nmap"])
+    assert not SkillModelRoute(operator="ANY", model="four").matches([])
+
+
+def test_child_factory_precedence_and_per_model_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = Settings(
+        llm=LlmSettings(
+            model="openai/root",
+            subagent_model="deepseek/cheap",
+            skill_model_routes=[
+                {"skill": "xss", "model": "anthropic/specialist"},
+                {"operator": "ANY", "model": "qwen/fallback"},
+            ],
+        )
+    )
+    seen_schema_models: list[str] = []
+    monkeypatch.setattr(
+        "strix.agents.factory.uses_chat_completions_tool_schema",
+        lambda model, _settings: seen_schema_models.append(model) or model != "openai/escalated",
+    )
+    monkeypatch.setattr(
+        "strix.agents.factory.make_model_settings",
+        lambda *_args, **_kwargs: ModelSettings(),
+    )
+    factory = make_child_factory(settings=settings, default_model="openai/root")
+
+    routed = factory(name="specialist", skills=["xss"])
+    explicit = factory(name="escalated", skills=["xss"], model="openai/escalated")
+
+    assert routed.model == "anthropic/specialist"
+    assert explicit.model == "openai/escalated"
+    assert seen_schema_models == ["anthropic/specialist", "openai/escalated"]
+
+
+def test_child_factory_falls_back_to_orchestrator() -> None:
+    settings = Settings(llm=LlmSettings(model="openai/root"))
+    child = make_child_factory(settings=settings, default_model="openai/root")(
+        name="child",
+        skills=[],
+    )
+    assert child.model == "openai/root"
+
+
+@pytest.mark.asyncio
+async def test_usage_hook_records_each_agents_actual_model() -> None:
+    hooks = ReportUsageHooks(model="openai/root")
+    state = MagicMock()
+    state.get_total_llm_cost.return_value = 0.0
+    context = SimpleNamespace(context={"agent_id": "child-1"})
+    agent = SimpleNamespace(name="child", model="deepseek/cheap")
+    response = SimpleNamespace(usage=Usage(input_tokens=10, output_tokens=5, total_tokens=15))
+
+    with patch("strix.core.hooks.get_global_report_state", return_value=state):
+        await hooks.on_llm_end(context, agent, response)
+
+    assert state.record_sdk_usage.call_args.kwargs["model"] == "deepseek/cheap"

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -9,9 +9,42 @@ import pytest
 from agents.model_settings import ModelSettings
 from agents.usage import Usage
 
-from strix.agents.factory import build_strix_agent, make_child_factory
+from strix.agents.factory import _resolve_child_api_key, build_strix_agent, make_child_factory
 from strix.config.settings import LlmSettings, Settings, SkillModelRoute
 from strix.core.hooks import ReportUsageHooks
+
+
+def test_child_api_key_prefers_explicit_subagent_key() -> None:
+    llm = LlmSettings(
+        model="openai/root",
+        api_key="root-key",
+        subagent_api_key="child-key",
+    )
+    # Explicit subagent key wins even when the child shares the root provider.
+    assert _resolve_child_api_key(llm, "openai/child", "openai/root") == "child-key"
+
+
+def test_child_api_key_reuses_root_key_only_for_same_provider() -> None:
+    llm = LlmSettings(model="openai/root", api_key="root-key")
+    assert _resolve_child_api_key(llm, "openai/mini", "openai/root") == "root-key"
+    # A cross-provider child must not receive the root provider's credential.
+    assert _resolve_child_api_key(llm, "anthropic/opus", "openai/root") is None
+
+
+def test_child_api_key_flows_into_model_settings_extra_args() -> None:
+    settings = Settings(
+        llm=LlmSettings(
+            model="openai/root",
+            api_key="root-key",
+            subagent_api_key="child-key",
+        )
+    )
+    child = make_child_factory(settings=settings, default_model="openai/root")(
+        name="worker",
+        skills=[],
+        model="anthropic/opus",
+    )
+    assert child.model_settings.extra_args["api_key"] == "child-key"
 
 
 def test_build_agent_accepts_model_and_settings() -> None:

--- a/tests/test_runner_root_prompt.py
+++ b/tests/test_runner_root_prompt.py
@@ -46,7 +46,8 @@ def _patch_engine_scaffold(
             reasoning_effort="high",
             force_required_tool_choice=False,
             timeout=300,
-        )
+        ),
+        runtime=types.SimpleNamespace(max_context_images=None),
     )
     monkeypatch.setattr(runner, "load_settings", lambda: settings)
     monkeypatch.setattr(runner, "configure_sdk_model_defaults", lambda _settings: None)


### PR DESCRIPTION
## Summary

Foundational change for fine-grained model control: **each agent gets its own model** instead of the whole scan being pinned to one model. Adds a default subagent model and ordered **skill-based routing** so specialist child agents can run on different models.

This is PR 1 of a split series. **PR 2 (budget fallbacks) stacks on this one;** the verification (#822) and dedupe (#823) PRs are independent.

## What changes for users
- **Nothing by default.** With only `STRIX_LLM` set, every agent uses it exactly as before.
- `STRIX_LLM` still works — it's now a back-compat **alias** for `STRIX_ORCHESTRATOR_MODEL`.
- Opt-in: give subagents their own model, and route specific skills to specific models.

## Config
| Env var | Meaning |
|---|---|
| `STRIX_ORCHESTRATOR_MODEL` / `STRIX_LLM` | Root/orchestrator model (required) |
| `STRIX_SUBAGENT_MODEL` | Default child-agent model (falls back to orchestrator) |
| `STRIX_SUBAGENT_REASONING_EFFORT` | Reasoning effort for children |
| `SUBAGENT_LLM_API_KEY` | Optional provider key for the subagent provider |
| `--subagent-model` | One-run CLI override of the default child model |

Skill routing is configured via the structured `llm.skill_model_routes` list (ordered; first match wins):

```json
{
  "llm": {
    "model": "openai/gpt-5.4",
    "subagent_model": "deepseek/deepseek-chat",
    "skill_model_routes": [
      {"skill": "business_logic", "model": "anthropic/claude-sonnet-4-6"},
      {"operator": "AND", "skills": ["oauth", "authentication_jwt"], "model": "openai/gpt-5.4"},
      {"operator": "OR", "skills": ["xss", "sql_injection"], "model": "dashscope/qwen-plus"},
      {"operator": "ANY", "model": "deepseek/deepseek-chat"}
    ]
  }
}
```

Precedence: explicit `create_agent(model=...)` → matching skill route → `subagent_model` → orchestrator model.

## Key implementation notes
- **`RunConfig.model`/`model_settings` are now `None`.** This is essential — RunConfig values override every per-agent route. Each `SandboxAgent` carries its own model + settings instead.
- Resolved child models are **persisted per agent** so a resumed scan reuses the same model.
- `chat_completions` tool-schema detection is computed **per child** from its resolved model.
- Provider-aware API-key mirroring stops the orchestrator credential leaking into a differently-routed child provider.

## Test plan
- `pytest tests/test_model_routing.py` — build-agent model/settings, skill-route operators, factory precedence + per-model schema, orchestrator fallback, and per-agent usage recording.
- Full suite green (248), `ruff` + `mypy` clean. Also fixes the pre-existing `test_runner_root_prompt.py` mock (missing `runtime`).