### PR TITLE
feat(llm): cache recent Claude prompt context

### DIFF
--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -26,6 +26,13 @@ if TYPE_CHECKING:
     from strix.config.settings import ReasoningEffort
 
 
+_CACHE_LOCATION_MESSAGE = "message"
+_CACHE_LOCATION_TOOL_CONFIG = "tool_config"
+_CACHE_ROLE_SYSTEM = "system"
+_CACHE_INDEX_PREVIOUS_MESSAGE = -2
+_CACHE_INDEX_LAST_MESSAGE = -1
+
+
 def _accepts_required_tool_choice(model_name: str | None) -> bool:
     name = (model_name or "").strip().lower()
     for prefix in ("litellm/", "any-llm/"):
@@ -295,7 +302,7 @@ def _reasoning_settings(
 def _prompt_cache_extra_args(model_name: str) -> dict[str, Any] | None:
     """LiteLLM ``cache_control_injection_points`` for Claude prompt caching.
 
-    System prompt + rolling last-message breakpoint everywhere; ``tool_config``
+    System prompt + rolling recent-message breakpoints everywhere; ``tool_config``
     only on Bedrock Converse (the only route whose LiteLLM transform consumes
     it — elsewhere it leaks onto the wire and native Anthropic 400s). Unmapped
     Bedrock models get no points at all: Bedrock rejects the passed-through
@@ -306,10 +313,17 @@ def _prompt_cache_extra_args(model_name: str) -> dict[str, Any] | None:
     if is_bedrock_route(model_name) and not bedrock_route_supports_prompt_caching(model_name):
         return None
 
-    points: list[dict[str, Any]] = [{"location": "message", "role": "system"}]
+    points: list[dict[str, Any]] = [
+        {"location": _CACHE_LOCATION_MESSAGE, "role": _CACHE_ROLE_SYSTEM}
+    ]
     if is_bedrock_route(model_name):
-        points.append({"location": "tool_config"})
-    points.append({"location": "message", "index": -1})
+        points.append({"location": _CACHE_LOCATION_TOOL_CONFIG})
+    points.extend(
+        [
+            {"location": _CACHE_LOCATION_MESSAGE, "index": _CACHE_INDEX_PREVIOUS_MESSAGE},
+            {"location": _CACHE_LOCATION_MESSAGE, "index": _CACHE_INDEX_LAST_MESSAGE},
+        ]
+    )
     return {"cache_control_injection_points": points}
 
 

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -70,6 +70,7 @@ def test_make_model_settings_enables_prompt_cache_for_bedrock_claude() -> None:
     assert _cache_points("bedrock/global.anthropic.claude-opus-4-8") == [
         {"location": "message", "role": "system"},
         {"location": "tool_config"},
+        {"location": "message", "index": -2},
         {"location": "message", "index": -1},
     ]
 
@@ -85,6 +86,7 @@ def test_make_model_settings_enables_prompt_cache_for_bedrock_claude() -> None:
 def test_make_model_settings_enables_prompt_cache_for_non_bedrock_claude(model_name: str) -> None:
     assert _cache_points(model_name) == [
         {"location": "message", "role": "system"},
+        {"location": "message", "index": -2},
         {"location": "message", "index": -1},
     ]
 
@@ -130,6 +132,7 @@ def test_prompt_cache_kept_for_non_bedrock_claude_even_if_unmapped(monkeypatch: 
     for model in ("anthropic/claude-brand-new-9", "openrouter/anthropic/claude-brand-new"):
         assert _cache_points(model) == [
             {"location": "message", "role": "system"},
+            {"location": "message", "index": -2},
             {"location": "message", "index": -1},
         ]
 


### PR DESCRIPTION
Fixes #279.

## Summary
- Adds a second rolling Claude prompt-cache breakpoint on the previous message (`index: -2`).
- Keeps the existing system prompt and latest-message breakpoints.
- Keeps Bedrock within Claude's four-cache-control-block limit by using system + tool_config + previous message + latest message.

## Test verification (RED -> GREEN)

RED on `origin/main` with only the updated expectations:

```text
$ uv run pytest tests/test_inputs.py::test_make_model_settings_enables_prompt_cache_for_bedrock_claude tests/test_inputs.py::test_make_model_settings_enables_prompt_cache_for_non_bedrock_claude -q
AssertionError: ... {'location': 'message', 'index': -1} != {'location': 'message', 'index': -2}
4 failed
```

GREEN after the fix:

```text
$ uv run pytest tests/test_inputs.py::test_make_model_settings_enables_prompt_cache_for_bedrock_claude tests/test_inputs.py::test_make_model_settings_enables_prompt_cache_for_non_bedrock_claude -q
4 passed
```

Fix-reverted proof:

```text
$ git apply -R /tmp/strix-issue-279-fix.patch && uv run pytest tests/test_inputs.py::test_make_model_settings_enables_prompt_cache_for_bedrock_claude -q
AssertionError: ... {'location': 'message', 'index': -1} != {'location': 'message', 'index': -2}
1 failed
```

## Validation
- `uv run pytest tests/test_inputs.py tests/test_models.py -q` -> `92 passed`
- `uv run ruff check strix/core/inputs.py tests/test_inputs.py` -> pass
- `uv run ruff format --check strix/core/inputs.py tests/test_inputs.py` -> pass
- `uv run mypy strix/core/inputs.py tests/test_inputs.py` -> pass
- `uv run bandit -q -c pyproject.toml strix/core/inputs.py` -> pass
