### PR TITLE
fix(cli): clarify Docker socket access errors

### DIFF
--- a/strix/interface/utils.py
+++ b/strix/interface/utils.py
@@ -26,6 +26,13 @@ from strix.utils.api_spec import detect_spec_format
 
 logger = logging.getLogger(__name__)
 
+DOCKER_PERMISSION_ERROR_MARKERS = ("permission denied", "operation not permitted")
+DOCKER_SOCKET_ACCESS_HINT = (
+    "Docker is installed, but Strix cannot access the Docker socket. "
+    "Run Strix with a user that can access Docker, or add your user to the docker group "
+    "and restart your shell before trying again.\n"
+)
+
 
 def get_severity_color(severity: str) -> str:
     severity_colors = {
@@ -1577,15 +1584,22 @@ def clone_repository(repo_url: str, run_name: str, dest_name: str | None = None)
         ) from e
 
 
+def _is_docker_permission_error(exc: DockerException) -> bool:
+    message = str(exc).lower()
+    return any(marker in message for marker in DOCKER_PERMISSION_ERROR_MARKERS)
+
+
 def check_docker_connection() -> Any:
     try:
         return docker.from_env()
-    except DockerException:
+    except DockerException as exc:
         console = Console()
         error_text = Text()
         error_text.append("DOCKER NOT AVAILABLE", style="bold red")
         error_text.append("\n\n", style="white")
         error_text.append("Cannot connect to Docker daemon.\n", style="white")
+        if _is_docker_permission_error(exc):
+            error_text.append(DOCKER_SOCKET_ACCESS_HINT, style="white")
         error_text.append(
             "Please ensure Docker Desktop is installed and running, and try running strix again.\n",
             style="white",

--- a/strix/interface/utils.py
+++ b/strix/interface/utils.py
@@ -25,6 +25,13 @@ from strix.utils.api_spec import detect_spec_format
 
 logger = logging.getLogger(__name__)
 
+DOCKER_PERMISSION_ERROR_MARKERS = ("permission denied", "operation not permitted")
+DOCKER_SOCKET_ACCESS_HINT = (
+    "Docker is installed, but Strix cannot access the Docker socket. "
+    "Run Strix with a user that can access Docker, or add your user to the docker group "
+    "and restart your shell before trying again.\n"
+)
+
 
 def get_severity_color(severity: str) -> str:
     severity_colors = {
@@ -1597,6 +1604,11 @@ def clone_repository(repo_url: str, run_name: str, dest_name: str | None = None)
         ) from e
 
 
+def _is_docker_permission_error(exc: BaseException) -> bool:
+    message = str(exc).lower()
+    return any(marker in message for marker in DOCKER_PERMISSION_ERROR_MARKERS)
+
+
 def check_docker_connection() -> Any:
     import docker
     from docker.errors import DockerException
@@ -1610,6 +1622,8 @@ def check_docker_connection() -> Any:
         error_text.append("DOCKER NOT AVAILABLE", style="bold red")
         error_text.append("\n\n", style="white")
         error_text.append("Cannot connect to Docker daemon.\n", style="white")
+        if _is_docker_permission_error(exc):
+            error_text.append(DOCKER_SOCKET_ACCESS_HINT, style="white")
         error_text.append(
             "Please ensure Docker Desktop is installed and running, and try running strix again.\n",
             style="white",

--- a/tests/test_docker_connection_message.py
+++ b/tests/test_docker_connection_message.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+from docker.errors import DockerException
+from rich.console import Console
+
+from strix.interface import utils
+
+
+DOCKER_PERMISSION_ERROR = "permission denied while trying to connect to the Docker daemon socket"
+DOCKER_SOCKET_HINT = "Docker socket"
+DOCKER_GROUP_HINT = "docker group"
+
+
+def test_docker_connection_permission_error_mentions_socket_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = io.StringIO()
+
+    def fake_console() -> Console:
+        return Console(file=output, color_system=None, force_terminal=False)
+
+    def fail_from_env() -> None:
+        raise DockerException(DOCKER_PERMISSION_ERROR)
+
+    monkeypatch.setattr(utils, "Console", fake_console)
+    monkeypatch.setattr(utils.docker, "from_env", fail_from_env)
+
+    with pytest.raises(RuntimeError, match="Docker not available"):
+        utils.check_docker_connection()
+
+    rendered = output.getvalue()
+    assert DOCKER_SOCKET_HINT in rendered
+    assert DOCKER_GROUP_HINT in rendered

--- a/tests/test_docker_connection_message.py
+++ b/tests/test_docker_connection_message.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import io
+
+import docker
+import pytest
+from docker.errors import DockerException
+from rich.console import Console
+
+from strix.interface import utils
+
+
+DOCKER_PERMISSION_ERROR = "permission denied while trying to connect to the Docker daemon socket"
+DOCKER_SOCKET_HINT = "Docker socket"
+DOCKER_GROUP_HINT = "docker group"
+
+
+def test_docker_connection_permission_error_mentions_socket_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = io.StringIO()
+
+    def fake_console() -> Console:
+        return Console(file=output, color_system=None, force_terminal=False)
+
+    def fail_from_env() -> None:
+        raise DockerException(DOCKER_PERMISSION_ERROR)
+
+    monkeypatch.setattr(utils, "Console", fake_console)
+    monkeypatch.setattr(docker, "from_env", fail_from_env)
+
+    with pytest.raises(RuntimeError, match="Docker not available"):
+        utils.check_docker_connection()
+
+    rendered = output.getvalue()
+    assert DOCKER_SOCKET_HINT in rendered
+    assert DOCKER_GROUP_HINT in rendered


### PR DESCRIPTION
## Summary

- Detect Docker daemon permission/socket access failures separately from generic Docker-unavailable errors.
- Tell affected users to run Strix with Docker socket access or add their user to the `docker` group.
- Preserve the current lazy Docker import while rebasing the fix onto the latest `main`.

## Issue

Fixes #482

## Test verification (RED -> GREEN)

Test-only against current upstream `main` (`52b1923`):

```text
$ uv run pytest -q tests/test_docker_connection_message.py
AssertionError: assert 'Docker socket' in rendered
1 failed
```

With the fix:

```text
$ uv run pytest -q tests/test_docker_connection_message.py
1 passed
```

Changed-line coverage:

```text
strix/interface/utils.py: 7/7 lines covered (100%)
```

## Full validation

The ignored local CI replay ran frozen dependency sync, Ruff format/lint, mypy, pyright, Bandit, and the complete pytest suite on both current upstream `main` and this branch.

```text
                       upstream main   this branch
Ruff format/lint       pass            pass
mypy                   pass            pass
Bandit                 pass            pass
pyright diagnostics    861             861
pytest                  1740 pass,      1741 pass,
                        1 fail          1 fail
```

The unchanged pytest failure is `tests/test_pricing.py::test_resolves_common_bare_model_names`; it depends on the current external model mapping. No baseline regression was introduced.
