### PR TITLE
fix(report): write executive report atomically

### DIFF
--- a/strix/report/writer.py
+++ b/strix/report/writer.py
@@ -179,17 +179,26 @@ def write_vulnerabilities(
 
 def _atomic_write_text(path: Path, payload: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        dir=str(path.parent),
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        delete=False,
-    ) as tmp:
-        tmp.write(payload)
-        tmp_path = Path(tmp.name)
-    tmp_path.replace(path)
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=str(path.parent),
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp.write(payload)
+            tmp_path = Path(tmp.name)
+        tmp_path.replace(path)
+    except Exception:
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("Failed to remove temporary report file: %s", tmp_path)
+        raise
 
 
 def render_vulnerability_md(report: dict[str, Any]) -> str:  # noqa: PLR0912, PLR0915

--- a/strix/report/writer.py
+++ b/strix/report/writer.py
@@ -115,10 +115,12 @@ def write_run_record(run_dir: Path, run_record: dict[str, Any]) -> None:
 
 def write_executive_report(run_dir: Path, final_scan_result: str) -> None:
     path = run_dir / "penetration_test_report.md"
-    with path.open("w", encoding="utf-8") as f:
-        f.write("# Security Penetration Test Report\n\n")
-        f.write(f"**Generated:** {datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S UTC')}\n\n")
-        f.write(f"{final_scan_result}\n")
+    payload = (
+        "# Security Penetration Test Report\n\n"
+        f"**Generated:** {datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S UTC')}\n\n"
+        f"{final_scan_result}\n"
+    )
+    _atomic_write_text(path, payload)
     logger.info("Saved final penetration test report to: %s", path)
 
 

--- a/tests/test_report_writer.py
+++ b/tests/test_report_writer.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+import strix.report.writer as report_writer
 from strix.report.writer import (
     read_run_record,
     render_vulnerability_md,
@@ -19,6 +20,22 @@ from strix.report.writer import (
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+REPORT_FILENAME = "penetration_test_report.md"
+EXISTING_EXECUTIVE_REPORT = "previous complete report\n"
+TIMESTAMP_FAILURE_MESSAGE = "timestamp unavailable"
+
+
+class FailingTimestamp:
+    def strftime(self, _format: str) -> str:
+        raise RuntimeError(TIMESTAMP_FAILURE_MESSAGE)
+
+
+class FailingDateTime:
+    @classmethod
+    def now(cls, _tz: object) -> FailingTimestamp:
+        return FailingTimestamp()
 
 
 def _sample_report(**overrides: Any) -> dict[str, Any]:
@@ -176,6 +193,20 @@ def test_write_vulnerabilities_skips_already_saved_ids(tmp_path: Path) -> None:
 
 def test_write_executive_report_writes_markdown(tmp_path: Path) -> None:
     write_executive_report(tmp_path, "Scan complete. No critical issues.")
-    content = (tmp_path / "penetration_test_report.md").read_text(encoding="utf-8")
+    content = (tmp_path / REPORT_FILENAME).read_text(encoding="utf-8")
     assert "# Security Penetration Test Report" in content
     assert "Scan complete. No critical issues." in content
+
+
+def test_write_executive_report_preserves_existing_report_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report_path = tmp_path / REPORT_FILENAME
+    report_path.write_text(EXISTING_EXECUTIVE_REPORT, encoding="utf-8")
+    monkeypatch.setattr(report_writer, "datetime", FailingDateTime)
+
+    with pytest.raises(RuntimeError, match=TIMESTAMP_FAILURE_MESSAGE):
+        write_executive_report(tmp_path, "replacement report")
+
+    assert report_path.read_text(encoding="utf-8") == EXISTING_EXECUTIVE_REPORT

--- a/tests/test_report_writer.py
+++ b/tests/test_report_writer.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import csv
 import json
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -18,13 +19,10 @@ from strix.report.writer import (
 )
 
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
-
 REPORT_FILENAME = "penetration_test_report.md"
 EXISTING_EXECUTIVE_REPORT = "previous complete report\n"
 TIMESTAMP_FAILURE_MESSAGE = "timestamp unavailable"
+REPLACE_FAILURE_MESSAGE = "replace failed"
 
 
 class FailingTimestamp:
@@ -210,3 +208,22 @@ def test_write_executive_report_preserves_existing_report_on_failure(
         write_executive_report(tmp_path, "replacement report")
 
     assert report_path.read_text(encoding="utf-8") == EXISTING_EXECUTIVE_REPORT
+
+
+def test_write_executive_report_removes_atomic_temp_file_on_replace_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_replace = Path.replace
+
+    def fail_temp_replace(self: Path, target: Path) -> Path:
+        if self.name.startswith(f".{REPORT_FILENAME}.") and self.suffix == ".tmp":
+            raise OSError(REPLACE_FAILURE_MESSAGE)
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", fail_temp_replace)
+
+    with pytest.raises(OSError, match=REPLACE_FAILURE_MESSAGE):
+        write_executive_report(tmp_path, "replacement report")
+
+    assert not list(tmp_path.glob(f".{REPORT_FILENAME}.*.tmp"))


### PR DESCRIPTION
Fixes #828.

## Summary

- Build the executive report content before touching `penetration_test_report.md`.
- Write the final report through the existing `_atomic_write_text` helper, matching the sibling report writers.
- Add regression coverage proving a generation-time failure preserves the previous report.

## Test verification (RED -> GREEN)

RED on `origin/main` with only the regression test added:

```text
$ uv run pytest tests/test_report_writer.py::test_write_executive_report_preserves_existing_report_on_failure -q
F [100%]
AssertionError: assert '# Security Penetration Test Report\n\n' == 'previous complete report\n'
1 failed
```

GREEN after the fix:

```text
$ uv run pytest tests/test_report_writer.py::test_write_executive_report_preserves_existing_report_on_failure -q
. [100%]
1 passed
```

## Validation

```text
$ ./run-ci.sh
12 passed
All checks passed!
2 files already formatted
Success: no issues found in 2 source files
```

Additional targeted checks:
- `uv run pytest tests/test_report_writer.py -q` -> `12 passed`
- `uv run ruff check strix/report/writer.py tests/test_report_writer.py` -> pass
- `uv run ruff format --check strix/report/writer.py tests/test_report_writer.py` -> pass
- `uv run mypy strix/report/writer.py tests/test_report_writer.py` -> pass
- `uv run bandit -q -c pyproject.toml strix/report/writer.py` -> pass
