### PR TITLE
Add a uv resolution cooldown for the Python deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -356,3 +356,15 @@ known_third_party = ["pydantic", "litellm"]
 exclude_dirs = ["docs", "build", "dist"]
 skips = ["B101", "B601", "B404", "B603", "B607"]  # Skip assert, shell injection, subprocess import and partial path checks
 severity = "medium"
+
+# ============================================================================
+# uv — dependency release-age cooldown
+# ============================================================================
+
+[tool.uv]
+# Don't resolve a version until it's a few days old — a guard against a freshly-
+# compromised upstream. One day under the Dependabot cooldown so its bumps still
+# resolve here; cryptography is exempt for fast security patches. Needs uv >= 0.9.17.
+required-version = ">=0.9.17"
+exclude-newer = "6 days"
+exclude-newer-package = { cryptography = false }

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,13 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "2026-07-18T22:23:51.950091Z"
+exclude-newer-span = "P6D"
+
+[options.exclude-newer-package]
+cryptography = false
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
@@ -1117,7 +1124,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
+    { name = "altgraph", marker = "python_full_version < '3.15' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1831,13 +1838,13 @@ name = "pyinstaller"
 version = "6.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
-    { name = "macholib", marker = "sys_platform == 'darwin'" },
-    { name = "packaging" },
-    { name = "pefile", marker = "sys_platform == 'win32'" },
-    { name = "pyinstaller-hooks-contrib" },
-    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
-    { name = "setuptools" },
+    { name = "altgraph", marker = "python_full_version < '3.15'" },
+    { name = "macholib", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "packaging", marker = "python_full_version < '3.15'" },
+    { name = "pefile", marker = "python_full_version < '3.15' and sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib", marker = "python_full_version < '3.15'" },
+    { name = "pywin32-ctypes", marker = "python_full_version < '3.15' and sys_platform == 'win32'" },
+    { name = "setuptools", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d5/4d/ec706c3fcf39e26888c35b39615ff4d5865d184069666c47492cff1fbe50/pyinstaller-6.21.0.tar.gz", hash = "sha256:bb9fab705983e393a2d1cac77d6972513057ad800215fd861dc15ff5272e98fd", size = 4061519, upload-time = "2026-06-13T14:15:06.25Z" }
 wheels = [
@@ -1859,7 +1866,7 @@ name = "pyinstaller-hooks-contrib"
 version = "2026.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/5b/c9fe0db5e83ee1c39b2258fa21d23b15e1a60786b6c5990ee5074ead8bb6/pyinstaller_hooks_contrib-2026.6.tar.gz", hash = "sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725", size = 173354, upload-time = "2026-06-08T22:37:16.152Z" }
 wheels = [


### PR DESCRIPTION
A resolver-layer release-age cooldown for the Python dependency tree. uv won't resolve a version until it's a few days old.

```toml
[tool.uv]
required-version = ">=0.9.17"
exclude-newer = "6 days"
exclude-newer-package = { cryptography = false }
```

This gates what `uv lock` / `uv add` / `uv sync` will *resolve*, which means it also covers the manual and local updates nobody opens a PR for. It does **not** affect `uv sync --frozen`, which installs the lockfile verbatim, so the release workflow behaves exactly as it does today.

## Why bother — this isn't hypothetical for this project

`litellm`, a core strix dependency, was compromised in the [TeamPCP campaign](https://securitylabs.datadoghq.com/articles/litellm-compromised-pypi-teampcp-supply-chain-campaign/) on 24 Mar 2026: malicious `1.82.7`/`1.82.8` sat on PyPI for ~40 minutes, long enough for tens of thousands of downloads, running a `.pth` injector on import to exfiltrate cloud credentials. The same actor backdoored `telnyx`, and Microsoft's [`durabletask`](https://www.stepsecurity.io/blog/microsofts-durabletask-pypi-package-compromised-in-supply-chain-attack) fell the same way in May (three bad versions in a 35-minute window).

These are smash-and-grab attacks. The malicious version harvests credentials the moment it installs, gets spotted, and is pulled within minutes to hours. The blast radius is whoever resolves the newest version inside that window. A few-days cooldown means a `uv lock` or a bump never resolves to a release that young.

The honest limit: a cooldown does nothing against a compromise that stays hidden *longer* than the window. It filters the fast ones, which is what these have been.

## Why 6 days

Long enough to clear the window every incident above sat in, short enough not to stall ordinary updates for a week.

`cryptography` is exempt via `exclude-newer-package = { cryptography = false }`, so its security patches land immediately. Its `<49` cap needs nothing extra here — uv honours that `pyproject.toml` constraint natively at resolution.

## uv version

The relative `exclude-newer` and `exclude-newer-package` options both landed in [uv 0.9.17](https://github.com/astral-sh/uv/pull/16814) (Dec 2025), so `required-version = ">=0.9.17"` is set. An older uv then fails with a clear "upgrade uv" message rather than a confusing parse error. The release workflow's `astral-sh/setup-uv` installs current uv, so CI is already well above this floor; it only matters for a contributor on a stale local uv.

## About the lockfile

Adding `exclude-newer` forces a full re-resolution, and uv records the window in `uv.lock`'s `[options]` block. `uv lock --check` fails until the lock is regenerated, so it's committed here.

A cooldown PR that touches the lock deserves scrutiny, so here's exactly what moved: **no package versions changed.** `setuptools` stays at `83.0.0` — the recent GHSA-h35f-9h28-mq5c bump is in the base and survives the cooldown untouched. The only other delta is uv emitting more precise environment markers on the `pyinstaller`/`macholib` dependency edges, which is an artifact of resolving from scratch instead of incrementally. The control for that: a plain `uv lock` with no cooldown on the same tree produces a no-op diff, so the markers are attributable to the re-resolve and not to this setting.

Rebased on current `main`.

## Relationship to #860

**Stands alone.** Merge it in any order, or on its own if you'd rather not take the Dependabot config.

The two are complementary rather than sequential. #860's cooldown gates *when a bump PR opens*; this gates *what any resolution produces*, so the resolver layer covers the local and manual path Dependabot never sees, and it keeps working if the Dependabot config is ever changed or removed. The 6 days is picked to sit one day under #860's 7 so a version Dependabot proposes still resolves cleanly here if both land. If #860 doesn't land, 6 days is a sensible standalone window either way.

It is a little opinionated, since it changes what `uv lock` resolves, so it's happily droppable if you'd rather keep just the updater-side cooldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
