### PR TITLE
Pin release-workflow actions to commit SHAs + least-privilege token

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -24,13 +27,15 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
 
       - name: Build
         shell: bash
@@ -50,7 +55,7 @@ jobs:
             tar -C dist/release -czvf "dist/release/strix-${VERSION}-${{ matrix.target }}.tar.gz" "strix-${VERSION}-${{ matrix.target }}"
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: strix-${{ matrix.target }}
           path: |
@@ -65,13 +70,13 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           path: release
           merge-multiple: true
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
         with:
           prerelease: ${{ !startsWith(github.ref, 'refs/tags/') }}
           generate_release_notes: true


### PR DESCRIPTION
Pins every third-party action in the release workflow to a full commit SHA (with the version in a trailing comment), and tightens the workflow's token permissions.

**Why:** `build-release.yml`'s `release` job has `contents: write` and publishes the binaries users install. Every `uses:` there is a mutable tag (`@v2`, `@v4`, …), and tag-hijacking of popular actions keeps happening: `aquasecurity/trivy-action` had 75 of its 76 tags force-pushed to steal CI credentials (Mar 2026, part of the TeamPCP campaign), following `tj-actions/changed-files` (2025) and before `codfish/semantic-release-action` (Jun 2026). In each case, workflows referencing the action by **commit SHA** were unaffected — a SHA is immutable, so pinning is the fix.

**Changes:**

- **SHA-pin all six actions** — `checkout`, `setup-python`, `setup-uv`, `upload-artifact`, `download-artifact`, `action-gh-release`. Each is pinned to the commit its `@major` resolves to *today*, so there's no version change — pure immutability — with the concrete version in a trailing comment. (`setup-uv`'s `@v5` is an *annotated* tag; it's pinned to the underlying commit, not the tag object, so Dependabot tracks it correctly.)
- **Least-privilege token** — a top-level `permissions: contents: read` (the `build` job only needs read; the `release` job keeps its explicit `contents: write`), and `persist-credentials: false` on the build checkout so the `GITHUB_TOKEN` isn't left in `.git/config`.

`actionlint` passes, and each pin resolves to the current released version.

Pairs with #860 — its `github-actions` Dependabot entry keeps these SHAs current (bumping the SHA + comment), so pinning doesn't leave them to go stale.
