### PR TITLE
fix(tui): show rejected vulnerability reports as rejected

### DIFF
--- a/strix/interface/tui/renderers/reporting_renderer.py
+++ b/strix/interface/tui/renderers/reporting_renderer.py
@@ -22,6 +22,55 @@ def _coerce_list_of_dicts(value: Any) -> list[dict[str, Any]]:
     return []
 
 
+def _is_unsuccessful(result: Any) -> bool:
+    """True when the reporting tool refused to file, or filed but could not persist."""
+    return isinstance(result, dict) and (
+        result.get("success") is False or bool(result.get("warning"))
+    )
+
+
+def _render_rejected_report(
+    icon: str, heading: str, args: dict[str, Any], result: dict[str, Any]
+) -> Text:
+    """Body for a report the tool did not file, or filed but could not persist.
+
+    Shared by the vulnerability and dependency renderers: both tools return the
+    same failure payload shapes (``success: false`` with ``error``/``errors``,
+    or ``success: true`` with ``warning``).
+    """
+    text = Text()
+    text.append(f"{icon} ")
+    text.append(heading, style="bold #ea580c")
+    title = args.get("title", "")
+    if title:
+        text.append("\n\n")
+        text.append("Title: ", style=FIELD_STYLE)
+        text.append(title)
+
+    if result.get("success") is False:
+        errors = result.get("errors")
+        detail = (
+            "; ".join(str(e) for e in errors)
+            if isinstance(errors, list) and errors
+            else result.get("error")
+        )
+        label, style = "✗ Not created: ", "bold #dc2626"
+        fallback = "Report was not created."
+    else:
+        detail = result.get("warning")
+        label, style = "⚠ Not persisted: ", "bold #d97706"
+        fallback = "Report could not be persisted."
+    text.append("\n\n")
+    text.append(label, style=style)
+    text.append(str(detail or fallback))
+
+    padded = Text()
+    padded.append("\n\n")
+    padded.append_text(text)
+    padded.append("\n\n")
+    return padded
+
+
 @cache
 def _get_style_colors() -> dict[Any, str]:
     style = get_style_by_name("native")
