### PR TITLE
docs(llm): add NVIDIA Build provider setup

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -35,6 +35,7 @@
               "llm-providers/openai",
               "llm-providers/anthropic",
               "llm-providers/openrouter",
+              "llm-providers/nvidia",
               "llm-providers/vertex",
               "llm-providers/bedrock",
               "llm-providers/azure",

--- a/docs/llm-providers/nvidia.mdx
+++ b/docs/llm-providers/nvidia.mdx
@@ -1,0 +1,49 @@
+---
+title: "NVIDIA Build"
+description: "Configure Strix with NVIDIA-hosted NIM models"
+---
+
+[NVIDIA Build](https://build.nvidia.com) exposes hosted NIM models through an
+OpenAI-compatible chat completions API.
+
+## Setup
+
+```bash
+export STRIX_LLM="nvidia_nim/openai/gpt-oss-120b"
+export LLM_API_KEY="nvapi-..."
+```
+
+LiteLLM supplies the hosted NVIDIA endpoint by default. You can also set it
+explicitly:
+
+```bash
+export LLM_API_BASE="https://integrate.api.nvidia.com/v1"
+```
+
+## Model format
+
+Use `nvidia_nim/<NVIDIA-model-id>`. NVIDIA model IDs can contain another slash,
+and the entire model ID after `nvidia_nim/` is preserved when Strix sends the
+request.
+
+For example, NVIDIA's GPT-OSS 120B model ID is `openai/gpt-oss-120b`, so the
+complete Strix value is:
+
+```bash
+export STRIX_LLM="nvidia_nim/openai/gpt-oss-120b"
+```
+
+<Warning>
+Do not omit `nvidia_nim/` for this model. In `openai/gpt-oss-120b`, the first
+`openai/` is interpreted as Strix's OpenAI routing prefix and is not sent as
+part of the model ID. NVIDIA requires the literal `openai/gpt-oss-120b` ID.
+</Warning>
+
+See the [NVIDIA API reference](https://docs.api.nvidia.com/nim/reference/openai-gpt-oss-120b-infer)
+for the model's request schema.
+
+## API key
+
+Create an API key from the model page on [NVIDIA Build](https://build.nvidia.com).
+Strix accepts it through the provider-neutral `LLM_API_KEY` variable and passes
+it to NVIDIA NIM automatically.

--- a/docs/llm-providers/openai.mdx
+++ b/docs/llm-providers/openai.mdx
@@ -29,3 +29,9 @@ export STRIX_LLM="openai/gpt-5.4"
 export LLM_API_KEY="your-key"
 export LLM_API_BASE="https://your-proxy.com/v1"
 ```
+
+The leading `openai/` selects Strix's OpenAI route and is removed before the
+request is sent. If a compatible provider's literal model ID also begins with
+`openai/`, use that provider's LiteLLM prefix instead. For example, NVIDIA's
+`openai/gpt-oss-120b` model is configured as
+`nvidia_nim/openai/gpt-oss-120b`; see the [NVIDIA Build guide](/llm-providers/nvidia).

--- a/docs/llm-providers/overview.mdx
+++ b/docs/llm-providers/overview.mdx
@@ -14,6 +14,7 @@ Set your model and API key:
 | GPT-5.4           | OpenAI        | `openai/gpt-5.4`                 |
 | Claude Sonnet 4.6 | Anthropic     | `anthropic/claude-sonnet-4-6`    |
 | Gemini 3 Pro      | Google Vertex | `vertex_ai/gemini-3-pro-preview` |
+| GPT-OSS 120B      | NVIDIA Build  | `nvidia_nim/openai/gpt-oss-120b` |
 
 ```bash
 export STRIX_LLM="openai/gpt-5.4"
@@ -42,6 +43,9 @@ See the [Local Models guide](/llm-providers/local) for setup instructions and re
   </Card>
   <Card title="OpenRouter" href="/llm-providers/openrouter">
     Access 100+ models through a single API.
+  </Card>
+  <Card title="NVIDIA Build" href="/llm-providers/nvidia">
+    Run hosted NIM models through NVIDIA's API.
   </Card>
   <Card title="Google Vertex AI" href="/llm-providers/vertex">
     Gemini 3 models via Google Cloud.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+import importlib
+import os
+
 import pytest
 from agents.model_settings import ModelSettings
 
 from strix.config.models import (
     RECOMMENDED_MODEL_NAMES,
+    StrixProvider,
+    _mirror_api_key_to_provider_env,
     is_recommended_or_frontier_model,
     request_timeout_extra_args,
 )
+
+
+NVIDIA_MODEL = "nvidia_nim/openai/gpt-oss-120b"
 
 
 @pytest.mark.parametrize("model_name", RECOMMENDED_MODEL_NAMES)
@@ -32,6 +40,55 @@ def test_request_timeout_extra_args_survives_model_settings_json_dump() -> None:
 @pytest.mark.parametrize("value", [None, 0, -1])
 def test_request_timeout_extra_args_disabled(value: float | None) -> None:
     assert request_timeout_extra_args(value) is None
+
+
+def test_nvidia_nim_route_preserves_namespaced_model_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+    model = StrixProvider().get_model(NVIDIA_MODEL)
+
+    assert type(model).__name__ == "LitellmModel"
+    assert vars(model)["model"] == NVIDIA_MODEL
+
+    litellm = importlib.import_module("litellm")
+
+    resolved_model, provider, _, api_base = litellm.get_llm_provider(NVIDIA_MODEL)
+    assert resolved_model == "openai/gpt-oss-120b"
+    assert provider == "nvidia_nim"
+    assert api_base == "https://integrate.api.nvidia.com/v1"
+
+
+def test_nvidia_nim_route_mirrors_generic_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.delenv("NVIDIA_NIM_API_KEY", raising=False)
+
+    _mirror_api_key_to_provider_env(NVIDIA_MODEL, "test-key")
+
+    assert os.environ["NVIDIA_NIM_API_KEY"] == "test-key"
+
+
+@pytest.mark.parametrize(
+    ("configured_model", "outbound_model"),
+    [
+        ("openai/gpt-5.4", "gpt-5.4"),
+        ("openai/moonshotai/kimi-k2.5", "moonshotai/kimi-k2.5"),
+        ("openai/openai/gpt-oss-120b", "openai/gpt-oss-120b"),
+    ],
+)
+def test_openai_route_strips_only_its_routing_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+    configured_model: str,
+    outbound_model: str,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    model = StrixProvider().get_model(configured_model)
+
+    assert vars(model)["model"] == outbound_model
 
 
 def test_recommended_models_are_matched_case_insensitively() -> None:


### PR DESCRIPTION
## Summary

- document NVIDIA Build with the unambiguous `nvidia_nim/<NVIDIA-model-id>` route
- explain why `openai/gpt-oss-120b` loses the routing prefix and how to preserve NVIDIA model IDs
- add regression coverage for NVIDIA provider resolution, API-key mirroring, and existing OpenAI alias behavior

## Root cause

`openai/` is an OpenAI Agents SDK routing alias in `StrixProvider`, so the issue configuration sends `gpt-oss-120b`. LiteLLM already supports NVIDIA NIM directly: `nvidia_nim/openai/gpt-oss-120b` resolves to NVIDIA while forwarding the required literal `openai/gpt-oss-120b` model ID. Keeping the existing OpenAI alias semantics avoids breaking documented local and proxy configurations.

## Testing

- `uv run --frozen pytest tests/test_models.py -q` - 62 passed
- all runnable tests - 308 passed, 1 skipped (12 unrelated baseline cases deselected: 10 Windows symlink/POSIX-mode cases and 2 upstream runner-fixture failures)
- `ruff check tests/test_models.py`
- `ruff format --check tests/test_models.py`
- docs navigation JSON and all referenced pages validated

Closes #804