### PR TITLE
security: redact session token from viewer access logs

### DIFF
--- a/strix/viewer/server.py
+++ b/strix/viewer/server.py
@@ -142,7 +142,12 @@ def _make_handler(state: _ViewerState) -> type[BaseHTTPRequestHandler]:
         server_version = "StrixViewer/1.0"
 
         def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
-            logger.debug("viewer %s - %s", self.address_string(), format % args)
+            # Redact the bootstrap token from log lines so it cannot be
+            # harvested from log files for session hijacking.
+            msg = format % args
+            if state.session_token and state.session_token in msg:
+                msg = msg.replace(state.session_token, "[REDACTED]")
+            logger.debug("viewer %s - %s", self.address_string(), msg)
 
         def do_GET(self) -> None:
             parts = urlsplit(self.path)


### PR DESCRIPTION
## Summary

The viewer server's `log_message()` override logs the full HTTP request line, including the query string. The bootstrap session token is passed as `?token=...` in the initial page load URL (via `authorized_url()`), so it appears in plain text in log output.

### Severity: Medium

If logs are persisted (e.g. `--log-file`, systemd journal, or redirected stdout), an attacker with read access to the log file can extract the token and hijack the viewer session — bypassing the session cookie authentication that protects:
- Live scan steering
- Report delivery
- Scan history browsing

### Fix

Detect the per-process session token in the formatted log message and replace it with `[REDACTED]` before emitting the log line. This is a minimal, targeted change that:
- Preserves all other log output unchanged
- Only redacts the specific session token, not arbitrary content
- Has zero performance impact (simple string `in` check on debug-level log lines)

### Files changed
- `strix/viewer/server.py`

### Testing
- Verified that normal request logging works unchanged
- Requests containing the session token now show `[REDACTED]` in log output