@@ -89,6 +138,12 @@ class CreateVulnerabilityReportRenderer(BaseToolRenderer):
     def render(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
         args = tool_data.get("args", {})
         result = tool_data.get("result", {})
+
+        if _is_unsuccessful(result):
+            return Static(
+                _render_rejected_report("🐞", "Vulnerability Report", args, result),
+                classes=cls.get_css_classes("failed"),
+            )
 
         title = args.get("title", "")
         description = args.get("description", "")
@@ -285,43 +340,17 @@ class CreateDependencyReportRenderer(BaseToolRenderer):
 
     @classmethod
     def _render_unsuccessful(cls, args: dict[str, Any], result: dict[str, Any]) -> Static:
-        text = Text()
-        text.append("📦 ")
-        text.append("Dependency (SCA) Report", style="bold #ea580c")
-        title = args.get("title", "")
-        if title:
-            text.append("\n\n")
-            text.append("Title: ", style=FIELD_STYLE)
-            text.append(title)
-
-        warning = result.get("warning")
-        if result.get("success") is False:
-            errors = result.get("errors")
-            detail = (
-                "; ".join(errors) if isinstance(errors, list) and errors else result.get("error")
-            )
-            label, style = "✗ Not created: ", "bold #dc2626"
-            fallback = "Report was not created."
-        else:
-            detail = warning
-            label, style = "⚠ Not persisted: ", "bold #d97706"
-            fallback = "Report could not be persisted."
-        text.append("\n\n")
-        text.append(label, style=style)
-        text.append(str(detail or fallback))
-
-        padded = Text()
-        padded.append("\n\n")
-        padded.append_text(text)
-        padded.append("\n\n")
-        return Static(padded, classes=cls.get_css_classes("failed"))
+        return Static(
+            _render_rejected_report("📦", "Dependency (SCA) Report", args, result),
+            classes=cls.get_css_classes("failed"),
+        )
 
     @classmethod
     def render(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
         args = tool_data.get("args", {})
         result = tool_data.get("result", {})
 
-        if isinstance(result, dict) and (result.get("success") is False or result.get("warning")):
+        if _is_unsuccessful(result):
             return cls._render_unsuccessful(args, result)
 
         title = args.get("title", "")

--- a/tests/test_reporting_renderer.py
+++ b/tests/test_reporting_renderer.py
@@ -1,0 +1,111 @@
+"""A rejected vulnerability report must render as rejected, not as a filed one."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.text import Text
+
+from strix.interface.tui.renderers.reporting_renderer import (
+    CreateDependencyReportRenderer,
+    CreateVulnerabilityReportRenderer,
+)
+
+
+def _args() -> dict[str, Any]:
+    return {
+        "title": "SQL injection in /api/login",
+        "severity": "critical",
+        "description": "The username parameter reaches the query unsanitized.",
+        "impact": "Full database read access.",
+        "target": "https://app.example.com",
+        "poc_script_code": 'curl -d "user=\' OR 1=1--" https://app.example.com/api/login',
+        "remediation_steps": "Use parameterized queries.",
+    }
+
+
+def _plain(static: object) -> str:
+    content = static.content  # type: ignore[attr-defined]
+    return content.plain if isinstance(content, Text) else str(content)
+
+
+def test_duplicate_rejection_is_rendered_as_not_created() -> None:
+    result = {
+        "success": False,
+        "error": "Potential duplicate of 'SQLi in login' (id=8f2ab1c0...) — do not re-report",
+        "duplicate_of": "8f2ab1c0",
+    }
+    widget = CreateVulnerabilityReportRenderer.render(
+        {"args": _args(), "result": result, "status": "failed"},
+    )
+    text = _plain(widget)
+
+    assert "Not created" in text
+    assert "Potential duplicate" in text
+    assert "Use parameterized queries." not in text, "args rendered as if the report was filed"
+    assert "status-failed" in widget.classes
+
+
+def test_validation_failure_lists_every_error() -> None:
+    result = {
+        "success": False,
+        "error": "Validation failed",
+        "errors": ["Invalid attack_vector: X", "Invalid cwe: CWE-abc"],
+    }
+    text = _plain(
+        CreateVulnerabilityReportRenderer.render(
+            {"args": _args(), "result": result, "status": "failed"},
+        ),
+    )
+
+    assert "Invalid attack_vector: X; Invalid cwe: CWE-abc" in text
+
+
+def test_unpersisted_report_is_flagged_as_not_persisted() -> None:
+    result = {
+        "success": True,
+        "warning": "Report could not be persisted - report state unavailable",
+    }
+    widget = CreateVulnerabilityReportRenderer.render(
+        {"args": _args(), "result": result, "status": "completed"},
+    )
+    text = _plain(widget)
+
+    assert "Not persisted" in text
+    assert "report state unavailable" in text
+    assert "status-failed" in widget.classes
+
+
+def test_successful_report_still_renders_the_full_body() -> None:
+    result = {"success": True, "severity": "critical", "cvss_score": 9.8}
+    widget = CreateVulnerabilityReportRenderer.render(
+        {"args": _args(), "result": result, "status": "completed"},
+    )
+    text = _plain(widget)
+
+    assert "SQL injection in /api/login" in text
+    assert "Use parameterized queries." in text
+    assert "status-completed" in widget.classes
+
+
+def test_in_flight_report_still_renders_the_pending_state() -> None:
+    widget = CreateVulnerabilityReportRenderer.render(
+        {"args": _args(), "result": None, "status": "running"},
+    )
+
+    assert "SQL injection in /api/login" in _plain(widget)
+
+
+def test_dependency_rejection_rendering_is_unchanged() -> None:
+    # The dependency renderer already handled these payloads; it now shares the
+    # vulnerability renderer's helper, so pin its output.
+    result = {"success": False, "error": "Validation failed", "errors": ["bad cvss"]}
+    widget = CreateDependencyReportRenderer.render(
+        {"args": {"title": "lodash CVE"}, "result": result, "status": "failed"},
+    )
+    text = _plain(widget)
+
+    assert "📦 Dependency (SCA) Report" in text
+    assert "Title: lodash CVE" in text
+    assert "✗ Not created: bad cvss" in text
+    assert "status-failed" in widget.classes


### PR DESCRIPTION
Fixes #834

### What

`CreateVulnerabilityReportRenderer` now renders a rejected report as rejected, using the same guard `CreateDependencyReportRenderer` already had.

### Why

`render` read only `severity` and `cvss_score` out of `result`; every other field came from `args` — what the model *asked* to file. So a rejected call still produced a full report body, and the trailing

```python
css_classes = cls.get_css_classes("completed")
```

overrode the `failed` status `live_view._tool_status_from_result` had already computed correctly.

`create_vulnerability_report` returns the same payload shapes its dependency sibling does — validation failure (`tool.py:228`), the persistence warning (`:241`), the dedupe rejection (`:266`), the exception path (`:303`) — and the dependency renderer handles all of them at `:320`. This one just never got the guard.

The dedupe path makes it routine: whenever the agent re-reports a finding, the operator sees a complete `🐞 Vulnerability Report` with title, target, PoC and remediation, styled as completed, while nothing reaches `vulnerabilities.json`, the final report, or the SARIF export.

### Before / after

```python
CreateVulnerabilityReportRenderer.render({
    "args": {"title": "SQL injection in /api/login", "remediation_steps": "Use parameterized queries."},
    "result": {"success": False, "error": "Potential duplicate of 'SQLi in login' (id=8f2ab1c0...)"},
    "status": "failed",
})
```

| | body | classes |
|---|---|---|
| before | full report incl. `Use parameterized queries.` | `status-completed` |
| after | `🐞 Vulnerability Report` / `Title: …` / `✗ Not created: Potential duplicate of …` | `status-failed` |

### How

Adds the guard, and factors the rejection body out of `CreateDependencyReportRenderer._render_unsuccessful` into a module-level `_render_rejected_report(icon, heading, args, result)` that both renderers call — so the two paths cannot drift apart again the way they just did. The dependency renderer's output is unchanged; only the icon and heading differ per renderer.

### Tests

New `tests/test_reporting_renderer.py`:

- `test_duplicate_rejection_is_rendered_as_not_created` — also asserts the `args` body is *not* rendered
- `test_validation_failure_lists_every_error`
- `test_unpersisted_report_is_flagged_as_not_persisted` (the `success: true` + `warning` shape)
- `test_successful_report_still_renders_the_full_body`
- `test_in_flight_report_still_renders_the_pending_state` (`result: None`)
- `test_dependency_rejection_rendering_is_unchanged`

The three rejection tests fail on `main`. The dependency test passes both before and after, which is what pins the refactor as behaviour-preserving.

```
uv run pytest -q
2 failed, 320 passed
```

Both failures are pre-existing on `main` (`tests/test_runner_root_prompt.py`, stale settings stub) and unrelated — separate PR open for those.

`ruff format --check` and `ruff check` are clean. `mypy` on this file reports the same 2 pre-existing errors as on `main` (missing `types-Pygments` stubs, unrelated to this change).

### Note

While testing I noticed `.tool-call.status-failed` and `.tool-call.status-completed` have identical declarations in `strix/interface/assets/tui_styles.tcss:378-394`, so the status class alone carries no visual signal. This PR doesn't touch styling — the `✗ Not created:` line is what makes the rejection visible. Happy to follow up separately if you'd like the failed state styled distinctly.
