### PR TITLE
docs(cli): document exit code 1 and clarify exit 0 semantics

### DIFF
--- a/docs/usage/cli.mdx
+++ b/docs/usage/cli.mdx
@@ -116,5 +116,6 @@ strix --mount ./huge-monorepo
 
 | Code | Meaning |
 |------|---------|
-| 0 | Scan completed, no vulnerabilities found |
+| 0 | Scan completed successfully (interactive mode always exits `0`; in headless mode, `0` means no vulnerabilities were found) |
+| 1 | A fatal error occurred before or during the scan (e.g. missing environment variables, Docker unavailable, invalid config file, diff-scope resolution failure, or an unhandled error) |
 | 2 | Vulnerabilities found (headless mode only) |


### PR DESCRIPTION
The Exit Codes table in the CLI reference only listed `0` and `2`, but the CLI also exits with `1` on fatal errors — missing environment variables, Docker unavailable, an invalid config file, diff-scope resolution failure, or an unhandled exception (all in `strix/interface/main.py`).

The table also implied exit `0` means no vulnerabilities were found, which only holds in headless mode; interactive runs always exit `0` regardless of findings (exit `2` is gated on `args.non_interactive`).

This documents exit code `1` and clarifies the two cases for exit `0`. Docs-only change.
