### PR TITLE
fix(report): use bare-model fallback in usage-ledger cost estimate

### DIFF
--- a/strix/report/usage.py
+++ b/strix/report/usage.py
@@ -203,7 +203,7 @@ def _estimate_litellm_entry_cost(entry: Any, model: str) -> float | None:
         try:
             cost = completion_cost(
                 completion_response={"model": candidate, "usage": usage_payload},
-                model=model,
+                model=candidate,
             )
             break
         except Exception:  # nosec B112  # noqa: BLE001, S112

--- a/tests/test_cost_tracking.py
+++ b/tests/test_cost_tracking.py
@@ -10,6 +10,7 @@ import pytest
 
 from strix.config.models import _configure_litellm_compatibility
 from strix.report.state import litellm_cost_callback
+from strix.report.usage import _estimate_litellm_cost, _estimate_litellm_entry_cost
 
 
 def test_streaming_logging_stays_enabled_for_cost_callback() -> None:
@@ -151,3 +152,44 @@ def test_cost_callback_records_nothing_when_no_cost_available() -> None:
         litellm_cost_callback({"response_cost": None, "model": "x/y"}, response)
 
     report_state.record_observed_llm_cost.assert_not_called()
+
+
+def test_entry_cost_estimate_falls_back_to_bare_model_name() -> None:
+    entry = SimpleNamespace(
+        input_tokens=1000,
+        output_tokens=500,
+        total_tokens=1500,
+        input_tokens_details=None,
+        output_tokens_details=None,
+    )
+
+    def fake_completion_cost(**kwargs: object) -> float:
+        if kwargs["model"] == "Mistral-7B-Instruct-v0.3":
+            return 0.0021
+        raise ValueError(kwargs["model"])
+
+    with patch("litellm.completion_cost", side_effect=fake_completion_cost):
+        cost = _estimate_litellm_entry_cost(entry, "mistralai/Mistral-7B-Instruct-v0.3")
+
+    assert cost == pytest.approx(0.0021)
+
+
+def test_usage_ledger_estimate_uses_bare_model_fallback_for_prefixed_openai_model() -> None:
+    entry = SimpleNamespace(
+        input_tokens=1000,
+        output_tokens=500,
+        total_tokens=1500,
+        input_tokens_details=None,
+        output_tokens_details=None,
+    )
+    usage = SimpleNamespace(request_usage_entries=[entry])
+
+    def fake_completion_cost(**kwargs: object) -> float:
+        if kwargs["model"] == "Mistral-7B-Instruct-v0.3":
+            return 0.0021
+        raise ValueError(kwargs["model"])
+
+    with patch("litellm.completion_cost", side_effect=fake_completion_cost):
+        cost = _estimate_litellm_cost(usage, "openai/mistralai/Mistral-7B-Instruct-v0.3")
+
+    assert cost == pytest.approx(0.0021)


### PR DESCRIPTION
## Problem

`_estimate_litellm_entry_cost` (`strix/report/usage.py`) builds a fallback list of model-name candidates so the LiteLLM cost lookup can fall back from the prefixed name to the bare model name:

```python
candidates = [model]
if "/" in model:
    candidates.append(model.split("/", 1)[-1])

for candidate in candidates:
    cost = completion_cost(
        completion_response={"model": candidate, "usage": usage_payload},
        model=model,   # pins the lookup to the original name
    )
```

But the pricing lookup passed `model=model`, so `completion_cost` always used the original prefixed name and the bare-name `candidate` was never actually tried (LiteLLM prioritizes the `model=` kwarg). The loop's fallback was dead code.

With e.g. `STRIX_LLM="openai/mistralai/Mistral-7B-Instruct-v0.3"` (pointing `LLM_API_BASE` at a self-hosted OpenAI-compatible server serving HF-named models), LiteLLM keys the price under the bare `Mistral-7B-Instruct-v0.3`. Every candidate resolves to a prefixed name absent from the price map, `cost` stays `None`, and the entry is reported as **$0.00**.

The sibling estimator `_estimate_response_cost` in `strix/report/state.py` builds the same candidate list and correctly passes `model=candidate` (locked by `test_cost_callback_estimates_cost_with_bare_model_fallback`). This path was written with `model=model`, defeating its own fallback.

## Fix

Pass `model=candidate` so the bare-name fallback is actually attempted, matching `_estimate_response_cost`. For single-candidate configs (`candidate == model`) behavior is unchanged.

## Tests

Adds two tests to `tests/test_cost_tracking.py` (mirroring the existing bare-model-fallback test): one on `_estimate_litellm_entry_cost`, one end-to-end through `_estimate_litellm_cost`, both pricing only the bare name. `uv run pytest tests/test_cost_tracking.py` → 11 passed; reverting the fix makes both new tests fail (`None == 0.0021`).
