### PR TITLE
security: harden self-update against supply-chain and path-traversal attacks

### DIFF
--- a/strix/interface/update_check.py
+++ b/strix/interface/update_check.py
@@ -306,14 +306,38 @@ def _download_and_replace(version: str, target: str, console: Console) -> bool:
                     f"expected sha256 {expected_digest}, got {actual_digest}"
                 )
         else:
-            console.print("[dim yellow]No published checksum available; skipping verification[/]")
+            raise RuntimeError(
+                f"No published checksum available for {filename}; "
+                f"refusing to install an unverified binary. "
+                f"Please ensure the release includes asset digests."
+            )
 
         if is_windows:
             with zipfile.ZipFile(archive_path) as zf:
-                zf.extract(binary_name, tmp_dir)
+                # Zip-slip guard: verify the member does not escape tmp_dir.
+                member = zf.getinfo(binary_name)
+                extracted = (tmp_dir / member.filename).resolve()
+                if not str(extracted).startswith(str(tmp_dir.resolve())):
+                    raise RuntimeError(
+                        f"Zip member {member.filename!r} would escape "
+                        f"the staging directory (zip-slip)"
+                    )
+                zf.extract(member, tmp_dir)
         else:
             with tarfile.open(archive_path, "r:gz") as tf:
-                tf.extract(binary_name, tmp_dir, filter="data")
+                # Tar-slip guard: verify the member does not escape tmp_dir.
+                member = tf.getmember(binary_name)
+                extracted = (tmp_dir / member.name).resolve()
+                if not str(extracted).startswith(str(tmp_dir.resolve())):
+                    raise RuntimeError(
+                        f"Tar member {member.name!r} would escape "
+                        f"the staging directory (tar-slip)"
+                    )
+                try:
+                    tf.extract(member, tmp_dir, filter="data")
+                except TypeError:
+                    # Python <3.12 does not support the filter parameter.
+                    tf.extract(member, tmp_dir)
 
         new_binary = tmp_dir / binary_name
         new_binary.chmod(new_binary.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)


### PR DESCRIPTION
## Summary

Three related hardening measures for `_download_and_replace()` in the self-update mechanism. These address the highest-severity findings from a security audit of the codebase.

---

### 1. Refuse unverified binaries — High Severity

**Before:** When no SHA-256 digest is published for a release asset, the code printed a dim yellow warning and proceeded to replace the running binary with unverified content:
`python
console.print('[dim yellow]No published checksum available; skipping verification[/]')
`

**Risk:** If an attacker compromises the GitHub release (account takeover, Actions supply-chain attack, or CDN MitM on a misconfigured proxy), they can inject a malicious binary that gets installed without any integrity check. The user sees only a dim warning that is easy to miss.

**After:** `raise RuntimeError(...)` — the update is aborted. The operator can still install manually after independent verification.

---

### 2. Zip-slip path traversal guard (Windows) — High Severity

**Before:** `zf.extract(binary_name, tmp_dir)` uses the archive member name directly.

**Risk:** A crafted zip containing a path like `../../malicious.exe` writes outside `tmp_dir`. Python >=3.12 has partial mitigations, but Python 3.11 (in-support per `pyproject.toml requires-python = '>=3.11'`) is fully vulnerable.

**After:** Resolve the extraction target path and verify it stays inside `tmp_dir` before extracting.

---

### 3. Tar-slip guard + Python 3.11 compatibility — High/Medium Severity

**Before:** `tf.extract(binary_name, tmp_dir, filter='data')`

**Risk (tar-slip):** Without path validation, tar members with absolute paths or `..` components could escape the staging directory.

**Risk (compatibility):** The `filter` parameter was introduced in Python 3.12. On Python 3.11 this raises `TypeError`, causing the entire self-update to crash.

**After:** Validate the resolved path (same pattern as the zip guard), use `filter='data'` when available, and fall back gracefully on Python <3.12.

---

### Files changed
- `strix/interface/update_check.py`

### Testing
- Verified that the normal update flow (with published checksums) works unchanged
- Missing checksums now correctly abort with a clear error message
- Path traversal attempts in both zip and tar archives are detected and rejected
- Python 3.11 compatibility restored for the tar extraction path