### PR TITLE
fix(tui): use the is_running property for app guards that never fired (#894)

### DIFF
--- a/strix/interface/tui/app.py
+++ b/strix/interface/tui/app.py
@@ -870,7 +870,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
             yield SplashScreen(id="splash_screen")
 
     def watch_show_splash(self, show_splash: bool) -> None:
-        if not show_splash and self.is_mounted:
+        if not show_splash and self.is_running:
             try:
                 splash = self.query_one("#splash_screen")
                 splash.remove()
@@ -942,7 +942,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1 or self.show_splash:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         try:
@@ -957,7 +957,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1 or self.show_splash:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         try:
@@ -989,7 +989,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         try:
@@ -1128,7 +1128,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         return self._get_rendered_events_content(events), "chat-content"
 
     def _update_chat_view(self) -> None:
-        if len(self.screen_stack) > 1 or self.show_splash or not self.is_mounted:
+        if len(self.screen_stack) > 1 or self.show_splash or not self.is_running:
             return
 
         try:
@@ -1492,7 +1492,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1 or self.show_splash:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         self._displayed_events.clear()
@@ -1565,7 +1565,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1 or self.show_splash:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         agent_id = agent_data["id"]
@@ -1704,7 +1704,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1 or self.show_splash:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         node = event.node
@@ -1724,7 +1724,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         if len(self.screen_stack) > 1 or self.show_splash:
             return
 
-        if not self.is_mounted:
+        if not self.is_running:
             return
 
         node = event.node
@@ -1776,7 +1776,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         return "Unknown Agent"
 
     def action_toggle_help(self) -> None:
-        if self.show_splash or not self.is_mounted:
+        if self.show_splash or not self.is_running:
             return
 
         try:
@@ -1794,7 +1794,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         self.push_screen(HelpScreen())
 
     async def action_request_quit(self) -> None:
-        if self.show_splash or not self.is_mounted:
+        if self.show_splash or not self.is_running:
             await self.action_custom_quit()
             return
 
@@ -1810,7 +1810,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
         self.push_screen(QuitScreen())
 
     def action_stop_selected_agent(self) -> None:
-        if self.show_splash or not self.is_mounted:
+        if self.show_splash or not self.is_running:
             return
 
         if len(self.screen_stack) > 1:
@@ -1969,7 +1969,7 @@ class StrixTUIApp(App):  # type: ignore[misc]
             return True
 
     def on_resize(self, event: events.Resize) -> None:
-        if self.show_splash or not self.is_mounted:
+        if self.show_splash or not self.is_running:
             return
 
         try:


### PR DESCRIPTION
## Summary

`textual`'s `App.is_mounted` is a **method** taking a widget, not a property — so a bare `self.is_mounted` is an always-truthy bound method, and every `if not self.is_mounted: return` guard in the TUI was dead. Worst case, the dead guard let `query_one` run against a missing screen, raise, get caught by the surrounding `except`, and re-schedule via `call_after_refresh` — looping instead of returning.

Closes #894.

## Changes

Switch the 13 app-level guards in `strix/interface/tui/app.py` to `App.is_running` (the bool property these guards actually want). The one correct `widget.is_mounted` (a `Widget` property) is left unchanged.

This resolves the `mypy` *"Function 'is_mounted' could always be true in boolean context"* and `pyright` `reportUnnecessaryComparison` findings from the issue. Confirmed by introspection that `App.is_running` is a `property` and `App.is_mounted` is a `function`, so `not self.is_running` is now a real check.
