### PR TITLE
fix(tls): fall back to certifi CA bundle for urllib callers in frozen…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
   "docker>=7.1.0",
   "textual>=6.0.0",
   "requests>=2.32.0",
+  # Direct dep: urllib callers fall back to certifi's CA bundle in frozen
+  # builds (see strix/utils/http.py).
+  "certifi>=2024.7.4",
   "cvss>=3.2",
   "caido-sdk-client>=0.2.0",
   "reportlab>=4.0",

--- a/strix/interface/viewer/auth.py
+++ b/strix/interface/viewer/auth.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any
 
 from strix.config.loader import load_settings
+from strix.utils.http import tls_context
 
 
 logger = logging.getLogger(__name__)
@@ -155,7 +156,9 @@ def _post_json(path: str, payload: dict[str, Any], *, timeout: int) -> tuple[int
         method="POST",
     )
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310  # nosec B310
+        with urllib.request.urlopen(  # noqa: S310  # nosec B310
+            request, timeout=timeout, context=tls_context()
+        ) as response:
             return response.status, _parse_body(response.read())
     except urllib.error.HTTPError as exc:
         return exc.code, _parse_body(exc.read())

--- a/strix/telemetry/posthog.py
+++ b/strix/telemetry/posthog.py
@@ -10,6 +10,7 @@ from strix.telemetry._common import (
     base_props,
     is_first_run,
 )
+from strix.utils.http import tls_context
 
 
 if TYPE_CHECKING:
@@ -42,7 +43,7 @@ def _send(event: str, properties: dict[str, Any]) -> bool:
             data=json.dumps(payload).encode(),
             headers={"Content-Type": "application/json"},
         )
-        with urllib.request.urlopen(req, timeout=10):  # noqa: S310  # nosec B310
+        with urllib.request.urlopen(req, timeout=10, context=tls_context()):  # noqa: S310  # nosec B310
             pass
     except Exception:  # noqa: BLE001
         logger.debug("posthog send failed for event %s", event, exc_info=True)

--- a/strix/telemetry/scarf.py
+++ b/strix/telemetry/scarf.py
@@ -13,6 +13,7 @@ from strix.telemetry._common import (
     get_version,
     is_first_run,
 )
+from strix.utils.http import tls_context
 
 
 if TYPE_CHECKING:
@@ -43,7 +44,7 @@ def _send(event: str, properties: dict[str, Any]) -> bool:
         if query:
             url = f"{url}?{query}"
         req = urllib.request.Request(url, method="POST")  # noqa: S310
-        with urllib.request.urlopen(req, timeout=10):  # noqa: S310  # nosec B310
+        with urllib.request.urlopen(req, timeout=10, context=tls_context()):  # noqa: S310  # nosec B310
             pass
     except Exception:  # noqa: BLE001
         logger.debug("scarf send failed for event %s", event, exc_info=True)

--- a/strix/utils/http.py
+++ b/strix/utils/http.py
@@ -1,0 +1,32 @@
+"""Shared TLS context for stdlib ``urllib`` callers.
+
+``ssl.create_default_context`` loads CA roots from OpenSSL's compiled-in
+default paths. In frozen (PyInstaller) builds those paths point at the build
+machine's Python installation, which does not exist on end-user machines, so
+the default context verifies against an empty store and every HTTPS request
+fails. ``certifi`` ships a CA bundle inside the binary; fall back to it
+whenever the platform store yields no CA certificates.
+"""
+
+from __future__ import annotations
+
+import ssl
+
+import certifi
+
+
+_context: ssl.SSLContext | None = None
+
+
+def tls_context() -> ssl.SSLContext:
+    """A default TLS context, backed by certifi when the OS store is empty."""
+    global _context  # noqa: PLW0603
+    if _context is None:
+        context = ssl.create_default_context()
+        if context.cert_store_stats().get("x509_ca", 0) == 0:
+            context = ssl.create_default_context(cafile=certifi.where())
+        _context = context
+    return _context
+
+
+__all__ = ["tls_context"]

--- a/uv.lock
+++ b/uv.lock
@@ -2415,6 +2415,7 @@ version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "caido-sdk-client" },
+    { name = "certifi" },
     { name = "cryptography" },
     { name = "cvss" },
     { name = "docker" },
@@ -2454,6 +2455,7 @@ dev = [
 requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.28.0" },
     { name = "caido-sdk-client", specifier = ">=0.2.0" },
+    { name = "certifi", specifier = ">=2024.7.4" },
     { name = "cryptography", specifier = ">=48.0.1,<49" },
     { name = "cvss", specifier = ">=3.2" },
     { name = "docker", specifier = ">=7.1.0" },


### PR DESCRIPTION
… builds

ssl.create_default_context() loads roots from OpenSSL's compiled-in paths, which point at the build machine's Python in PyInstaller binaries and don't exist on end-user machines. The viewer relay client then fails every HTTPS call with certificate verification errors, surfacing as 502 'unavailable' from /api/auth/otp/start. Use certifi's bundled CA store whenever the platform store yields no CA certificates (viewer auth, posthog, scarf).