### PR TITLE
Add Dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # Python dependencies (uv is a first-class Dependabot ecosystem).
+  # Ungrouped so each update is its own PR — easier to review and to run
+  # against CI individually; capped so the weekly volume stays sane.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7           # let a new release age a little before a PR opens
+      exclude: ["cryptography"] # ...but security-critical patches land fast
+    ignore:
+      # Respect the deliberate version caps in pyproject.toml so Dependabot
+      # doesn't open bumps past them (they'd only fail CI or be closed).
+      # In-range (patch/minor) updates below each cap still flow normally.
+      - dependency-name: "cryptography"
+        versions: [">=49"]      # 49.x drops the universal2 macOS wheel (#859)
+      - dependency-name: "openai"
+        versions: [">=2.45"]    # fresh-install compatibility cap (#748)
+      - dependency-name: "openai-agents"
+        versions: [">0.14.6"]   # exact-pinned during the SDK migration
+
+  # GitHub Actions in the release workflow — grouped into one weekly PR.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+    cooldown:
+      default-days: 7
+
+  # Sandbox image base — enable once it's pinned off ':latest'.
+  # - package-ecosystem: "docker"
+  #   directory: "/containers"
+  #   schedule:
+  #     interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,15 @@ updates:
       - dependency-name: "openai-agents"
         versions: [">0.14.6"]   # exact-pinned during the SDK migration
 
+  # Local-viewer SPA — the tree's npm ecosystem.
+  - package-ecosystem: "npm"
+    directory: "/strix/viewer/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+
   # GitHub Actions in the release workflow — grouped into one weekly PR.
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Small quality-of-life PR. Dependabot's **security updates** already run here (e.g. #852, bumping setuptools) — but with no committed config there's no cooldown, no GitHub Actions coverage, and nothing guarding your deliberate version caps. This adds a `.github/dependabot.yml` for that controlled layer, alongside the existing pre-commit.ci hook autoupdates.

A few light defaults:

- **uv** version updates, ungrouped — one PR per package (capped at 5/week) — so each can be reviewed and reverted on its own. There's no `pull_request` workflow in the repo today, so these arrive on review rather than a green check; ungrouped is what keeps that review tractable, and it's easy to switch to `groups:` later if the volume annoys you.
- **npm** version updates for the local-viewer SPA (`strix/viewer/frontend`) — the tree's second package ecosystem — same shape as uv.
- **GitHub Actions** grouped into one weekly PR (security updates don't cover these). This composes with the SHA pinning in #862 rather than fighting it: when an action is pinned to a commit SHA with a trailing `# vX.Y.Z` comment, Dependabot bumps **both** the SHA and the comment, so the pins stay pins and just move forward. Order doesn't matter — whichever lands second picks up the other.
- A short **7-day cooldown** so a release ages before a PR opens — a light guard against pulling a freshly-compromised version. Cooldown [applies only to version updates, never to security updates](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown), so your security fixes still land immediately; `cryptography` is excluded too.
- **Respects your deliberate version caps** via `ignore` rules so Dependabot won't propose bumps past them: `cryptography` (`<49`, #859), `openai` (`<2.45`, #748), and the `openai-agents` `==0.14.6` migration pin. In-range patch/minor updates below each cap still flow. (The `openai-agents` pin is the one most worth a second look — drop that entry if you'd rather be nudged when a new SDK release lands.)

There's also a commented-out `docker` entry for the sandbox image, ready to enable once its base is pinned off `:latest`.

The cooldown here is the **updater** layer. The matching **resolver**-layer cooldowns — so manual/local updates age too — are in #861 (uv) and #864 (npm).

**To activate:** merging doesn't start it on its own — enable it once under **Settings → Code security → Dependabot** → **Dependabot version updates**. Runs then show under **Insights → Dependency graph → Dependabot** (first PRs arrive on the weekly schedule).
