### PR TITLE
fix(core): treat cloned repo targets as source-aware whitebox scans

### DIFF
--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -34,10 +34,12 @@ def _accepts_required_tool_choice(model_name: str | None) -> bool:
 
 
 def is_whitebox_scan(targets_info: list[dict[str, Any]]) -> bool:
-    """True iff any target puts source in the workspace (local tree or cloned repo).
+    """Return whether the targets represent a source-aware scan.
 
-    Mirrors ``collect_local_sources``: a ``repository`` target is source-aware
-    once it has been cloned, exactly like a ``local_code`` target.
+    A ``repository`` target is source-aware once cloned, like a ``local_code``
+    one. Derived from targets rather than ``local_sources`` because older
+    resumed runs may not have persisted the latter, while ``targets_info``
+    still describes the cloned repository in the reused sandbox.
     """
     return any(
         t.get("type") == "local_code" or (t.get("details") or {}).get("cloned_repo_path")

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -33,6 +33,18 @@ def _accepts_required_tool_choice(model_name: str | None) -> bool:
     return name.startswith("openai/") or is_known_openai_bare_model(name)
 
 
+def is_whitebox_scan(targets_info: list[dict[str, Any]]) -> bool:
+    """True iff any target puts source in the workspace (local tree or cloned repo).
+
+    Mirrors ``collect_local_sources``: a ``repository`` target is source-aware
+    once it has been cloned, exactly like a ``local_code`` target.
+    """
+    return any(
+        t.get("type") == "local_code" or (t.get("details") or {}).get("cloned_repo_path")
+        for t in targets_info or []
+    )
+
+
 def build_root_task(scan_config: dict[str, Any]) -> str:
     targets = scan_config.get("targets", []) or []
     diff_scope = scan_config.get("diff_scope") or {}

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -34,6 +34,7 @@ from strix.core.inputs import (
     DEFAULT_MAX_TURNS,
     build_root_task,
     build_scope_context,
+    is_whitebox_scan,
     make_model_settings,
 )
 from strix.core.paths import run_dir_for, runtime_state_dir
@@ -208,7 +209,7 @@ async def run_strix_scan(
     try:
         targets = scan_config.get("targets") or []
         scan_mode = str(scan_config.get("scan_mode") or "deep")
-        is_whitebox = any(t.get("type") == "local_code" for t in targets)
+        is_whitebox = is_whitebox_scan(targets)
         skills = list(scan_config.get("skills") or [])
         root_task = build_root_task(scan_config)
         model_settings = make_model_settings(

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -31,6 +31,7 @@ from strix.config.models import (
     is_known_openai_bare_model,
     is_recommended_or_frontier_model,
 )
+from strix.core.inputs import is_whitebox_scan
 from strix.core.paths import run_dir_for, runtime_state_dir
 from strix.interface.cli import run_cli
 from strix.interface.tui import run_tui
@@ -53,7 +54,6 @@ from strix.interface.utils import (
     generate_run_name,
     image_exists,
     infer_target_type,
-    is_whitebox_scan,
     process_pull_line,
     read_target_list_file,
     resolve_diff_scope_context,

--- a/strix/interface/utils.py
+++ b/strix/interface/utils.py
@@ -1244,11 +1244,6 @@ def assign_workspace_subdirs(targets_info: list[dict[str, Any]]) -> None:
         details["workspace_subdir"] = workspace_subdir
 
 
-def is_whitebox_scan(targets_info: list[dict[str, Any]]) -> bool:
-    """True iff any target is a local source tree (whitebox / source-aware)."""
-    return any(t.get("type") == "local_code" for t in targets_info or [])
-
-
 def collect_local_sources(targets_info: list[dict[str, Any]]) -> list[dict[str, Any]]:
     local_sources: list[dict[str, Any]] = []
 

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -77,7 +77,7 @@ def test_is_whitebox_scan_for_cloned_repository_target() -> None:
 
 
 def test_is_whitebox_scan_matches_collect_local_sources() -> None:
-    """The flag must agree with whether source actually lands in the workspace.
+    """Keep whitebox classification aligned with source collection for supported targets.
 
     ``collect_local_sources`` is what puts code in ``/workspace``; deriving the
     whitebox flag from a narrower rule is how repo targets silently lost the

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -7,7 +7,13 @@ from typing import Any
 
 import pytest
 
-from strix.core.inputs import build_root_task, child_initial_input, make_model_settings
+from strix.core.inputs import (
+    build_root_task,
+    child_initial_input,
+    is_whitebox_scan,
+    make_model_settings,
+)
+from strix.interface.utils import collect_local_sources
 
 
 def _child_kwargs(parent_history: list[Any]) -> dict[str, Any]:
@@ -53,6 +59,43 @@ def test_child_initial_input_no_consecutive_same_role(parent_history: list[Any])
 
     roles = [msg["role"] for msg in result]
     assert all(prev != nxt for prev, nxt in pairwise(roles))
+
+
+def _cloned_repo_target() -> dict[str, Any]:
+    return {
+        "type": "repository",
+        "details": {
+            "target_repo": "https://example.com/org/repo",
+            "cloned_repo_path": "/clone",
+            "workspace_subdir": "repo",
+        },
+    }
+
+
+def test_is_whitebox_scan_for_cloned_repository_target() -> None:
+    assert is_whitebox_scan([_cloned_repo_target()]) is True
+
+
+def test_is_whitebox_scan_matches_collect_local_sources() -> None:
+    """The flag must agree with whether source actually lands in the workspace.
+
+    ``collect_local_sources`` is what puts code in ``/workspace``; deriving the
+    whitebox flag from a narrower rule is how repo targets silently lost the
+    source-aware skills.
+    """
+    cases: list[list[dict[str, Any]]] = [
+        [_cloned_repo_target()],
+        [{"type": "local_code", "details": {"target_path": "/src"}}],
+        [{"type": "web_application", "details": {"target_url": "https://app.example.com"}}],
+        [
+            _cloned_repo_target(),
+            {"type": "web_application", "details": {"target_url": "https://app.example.com"}},
+        ],
+        [{"type": "repository", "details": {"target_repo": "https://example.com/org/repo"}}],
+        [],
+    ]
+    for targets in cases:
+        assert is_whitebox_scan(targets) is bool(collect_local_sources(targets)), targets
 
 
 def test_build_root_task_empty_config() -> None:

--- a/tests/test_prompt_skills.py
+++ b/tests/test_prompt_skills.py
@@ -1,0 +1,33 @@
+"""Tests for skill resolution in strix.agents.prompt."""
+
+from __future__ import annotations
+
+from strix.agents.prompt import _resolve_skills
+
+
+def test_whitebox_pulls_in_source_aware_skills() -> None:
+    skills = _resolve_skills(requested=[], is_root=True, scan_mode="deep", is_whitebox=True)
+
+    assert "coordination/source_aware_whitebox" in skills
+    assert "custom/source_aware_sast" in skills
+
+
+def test_blackbox_omits_source_aware_skills() -> None:
+    skills = _resolve_skills(requested=[], is_root=True, scan_mode="deep", is_whitebox=False)
+
+    assert "coordination/source_aware_whitebox" not in skills
+    assert "custom/source_aware_sast" not in skills
+
+
+def test_resolve_skills_preserves_request_order_and_dedupes() -> None:
+    skills = _resolve_skills(
+        requested=["vulnerabilities/xss", "custom/source_aware_sast"],
+        is_root=False,
+        scan_mode="quick",
+        is_whitebox=True,
+    )
+
+    assert skills[0] == "vulnerabilities/xss"
+    assert skills.count("custom/source_aware_sast") == 1
+    assert "scan_modes/quick" in skills
+    assert "coordination/root_agent" not in skills

--- a/tests/test_runner_root_prompt.py
+++ b/tests/test_runner_root_prompt.py
@@ -17,6 +17,7 @@ import strix.tools.notes.tools as notes_tools
 import strix.tools.todo.tools as todo_tools
 from strix.core import runner
 from strix.core.agents import AgentCoordinator
+from strix.core.inputs import is_whitebox_scan
 
 
 def _make_rate_limit_error() -> RateLimitError:
@@ -89,6 +90,56 @@ def _patch_engine_scaffold(
 
     monkeypatch.setattr(runner, "run_agent_loop", _raise_rate_limit)
     return captured
+
+
+@pytest.mark.asyncio
+async def test_cloned_repo_target_makes_root_agent_whitebox(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """A repo + domain scan is source-aware: the repo is cloned into /workspace."""
+    captured = _patch_engine_scaffold(monkeypatch, tmp_path, {"authorized_targets": []})
+
+    targets = [
+        {
+            "type": "repository",
+            "details": {
+                "target_repo": "https://example.com/org/repo",
+                "cloned_repo_path": "/clone",
+                "workspace_subdir": "repo",
+            },
+        },
+        {"type": "web_application", "details": {"target_url": "https://app.example.com"}},
+    ]
+
+    await runner.run_strix_scan(
+        scan_config={"targets": targets, "scan_mode": "deep"},
+        scan_id="scan-whitebox",
+        image="img",
+        coordinator=AgentCoordinator(),
+    )
+
+    assert captured["kwargs"]["is_whitebox"] is True
+    assert captured["kwargs"]["is_whitebox"] is is_whitebox_scan(targets)
+
+
+@pytest.mark.asyncio
+async def test_url_only_scan_is_not_whitebox(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    captured = _patch_engine_scaffold(monkeypatch, tmp_path, {"authorized_targets": []})
+
+    targets = [{"type": "web_application", "details": {"target_url": "https://app.example.com"}}]
+
+    await runner.run_strix_scan(
+        scan_config={"targets": targets, "scan_mode": "deep"},
+        scan_id="scan-blackbox",
+        image="img",
+        coordinator=AgentCoordinator(),
+    )
+
+    assert captured["kwargs"]["is_whitebox"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #884.

A `repository` target is cloned into `/workspace/<subdir>` and returned by `collect_local_sources`, exactly like a `local_code` target — but both whitebox checks tested only `type == "local_code"`. So `strix -t https://github.com/org/repo -t https://your-app.com`, the invocation `docs/quickstart.mdx:63` documents as "white-box testing", ran with `is_whitebox=False`: source-aware skills not preloaded, telemetry recording blackbox.

### Before / after

```python
targets = [{"type": "repository", "details": {"cloned_repo_path": "/clone", "workspace_subdir": "repo"}}]

bool(collect_local_sources(targets))  # True — source is in the workspace
is_whitebox_scan(targets)             # before: False    after: True
```

### Change

The predicate was duplicated — `interface/utils.py:1247` feeds telemetry, an inlined copy at `core/runner.py:211` gates skills — so the two could drift. Both now share one helper, aligned with `collect_local_sources` for the target shapes the CLI produces:

```python
def is_whitebox_scan(targets_info: list[dict[str, Any]]) -> bool:
    return any(
        t.get("type") == "local_code" or (t.get("details") or {}).get("cloned_repo_path")
        for t in targets_info or []
    )
```

It lives in `strix/core/inputs.py`, which already owns target-dict interpretation (`build_root_task`, `build_scope_context`) and sits on the right side of the interface → core import direction, so `runner.py` can reach it. If you'd rather keep it in `interface/utils.py`, I'm happy to drop the move and patch both sites in place.

### Tests

7 new, across `test_inputs.py`, `test_runner_root_prompt.py`, and a new `test_prompt_skills.py`:

- a cloned-repo target is whitebox; a URL-only scan is not
- the predicate agrees with `bool(collect_local_sources(...))` on representative target-type combinations, including repo+domain and an uncloned repo — this covers the seam that was missing, so narrowing either function in isolation should now trip a test
- the runner's flag reaches `build_strix_agent`
- `_resolve_skills(is_whitebox=True)` pulls in `coordination/source_aware_whitebox` and `custom/source_aware_sast`

Verified by reverting the predicate in place: exactly the three behavior tests fail (421 passed), and pass again on restore.

### Checks

424 passed. ruff, mypy, pyright and bandit all at parity with `main` — pyright total is unchanged at 981 (`inputs.py` 40→42, `runner.py` 15→13; the two `dict.get()` errors moved with the code). No docs change needed: `docs/quickstart.mdx:63` and `docs/usage/cli.mdx:105` already document the fixed behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
