### PR TITLE
chore: release v1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "strix-agent"
-version = "1.2.0"
+version = "1.3.0"
 description = "Open-source AI Hackers for your apps"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2411,7 +2411,7 @@ wheels = [
 
 [[package]]
 name = "strix-agent"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "caido-sdk-client" },


### PR DESCRIPTION
Bumps the version to `1.3.0` (`pyproject.toml` + `uv.lock`), matching the previous release bump (#v1.2.0).