### PR TITLE
security: bound Content-Length parsing in viewer server

### DIFF
--- a/strix/viewer/server.py
+++ b/strix/viewer/server.py
@@ -187,8 +187,17 @@ def _make_handler(state: _ViewerState) -> type[BaseHTTPRequestHandler]:
                 logger.exception("viewer request failed: POST %s", path)
                 self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": "internal error"})
 
+        # Cap on request body size so a client cannot force unbounded
+        # memory allocation by sending a huge Content-Length.
+        _MAX_BODY_BYTES = 2 * 1024 * 1024  # 2 MiB
+
         def _read_body(self) -> dict[str, Any]:
-            length = int(self.headers.get("Content-Length") or 0)
+            try:
+                length = int(self.headers.get("Content-Length") or 0)
+            except (ValueError, OverflowError):
+                return {}
+            if length < 0 or length > self._MAX_BODY_BYTES:
+                return {}
             raw = self.rfile.read(length) if length else b""
             try:
                 body = json.loads(raw or b"{}")


### PR DESCRIPTION
## Summary

The viewer server's `_read_body()` method has two issues with `Content-Length` handling:

### 1. Unbounded memory allocation (OOM DoS) — Medium Severity

A client can send `Content-Length: 999999999999` and force the server to attempt allocating an enormous buffer via `self.rfile.read(length)`, causing an out-of-memory denial of service against the viewer process.

**Fix:** Added `_MAX_BODY_BYTES = 2 * 1024 * 1024` (2 MiB) cap. Any `Content-Length` above this limit causes `_read_body()` to return an empty dict, so the endpoint returns its normal validation error.

### 2. Unhandled ValueError on malformed Content-Length — Low Severity

`int(self.headers.get('Content-Length') or 0)` raises `ValueError` if the header contains a non-integer value (e.g. `'abc'` or `'12,34'`). The outer `except Exception` catches it but produces a 500 + full stack trace in logs for what should be a malformed request.

**Fix:** Wrapped the `int()` conversion in `try/except (ValueError, OverflowError)` so malformed headers degrade gracefully.

### Files changed
- `strix/viewer/server.py`

### Testing
- Verified the fix preserves all existing endpoint behavior for valid requests
- Invalid/oversized Content-Length values now return empty body (endpoints handle this via their existing validation)