### PR TITLE
fix(report): write the executive report atomically

### DIFF
--- a/strix/report/writer.py
+++ b/strix/report/writer.py
@@ -57,10 +57,13 @@ def write_run_record(run_dir: Path, run_record: dict[str, Any]) -> None:
 
 def write_executive_report(run_dir: Path, final_scan_result: str) -> None:
     path = run_dir / "penetration_test_report.md"
-    with path.open("w", encoding="utf-8") as f:
-        f.write("# Security Penetration Test Report\n\n")
-        f.write(f"**Generated:** {datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S UTC')}\n\n")
-        f.write(f"{final_scan_result}\n")
+    generated = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+    _atomic_write_text(
+        path,
+        "# Security Penetration Test Report\n\n"
+        f"**Generated:** {generated}\n\n"
+        f"{final_scan_result}\n",
+    )
     logger.info("Saved final penetration test report to: %s", path)
 
 

--- a/tests/test_report_writer.py
+++ b/tests/test_report_writer.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from strix.report import writer
 from strix.report.writer import (
     read_run_record,
     render_vulnerability_md,
@@ -177,3 +178,28 @@ def test_write_executive_report_writes_markdown(tmp_path: Path) -> None:
     content = (tmp_path / "penetration_test_report.md").read_text(encoding="utf-8")
     assert "# Security Penetration Test Report" in content
     assert "Scan complete. No critical issues." in content
+
+
+def test_write_executive_report_keeps_previous_report_when_rendering_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_executive_report(tmp_path, "First complete report.")
+    path = tmp_path / "penetration_test_report.md"
+
+    class _BoomDatetime:
+        @staticmethod
+        def now(_tz: Any) -> Any:
+            raise OSError("clock unavailable")
+
+    monkeypatch.setattr(writer, "datetime", _BoomDatetime)
+
+    with pytest.raises(OSError, match="clock unavailable"):
+        write_executive_report(tmp_path, "Second report.")
+
+    assert "First complete report." in path.read_text(encoding="utf-8")
+
+
+def test_write_executive_report_leaves_no_temp_files(tmp_path: Path) -> None:
+    write_executive_report(tmp_path, "Scan complete.")
+    assert [p.name for p in tmp_path.iterdir()] == ["penetration_test_report.md"]


### PR DESCRIPTION
Fixes #828

### What

`write_executive_report` now builds its payload first and writes it through the module's existing `_atomic_write_text` helper, instead of truncating the destination in place with `path.open("w")`.

### Why

It was the only artifact writer in `writer.py` that was not atomic. `write_run_record` (`:52`), the per-vulnerability markdown (`:78`), `vulnerabilities.csv` (`:103`) and `vulnerabilities.json` (`:105`) all already route through `_atomic_write_text`, which writes a temp file in the same directory and `Path.replace()`s it into place.

Because `open("w")` truncates before the first byte is written, any failure partway through — ENOSPC, a disconnected network mount, `Ctrl-C`, an OOM kill — left `penetration_test_report.md` truncated or empty **and** the previous complete report already destroyed. That file is the primary human-readable deliverable of a scan.

### Before / after

```python
writer.write_executive_report(run_dir, "First complete report.")
# ... second write fails partway through (timestamp render raises) ...
(run_dir / "penetration_test_report.md").read_text()
```

| | result |
|---|---|
| before | `'# Security Penetration Test Report\n\n'` — prior report lost |
| after | `'# Security Penetration Test Report\n\n**Generated:** ...\n\nFirst complete report.\n'` — prior report intact |

### Tests

Added to `tests/test_report_writer.py`:

- `test_write_executive_report_keeps_previous_report_when_rendering_fails` — writes a report, patches the timestamp source to raise, and asserts the first report survives. **Fails on `main`** (`AssertionError`), passes with this change.
- `test_write_executive_report_leaves_no_temp_files` — guards that the atomic write cleans up after itself.

```
uv run pytest tests/test_report_writer.py -q
13 passed
```

Full suite is unchanged at `2 failed, 314 passed`; both failures are pre-existing on `main` (`tests/test_runner_root_prompt.py`, a stale `SimpleNamespace` settings stub missing `runtime`) and unrelated to this change — I have a separate PR for those.

`ruff format --check`, `ruff check` and `mypy strix/report/writer.py` are clean.

### Scope

One function, one file, plus tests. No API or output-format change: the produced report is byte-identical on the success path.
