### PR TITLE
runtime: resolve staged local-dir path to avoid symlink rejection on macOS

### DIFF
--- a/strix/runtime/local_dir_staging.py
+++ b/strix/runtime/local_dir_staging.py
@@ -110,11 +110,6 @@ def stage_symlink_safe_dir(src_root: Path) -> tuple[Path, Path | None]:
     if not tree_has_symlink(root):
         return root, None
 
-    # ``.resolve()`` matters: ``mkdtemp()`` honors ``$TMPDIR``, and on macOS
-    # the default ``$TMPDIR`` resolves through ``/var``, itself a symlink to
-    # ``/private/var``. ``LocalDir`` rejects any symlink component in its
-    # source path, so an unresolved staged path would trip the very check
-    # this function exists to satisfy.
     staged = Path(tempfile.mkdtemp(prefix=_STAGING_PREFIX)).resolve()
     try:
         _stage_dir(root, staged, root, frozenset({root}))

--- a/strix/runtime/local_dir_staging.py
+++ b/strix/runtime/local_dir_staging.py
@@ -110,7 +110,12 @@ def stage_symlink_safe_dir(src_root: Path) -> tuple[Path, Path | None]:
     if not tree_has_symlink(root):
         return root, None
 
-    staged = Path(tempfile.mkdtemp(prefix=_STAGING_PREFIX))
+    # ``.resolve()`` matters: ``mkdtemp()`` honors ``$TMPDIR``, and on macOS
+    # the default ``$TMPDIR`` resolves through ``/var``, itself a symlink to
+    # ``/private/var``. ``LocalDir`` rejects any symlink component in its
+    # source path, so an unresolved staged path would trip the very check
+    # this function exists to satisfy.
+    staged = Path(tempfile.mkdtemp(prefix=_STAGING_PREFIX)).resolve()
     try:
         _stage_dir(root, staged, root, frozenset({root}))
     except OSError:

--- a/tests/test_local_dir_staging.py
+++ b/tests/test_local_dir_staging.py
@@ -106,3 +106,38 @@ def test_nested_symlinks_inside_linked_dir(tmp_path: Path) -> None:
     assert (staged / "pkg" / "shared_link" / "conf.json").read_text() == "{}\n"
     assert not (staged / "pkg" / "shared_link" / "escape").exists()
     assert not (staged / "shared" / "escape").exists()
+
+
+def test_staged_path_has_no_symlink_ancestor(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    """The staging directory itself must never sit behind a symlink.
+
+    ``tempfile.mkdtemp()`` honors ``$TMPDIR``, and on macOS the default
+    ``$TMPDIR`` resolves through ``/var``, which is itself a symlink to
+    ``/private/var``. ``LocalDir`` rejects any symlink component in its
+    source path, so returning the raw ``mkdtemp()`` result breaks every
+    local-dir upload on macOS whenever the source tree contains a symlink.
+    This reproduces that shape without depending on the host OS layout.
+    """
+    repo = _make_repo(tmp_path)
+    (repo / "link.py").symlink_to(repo / "pkg" / "mod.py")
+
+    real_tmp_root = tmp_path / "real_tmp"
+    real_tmp_root.mkdir()
+    symlinked_tmp_root = tmp_path / "tmp_symlink"
+    symlinked_tmp_root.symlink_to(real_tmp_root)
+
+    def fake_mkdtemp(prefix: str = "") -> str:
+        real_dir = real_tmp_root / f"{prefix}fake"
+        real_dir.mkdir()
+        return str(symlinked_tmp_root / real_dir.name)
+
+    monkeypatch.setattr(
+        "strix.runtime.local_dir_staging.tempfile.mkdtemp", fake_mkdtemp
+    )
+
+    upload_path, staged = stage_symlink_safe_dir(repo)
+
+    assert staged is not None
+    assert upload_path == staged
+    for path in (staged, *staged.parents):
+        assert not path.is_symlink(), f"staged path has a symlink ancestor: {path}"


### PR DESCRIPTION
## Problem

`stage_symlink_safe_dir()` in `strix/runtime/local_dir_staging.py` exists specifically to give `LocalDir` a symlink-free path to upload. But the staging directory it creates is never resolved:

    staged = Path(tempfile.mkdtemp(prefix=_STAGING_PREFIX))

`tempfile.mkdtemp()` honors `$TMPDIR`. On macOS, the default `$TMPDIR` (e.g. `/var/folders/xx/yyyy/T/`) resolves through `/var`, which is itself a symlink to `/private/var`. Since `LocalDir` rejects *any* symlink component in its source path, every local-dir scan whose source tree contains at least one symlink fails on macOS with:

    agents.sandbox.errors.LocalDirReadError: failed to read local dir artifact: ...
      reason: symlink_not_supported

i.e. the function that exists to avoid this exact error trips it itself, on every macOS machine, for any repo with an in-tree symlink (common in JS/TS monorepos, venvs, etc.). In the TUI this currently surfaces as the run failing near-instantly in the background while the screen stays on "Loading..." indefinitely (a separate UX issue, not addressed here).

## Fix

Resolve the staged path before returning it:

    staged = Path(tempfile.mkdtemp(prefix=_STAGING_PREFIX)).resolve()

## Testing

Added `test_staged_path_has_no_symlink_ancestor`, which monkeypatches `tempfile.mkdtemp` to return a path behind a symlink (reproducing the `/var` -> `/private/var` shape without depending on host OS layout) and asserts the returned staged path has no symlink ancestors. Fails without the fix, passes with it. Full existing suite for this module (`tests/test_local_dir_staging.py`) still passes (8/8).

## Note

This looks distinct from #843 (large-repo copy failures reported on Linux/WSL): that report doesn't show the symlink-rejection signature, so it's likely a different failure mode in the same staging/copy pipeline. Mentioning in case it's a useful data point, not claiming to fix it here.