### PR TITLE
ci: publish strix-agent to PyPI on release tags

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -119,3 +119,36 @@ jobs:
           prerelease: ${{ !startsWith(github.ref, 'refs/tags/') }}
           generate_release_notes: true
           files: release/**
+
+  publish-pypi:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5.4.2
+
+      - name: Verify tag matches package version
+        shell: bash
+        run: |
+          VERSION="$(uv run python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "${TAG_VERSION}" != "${VERSION}" ]]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match pyproject.toml version ${VERSION}"
+            exit 1
+          fi
+
+      - name: Build Python distribution
+        shell: bash
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1


### PR DESCRIPTION
## Summary

- Add a tag-only `publish-pypi` job to the release workflow using PyPI Trusted Publishing (`id-token: write`, environment `pypi`).
- Build the Python sdist/wheel with `uv build` and publish via the pinned `pypa/gh-action-pypi-publish` action.
- Fail the publish job early if the release tag version does not match `[project].version` in `pyproject.toml`.

Fixes #883

## Validation

This is a declarative workflow change, so there is no executable product RED/GREEN to invent. The pre-change workflow had no job that built Python distributions or published to PyPI; it only built standalone binaries and created a GitHub Release.

```text
$ uv build
Building source distribution...
Building wheel from source distribution...
Successfully built dist/strix_agent-1.4.0.tar.gz
Successfully built dist/strix_agent-1.4.0-py3-none-any.whl
```

```text
$ uv run python - <<'PY'
from pathlib import Path
import yaml
path = Path('.github/workflows/build-release.yml')
with path.open(encoding='utf-8') as fh:
    doc = yaml.safe_load(fh)
assert 'publish-pypi' in doc['jobs']
assert doc['jobs']['publish-pypi']['permissions']['id-token'] == 'write'
print('workflow yaml parsed')
PY
workflow yaml parsed
```

No build artifacts are committed.
