### PR TITLE
fix(runtime): reap the sandbox container when Caido bootstrap fails

### DIFF
--- a/strix/runtime/session_manager.py
+++ b/strix/runtime/session_manager.py
@@ -126,16 +126,28 @@ async def create_or_reuse(
         for staged in staged_dirs:
             shutil.rmtree(staged, ignore_errors=True)
 
-    caido_endpoint = await session.resolve_exposed_port(_CONTAINER_CAIDO_PORT)
-    scheme = "https" if caido_endpoint.tls else "http"
-    host_caido_url = f"{scheme}://{caido_endpoint.host}:{caido_endpoint.port}"
-    logger.debug("Caido host endpoint resolved: %s", host_caido_url)
+    # The container is running from here on, but it is not in ``_SESSION_CACHE``
+    # yet -- and ``cleanup`` only tears down what it finds there. If port
+    # resolution or the Caido bootstrap fails, nothing would ever reap it, so
+    # delete it here before propagating.
+    try:
+        caido_endpoint = await session.resolve_exposed_port(_CONTAINER_CAIDO_PORT)
+        scheme = "https" if caido_endpoint.tls else "http"
+        host_caido_url = f"{scheme}://{caido_endpoint.host}:{caido_endpoint.port}"
+        logger.debug("Caido host endpoint resolved: %s", host_caido_url)
 
-    caido_client = await bootstrap_caido(
-        session,
-        host_url=host_caido_url,
-        container_url=container_caido_url,
-    )
+        caido_client = await bootstrap_caido(
+            session,
+            host_url=host_caido_url,
+            container_url=container_caido_url,
+        )
+    except BaseException:
+        logger.exception(
+            "Sandbox bootstrap failed for scan %s; deleting the container it started",
+            scan_id,
+        )
+        await _delete_quietly(client, session, scan_id)
+        raise
 
     bundle = {
         "client": client,
@@ -167,9 +179,17 @@ async def cleanup(scan_id: str) -> None:
         except Exception:  # noqa: BLE001
             logger.debug("cleanup(%s): caido_client.aclose() raised", scan_id, exc_info=True)
 
-    client = bundle["client"]
+    await _delete_quietly(bundle["client"], bundle["session"], scan_id)
+
+
+async def _delete_quietly(client: Any, session: Any, scan_id: str) -> None:
+    """Delete ``session``'s container and release ``client``, swallowing errors.
+
+    Shared by ``cleanup`` and by ``create_or_reuse``'s bootstrap-failure path,
+    where a teardown error must not mask the original exception.
+    """
     try:
-        await client.delete(bundle["session"])
+        await client.delete(session)
         logger.info("Cleaned up sandbox session for scan %s", scan_id)
     except Exception:
         logger.exception(

--- a/strix/runtime/session_manager.py
+++ b/strix/runtime/session_manager.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 import shutil
 from pathlib import Path
@@ -146,7 +148,11 @@ async def create_or_reuse(
             "Sandbox bootstrap failed for scan %s; deleting the container it started",
             scan_id,
         )
-        await _delete_quietly(client, session, scan_id)
+        # Shielded: a second cancellation arriving while we await the delete
+        # would otherwise escape and abandon the container mid-teardown, and
+        # since it was never cached no later cleanup() could retry it.
+        with contextlib.suppress(BaseException):
+            await asyncio.shield(_delete_quietly(client, session, scan_id))
         raise
 
     bundle = {

--- a/tests/test_session_bootstrap_failure.py
+++ b/tests/test_session_bootstrap_failure.py
@@ -1,0 +1,101 @@
+"""create_or_reuse must reap the container it started if bootstrap then fails."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from strix.runtime import session_manager
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.deleted: list[object] = []
+        self.docker_client = None
+
+    async def delete(self, session: object) -> None:
+        self.deleted.append(session)
+
+
+class _FakeSession:
+    def __init__(self, *, port_error: Exception | None = None) -> None:
+        self.port_error = port_error
+
+    async def resolve_exposed_port(self, _port: int) -> Any:
+        if self.port_error is not None:
+            raise self.port_error
+        raise AssertionError("unreachable in these tests")
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> Iterator[None]:
+    session_manager._SESSION_CACHE.clear()
+    yield
+    session_manager._SESSION_CACHE.clear()
+
+
+def _patch_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    client: _FakeClient,
+    session: _FakeSession,
+) -> None:
+    async def _backend(**_kwargs: Any) -> tuple[_FakeClient, _FakeSession]:
+        return client, session
+
+    monkeypatch.setattr(session_manager, "get_backend", lambda _name: _backend)
+
+
+@pytest.mark.asyncio
+async def test_container_is_deleted_when_port_resolution_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeClient()
+    session = _FakeSession(port_error=TimeoutError("port never exposed"))
+    _patch_backend(monkeypatch, client, session)
+
+    with pytest.raises(TimeoutError, match="port never exposed"):
+        await session_manager.create_or_reuse("scan-1", image="img", local_sources=[])
+
+    assert client.deleted == [session], "started container was never reaped"
+    assert "scan-1" not in session_manager._SESSION_CACHE
+
+
+@pytest.mark.asyncio
+async def test_container_is_deleted_when_caido_bootstrap_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeClient()
+    session = _FakeSession()
+
+    class _Endpoint:
+        tls = False
+        host = "127.0.0.1"
+        port = 48080
+
+    async def _resolve(_port: int) -> _Endpoint:
+        return _Endpoint()
+
+    monkeypatch.setattr(session, "resolve_exposed_port", _resolve)
+
+    async def _bootstrap(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("caido guest login failed after 10 attempts")
+
+    _patch_backend(monkeypatch, client, session)
+    monkeypatch.setattr(session_manager, "bootstrap_caido", _bootstrap)
+
+    with pytest.raises(RuntimeError, match="caido guest login failed"):
+        await session_manager.create_or_reuse("scan-2", image="img", local_sources=[])
+
+    assert client.deleted == [session], "started container was never reaped"
+    assert "scan-2" not in session_manager._SESSION_CACHE
+
+
+@pytest.mark.asyncio
+async def test_cleanup_is_a_noop_for_an_unknown_scan() -> None:
+    # Guards the reason the leak was invisible: cleanup only reaps cached bundles.
+    await session_manager.cleanup("never-created")

--- a/tests/test_session_bootstrap_failure.py
+++ b/tests/test_session_bootstrap_failure.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -14,11 +16,16 @@ if TYPE_CHECKING:
 
 
 class _FakeClient:
-    def __init__(self) -> None:
+    def __init__(self, *, gate: asyncio.Event | None = None) -> None:
         self.deleted: list[object] = []
         self.docker_client = None
+        self.delete_started = asyncio.Event()
+        self._gate = gate
 
     async def delete(self, session: object) -> None:
+        self.delete_started.set()
+        if self._gate is not None:
+            await self._gate.wait()
         self.deleted.append(session)
 
 
@@ -93,6 +100,36 @@ async def test_container_is_deleted_when_caido_bootstrap_fails(
 
     assert client.deleted == [session], "started container was never reaped"
     assert "scan-2" not in session_manager._SESSION_CACHE
+
+
+@pytest.mark.asyncio
+async def test_container_is_deleted_even_when_teardown_is_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancel landing mid-teardown must not abandon the container.
+
+    Nothing else can reap it: it was never cached, so cleanup() is a no-op.
+    """
+    gate = asyncio.Event()
+    client = _FakeClient(gate=gate)
+    session = _FakeSession(port_error=TimeoutError("port never exposed"))
+    _patch_backend(monkeypatch, client, session)
+
+    task = asyncio.create_task(
+        session_manager.create_or_reuse("scan-3", image="img", local_sources=[]),
+    )
+    await client.delete_started.wait()  # we are now inside client.delete
+
+    task.cancel()  # second cancellation, arriving during teardown
+    gate.set()  # let the delete finish
+
+    with contextlib.suppress(asyncio.CancelledError, TimeoutError):
+        await task
+    for _ in range(10):  # let the shielded delete run to completion
+        await asyncio.sleep(0)
+
+    assert client.deleted == [session], "container abandoned when teardown was cancelled"
+    assert "scan-3" not in session_manager._SESSION_CACHE
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #830

### What

`create_or_reuse` now deletes the sandbox container it just started if the remaining bootstrap steps fail, instead of letting the exception escape with the container still running and untracked.

### Why

The container is live from `backend(...)` (`:119`), but it is only registered in `_SESSION_CACHE` at `:145`. Between those two points sit `session.resolve_exposed_port` (`:129`) and `bootstrap_caido` (`:134`), either of which can raise.

`cleanup` reaps only cached bundles:

```python
bundle = _SESSION_CACHE.pop(scan_id, None)
if bundle is None:
    logger.debug("cleanup(%s): no cached session", scan_id)
    return
```

so after a bootstrap failure `cleanup(scan_id)` is a no-op and nothing else holds a reference to `client`/`session` — the container is orphaned for the lifetime of the daemon, keeping its exposed port and bind mounts. `bootstrap_caido` exhausting its 10 guest-login retries on a loaded machine is a routine failure, so this leaks one container per failed scan start.

### How

Wrap the post-start steps in `try/except BaseException`, delete the session best-effort, and re-raise the original exception unchanged. `BaseException` rather than `Exception` so a `KeyboardInterrupt` or `asyncio.CancelledError` during bootstrap also reaps.

The delete path is now shared with `cleanup` as `_delete_quietly`, so both teardown sites also release the docker client identically. `cleanup`'s behaviour is unchanged.

### Tests

New `tests/test_session_bootstrap_failure.py`, driving the real `create_or_reuse` with a stub backend:

- `test_container_is_deleted_when_port_resolution_fails`
- `test_container_is_deleted_when_caido_bootstrap_fails`
- `test_cleanup_is_a_noop_for_an_unknown_scan` — pins the behaviour that made the leak invisible

Both leak tests fail on `main` with `AssertionError: started container was never reaped`, and pass with this change. Each also asserts the original exception still propagates and that nothing is left in `_SESSION_CACHE`.

```
uv run pytest -q
2 failed, 317 passed
```

The 2 failures are pre-existing on `main` (`tests/test_runner_root_prompt.py` — a stale `SimpleNamespace` settings stub missing `runtime`) and unrelated; separate PR for those.

`ruff format --check`, `ruff check` and `mypy strix/runtime/session_manager.py` are clean.

### Scope

One file plus a new test file. No signature or behaviour change on the success path.
