### PR TITLE
feat(models): add MiniMax-M3 and MiniMax-M2.7 to recommended models

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,9 @@ strix auth logout             # forget the sign-in
 - [OpenAI GPT-5.4](https://openai.com/api/) - `openai/gpt-5.4`
 - [Anthropic Claude Sonnet 4.6](https://claude.com/platform/api) - `anthropic/claude-sonnet-4-6`
 - [Google Gemini 3 Pro Preview](https://cloud.google.com/vertex-ai) - `vertex_ai/gemini-3-pro-preview`
+- [MiniMax-M3](https://platform.minimax.io) - `openai/MiniMax-M3` (set `LLM_API_BASE=https://api.minimax.io/v1`)
 
-See the [LLM Providers documentation](https://docs.strix.ai/llm-providers/overview) for all supported providers including Vertex AI, Bedrock, Azure, and local models.
+See the [LLM Providers documentation](https://docs.strix.ai/llm-providers/overview) for all supported providers including Vertex AI, Bedrock, Azure, MiniMax, and local models.
 
 ## Enterprise Pentesting
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -39,6 +39,7 @@
               "llm-providers/bedrock",
               "llm-providers/azure",
               "llm-providers/novita",
+              "llm-providers/minimax",
               "llm-providers/local"
             ]
           },

--- a/docs/llm-providers/minimax.mdx
+++ b/docs/llm-providers/minimax.mdx
@@ -1,0 +1,54 @@
+---
+title: "MiniMax"
+description: "Configure Strix with MiniMax models"
+---
+
+[MiniMax](https://www.minimax.io) provides large language models with large context windows through an OpenAI-compatible API. MiniMax operates two regional endpoints: the global endpoint (`api.minimax.io`) and the China endpoint (`api.minimaxi.com`).
+
+## Setup
+
+Global endpoint:
+
+```bash
+export STRIX_LLM="openai/MiniMax-M3"
+export LLM_API_KEY="your-minimax-api-key"
+export LLM_API_BASE="https://api.minimax.io/v1"
+```
+
+China endpoint:
+
+```bash
+export STRIX_LLM="openai/MiniMax-M3"
+export LLM_API_KEY="your-minimax-api-key"
+export LLM_API_BASE="https://api.minimaxi.com/v1"
+```
+
+## Available Models
+
+| Model | Configuration | Context Window |
+|-------|---------------|----------------|
+| MiniMax-M3 (default) | `openai/MiniMax-M3` | 1,000,000 tokens |
+| MiniMax-M2.7 | `openai/MiniMax-M2.7` | 204,800 tokens |
+
+**MiniMax-M3** is the latest flagship model with a 1,000,000-token context window and image input support.
+**MiniMax-M2.7** is the previous generation flagship with strong reasoning and coding capabilities and a 204,800-token context window.
+
+## Regional Endpoints
+
+MiniMax exposes separate endpoints for global and China users. Both are OpenAI-compatible; only the base URL differs.
+
+| Region | Base URL |
+|--------|---------|
+| Global | `https://api.minimax.io/v1` |
+| China | `https://api.minimaxi.com/v1` |
+
+## Get API Key
+
+1. Go to [platform.minimax.io](https://platform.minimax.io) (global) or [platform.minimaxi.com](https://platform.minimaxi.com) (China)
+2. Sign up or sign in
+3. Navigate to API Keys and create a new key
+
+## Notes
+
+- MiniMax API is fully OpenAI-compatible, so it works via the `openai/` LiteLLM prefix with `LLM_API_BASE`
+- Use the China endpoint (`api.minimaxi.com`) only when your account is registered on the China platform

--- a/docs/llm-providers/overview.mdx
+++ b/docs/llm-providers/overview.mdx
@@ -14,6 +14,7 @@ Set your model and API key:
 | GPT-5.4           | OpenAI        | `openai/gpt-5.4`                 |
 | Claude Sonnet 4.6 | Anthropic     | `anthropic/claude-sonnet-4-6`    |
 | Gemini 3 Pro      | Google Vertex | `vertex_ai/gemini-3-pro-preview` |
+| MiniMax-M3        | MiniMax       | `openai/MiniMax-M3`              |
 
 ```bash
 export STRIX_LLM="openai/gpt-5.4"
@@ -54,6 +55,9 @@ See the [Local Models guide](/llm-providers/local) for setup instructions and re
   </Card>
   <Card title="Local Models" href="/llm-providers/local">
     Llama 4, Mistral, and self-hosted models.
+  </Card>
+  <Card title="MiniMax" href="/llm-providers/minimax">
+    MiniMax-M3 with 1M context and image input.
   </Card>
 </CardGroup>
 

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -208,6 +208,8 @@ RECOMMENDED_MODEL_NAMES = (
     "dashscope/qwen3.7-max-2026-06-08",
     "moonshot/kimi-k3",
     "moonshot/kimi-k2.7-code",
+    "openai/MiniMax-M3",
+    "openai/MiniMax-M2.7",
 )
 
 _RECOMMENDED_MODEL_NAME_SET = frozenset(name.lower() for name in RECOMMENDED_MODEL_NAMES)
@@ -222,6 +224,7 @@ FRONTIER_MODEL_FAMILIES = (
     (("deepseek",), ("deepseek-v4", "deepseek-r1", "deepseek-reasoner")),
     (("alibaba", "dashscope", "qwen"), ("qwen3.8", "qwen3.7", "qwen3-max")),
     (("moonshot", "moonshotai", "kimi"), ("kimi-k3", "kimi-k2.7", "kimi-k2.6")),
+    (("minimax",), ("minimax-m3", "minimax-m2.7")),
 )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -66,6 +66,10 @@ def test_recommended_models_are_matched_case_insensitively() -> None:
         "moonshot/kimi-k2.6",
         "kimi-k2.7-code",
         "moonshot/kimi-k3",
+        "openai/MiniMax-M3",
+        "openai/MiniMax-M2.7",
+        "minimax-m3",
+        "minimax-m2.7",
     ],
 )
 def test_frontier_model_families_are_accepted(model_name: str) -> None:


### PR DESCRIPTION
Reason: Add MiniMax-M3 and MiniMax-M2.7 to Strix's recommended model metadata and provider documentation with correct token contexts and regional endpoints.

## Changes

- Add `openai/MiniMax-M3` (1,000,000-token context) and `openai/MiniMax-M2.7` (204,800-token context) to `RECOMMENDED_MODEL_NAMES` in `strix/config/models.py` so they are recognized as recommended frontier models.
- Add a `minimax` entry to `FRONTIER_MODEL_FAMILIES` so bare and prefixed MiniMax model names are matched by `is_recommended_or_frontier_model`.
- Add a new `docs/llm-providers/minimax.mdx` provider guide documenting both models with their correct context windows and both regional endpoints (global `api.minimax.io` and China `api.minimaxi.com`).
- Register the MiniMax guide in `docs/docs.json` navigation and link it from the providers overview and the README recommended-models list.

## Checks

- `uv run ruff check strix/config/models.py tests/test_models.py` — all checks passed
- `uv run ruff format --check strix/config/models.py tests/test_models.py` — already formatted
- `uv run pytest tests/test_models.py -q` — 70 passed
