### PR TITLE
fix(tui): use running state for app lifecycle guards

### DIFF
--- a/strix/interface/tui/app.py
+++ b/strix/interface/tui/app.py
@@ -869,7 +869,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
             yield SplashScreen(id="splash_screen")
 
     def watch_show_splash(self, show_splash: bool) -> None:
-        if not show_splash and self.is_mounted:
+        if not show_splash and self.is_running:
             try:
                 splash = self.query_one("#splash_screen")
                 splash.remove()
@@ -941,7 +941,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1 or self.show_splash:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         try:
@@ -956,7 +956,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1 or self.show_splash:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         try:
@@ -988,7 +988,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         try:
@@ -1127,7 +1127,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         return self._get_rendered_events_content(events), "chat-content"
 
     def _update_chat_view(self) -> None:
-        if len(self.screen_stack) > 1 or self.show_splash or not self.is_mounted:
+        if len(self.screen_stack) > 1 or self.show_splash or not self.is_running:
             return
 
         try:
@@ -1491,7 +1491,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1 or self.show_splash:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         self._displayed_events.clear()
@@ -1564,7 +1564,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1 or self.show_splash:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         agent_id = agent_data["id"]
@@ -1703,7 +1703,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1 or self.show_splash:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         node = event.node
@@ -1723,7 +1723,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1 or self.show_splash:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         node = event.node
@@ -1775,7 +1775,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         return "Unknown Agent"
 
     def action_toggle_help(self) -> None:
-        if self.show_splash or not self.is_mounted:
+        if self.show_splash or not self.is_running:
             return
 
         try:
@@ -1793,7 +1793,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         self.push_screen(HelpScreen())
 
     async def action_request_quit(self) -> None:
-        if self.show_splash or not self.is_mounted:
+        if self.show_splash or not self.is_running:
             await self.action_custom_quit()
             return
 
@@ -1809,7 +1809,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         self.push_screen(QuitScreen())
 
     def action_stop_selected_agent(self) -> None:
-        if self.show_splash or not self.is_mounted:
+        if self.show_splash or not self.is_running:
             return
 
         if len(self.screen_stack) > 1:
@@ -1968,7 +1968,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
             return True
 
     def on_resize(self, event: events.Resize) -> None:
-        if self.show_splash or not self.is_mounted:
+        if self.show_splash or not self.is_running:
             return
 
         try:

--- a/tests/test_tui_app_lifecycle.py
+++ b/tests/test_tui_app_lifecycle.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+from typing import NoReturn
+
+from strix.interface.tui.app import StrixTUIApp
+
+
+def test_focus_chat_input_returns_when_app_is_not_running() -> None:
+    scheduled_callbacks: list[object] = []
+
+    def query_one(_selector: str, _widget_type: type[object]) -> NoReturn:
+        raise ValueError("screen is not mounted")
+
+    app = SimpleNamespace(
+        screen_stack=[],
+        show_splash=False,
+        is_mounted=lambda _widget: False,
+        is_running=False,
+        query_one=query_one,
+        call_after_refresh=scheduled_callbacks.append,
+    )
+
+    StrixTUIApp._focus_chat_input(app)  # type: ignore[arg-type]
+
+    assert scheduled_callbacks == []


### PR DESCRIPTION
## Summary
- Replaces app-level `self.is_mounted` truthiness guards with `self.is_running` in the TUI lifecycle paths.
- Leaves the existing widget-level `widget.is_mounted` safety check unchanged.
- Adds a regression test proving a not-running app returns before querying or rescheduling focus work.

Closes #894.

## Test verification (RED -> GREEN)

RED on `origin/main` with only the regression test added:
```text
$ uv run pytest tests/test_tui_app_lifecycle.py -q
F                                                                        [100%]
AttributeError: 'types.SimpleNamespace' object has no attribute '_focus_chat_input'
1 failed in 4.80s
```

GREEN after the fix:
```text
$ uv run pytest tests/test_tui_app_lifecycle.py tests/test_proxy_renderer.py -q
....                                                                     [100%]
4 passed in 4.79s
```

Local CI replay:
```text
$ ./run-ci.sh
....                                                                     [100%]
4 passed in 4.80s
All checks passed!
2 files already formatted
Success: no issues found in 1 source file
```

Known baseline:
```text
$ uv run mypy strix/interface/tui/app.py
38 pre-existing Textual typing errors in strix/interface/tui/app.py

$ uv run pyright strix/interface/tui/app.py
117 pre-existing Textual typing/private-usage errors in strix/interface/tui/app.py
```