### PR TITLE
fix(llm): add a stall deadline to the codex stream

### DIFF
--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import inspect
+import logging
 import os
 import time
 from typing import TYPE_CHECKING, Any
 
+import httpx
 from agents import (
     set_default_openai_api,
     set_default_openai_key,
@@ -24,6 +27,7 @@ from agents.retry import (
     RetryPolicyContext,
     retry_policies,
 )
+from openai import APITimeoutError
 from openai.types.responses import Response, ResponseCompletedEvent
 from openai.types.responses.response_usage import ResponseUsage
 from openai.types.shared import Reasoning
@@ -32,8 +36,15 @@ from strix.config import codex
 from strix.config.loader import load_settings
 
 
+logger = logging.getLogger(__name__)
+
+# Releasing a stalled stream is a local teardown, not a model call; it gets its own
+# short bound so cleanup can never inherit the stall.
+_STREAM_CLOSE_TIMEOUT_S = 30.0
+
+
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Awaitable
 
     from agents.agent_output import AgentOutputSchemaBase
     from agents.handoffs import Handoff
@@ -74,9 +85,11 @@ class _CodexResponsesModel(OpenAIResponsesModel):
         openai_client: AsyncOpenAI,
         *,
         reasoning_effort: ReasoningEffort | None = None,
+        stall_timeout: float | None = None,
     ) -> None:
         super().__init__(model, openai_client)
         self._reasoning_effort = reasoning_effort
+        self._stall_timeout = stall_timeout if stall_timeout and stall_timeout > 0 else None
 
     def _codex_settings(self, model_settings: ModelSettings) -> ModelSettings:
         overrides = ModelSettings(store=False, response_include=["reasoning.encrypted_content"])
@@ -90,11 +103,29 @@ class _CodexResponsesModel(OpenAIResponsesModel):
             overrides = overrides.resolve(ModelSettings(reasoning=Reasoning(effort=effort)))
         return model_settings.resolve(overrides)
 
+    def _stalled(self, phase: str) -> APITimeoutError:
+        """A timeout error for a stream that went silent, so retry policy applies.
+
+        ``APITimeoutError`` is what the transient-retry path in
+        ``strix.core.execution`` and the SDK's own network-error policy already
+        act on, so a stall replays the turn instead of failing the agent.
+        """
+        logger.warning(
+            "ChatGPT backend stream stalled during %s: no data for %.0fs. Aborting so the "
+            "turn can be replayed; raise STRIX_CODEX_STREAM_STALL_S to allow longer silences.",
+            phase,
+            self._stall_timeout or 0.0,
+        )
+        return APITimeoutError(httpx.Request("POST", f"{codex.CODEX_BASE_URL}/responses"))
+
     async def _fetch_response(self, *args: Any, stream: bool = False, **kwargs: Any) -> Any:
         if len(args) >= 3:  # model_settings is positional arg 2
             args = (*args[:2], self._codex_settings(args[2]), *args[3:])
         try:
-            events = await super()._fetch_response(*args, stream=True, **kwargs)  # type: ignore[call-overload]
+            opening = super()._fetch_response(*args, stream=True, **kwargs)  # type: ignore[call-overload]
+            events = await self._deadline(opening)
+        except TimeoutError as exc:
+            raise self._stalled("stream open") from exc
         except Exception as exc:
             guardrail = self._as_guardrail(exc)
             if guardrail is not None:
@@ -119,10 +150,30 @@ class _CodexResponsesModel(OpenAIResponsesModel):
             return codex.CodexContentGuardrailError(self.model, exc)
         return None
 
+    async def _deadline(self, awaitable: Awaitable[Any]) -> Any:
+        """Await under the stall deadline, or unbounded when it is disabled."""
+        if self._stall_timeout is None:
+            return await awaitable
+        return await asyncio.wait_for(awaitable, self._stall_timeout)
+
     async def _guarded(self, events: Any) -> AsyncIterator[Any]:
-        """Convert mid-stream guardrail rejections and close the stream on exit."""
+        """Convert mid-stream guardrail rejections and close the stream on exit.
+
+        Each event is pulled under a stall deadline. An httpx read timeout only
+        runs while a read is pending, so a response body that is never consumed
+        cannot expire on its own: the request looks alive, ``LLM_TIMEOUT`` never
+        fires, and the agent waits forever on a connection the backend has
+        already finished with.
+        """
+        iterator = events.__aiter__()
         try:
-            async for event in events:
+            while True:
+                try:
+                    event = await self._deadline(iterator.__anext__())
+                except StopAsyncIteration:
+                    break
+                except TimeoutError as exc:
+                    raise self._stalled("stream read") from exc
                 yield event
         except Exception as exc:
             guardrail = self._as_guardrail(exc)
@@ -134,17 +185,18 @@ class _CodexResponsesModel(OpenAIResponsesModel):
 
     @staticmethod
     async def _aclose(events: Any) -> None:
+        # Bounded: releasing a stalled stream must not become a second place to hang.
         aclose = getattr(events, "aclose", None)
         if callable(aclose):
             with contextlib.suppress(Exception):
-                await aclose()
+                await asyncio.wait_for(aclose(), _STREAM_CLOSE_TIMEOUT_S)
             return
         close = getattr(events, "close", None)
         if callable(close):
             with contextlib.suppress(Exception):
                 result = close()
                 if inspect.isawaitable(result):
-                    await result
+                    await asyncio.wait_for(result, _STREAM_CLOSE_TIMEOUT_S)
 
 
 class _NonStreamingModel(Model):
@@ -299,6 +351,7 @@ class StrixProvider(MultiProvider):
                 slug,
                 codex.get_subscription_client(),
                 reasoning_effort=llm.reasoning_effort,
+                stall_timeout=llm.codex_stream_stall_timeout,
             )
         model = super().get_model(model_name)
         if llm.disable_streaming:

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -52,6 +52,11 @@ class LlmSettings(BaseSettings):
         default=False,
         alias="LLM_DISABLE_STREAMING",
     )
+    codex_stream_stall_timeout: float = Field(
+        default=300.0,
+        ge=0.0,
+        alias="STRIX_CODEX_STREAM_STALL_S",
+    )
     timeout: int = Field(default=300, alias="LLM_TIMEOUT")
 
 

--- a/tests/test_codex_streaming.py
+++ b/tests/test_codex_streaming.py
@@ -9,6 +9,7 @@ works where the stock responses model would fail.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -18,11 +19,13 @@ import pytest
 from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
 from agents.models.openai_responses import OpenAIResponsesModel
-from openai import AsyncOpenAI, BadRequestError
+from openai import APITimeoutError, AsyncOpenAI, BadRequestError
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 
 from strix.config import codex
 from strix.config.models import _CodexResponsesModel
+from strix.config.settings import LlmSettings
+from strix.core.execution import _is_transient_model_error
 
 
 if TYPE_CHECKING:
@@ -205,6 +208,82 @@ async def test_guarded_yields_all_events_when_clean() -> None:
     stream = _TrackingStream(["a", "b", "c"], None)
     assert await _drain(model._guarded(stream)) == ["a", "b", "c"]
     assert stream.closed is True
+
+
+class _StallingStream:
+    """Yields ``events``, then goes silent forever, like a backend that stops sending."""
+
+    def __init__(self, events: list[Any]) -> None:
+        self._events = iter(events)
+        self.closed = False
+
+    def __aiter__(self) -> _StallingStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._events)
+        except StopIteration:
+            await asyncio.Event().wait()  # never resolves
+            raise AssertionError from None  # pragma: no cover
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_guarded_aborts_a_stalled_stream() -> None:
+    # A stream that stops sending must not hang the agent forever: no read is
+    # pending, so no httpx read timeout can fire and LLM_TIMEOUT never applies.
+    model = _CodexResponsesModel(
+        model="gpt-5.6-sol",
+        openai_client=_client("http://x/backend-api"),
+        stall_timeout=0.05,
+    )
+    stream = _StallingStream(["a", "b"])
+    with pytest.raises(APITimeoutError):
+        await _drain(model._guarded(stream))
+    assert stream.closed is True  # the dead connection is released, not leaked
+
+
+@pytest.mark.asyncio
+async def test_stalled_stream_error_is_retryable() -> None:
+    # The stall surfaces as the error the transient-retry path already replays on.
+    model = _CodexResponsesModel(
+        model="gpt-5.6-sol",
+        openai_client=_client("http://x/backend-api"),
+        stall_timeout=0.05,
+    )
+    with pytest.raises(APITimeoutError) as exc_info:
+        await _drain(model._guarded(_StallingStream([])))
+    assert _is_transient_model_error(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_stall_deadline_off_by_default_for_direct_construction() -> None:
+    # Without an explicit timeout the wrapper stays unbounded, so existing
+    # callers and a zeroed STRIX_CODEX_STREAM_STALL_S keep stock behaviour.
+    model = _CodexResponsesModel(model="gpt-5.5", openai_client=_client("http://x/backend-api"))
+    assert model._stall_timeout is None
+    zeroed = _CodexResponsesModel(
+        model="gpt-5.5", openai_client=_client("http://x/backend-api"), stall_timeout=0
+    )
+    assert zeroed._stall_timeout is None
+
+
+@pytest.mark.asyncio
+async def test_stall_deadline_does_not_disturb_a_healthy_stream(backend_url: str) -> None:
+    model = _CodexResponsesModel(
+        model="gpt-5.5", openai_client=_client(backend_url), stall_timeout=30.0
+    )
+    response = await model.get_response(**_call_kwargs())
+    assert response.usage.total_tokens == 2
+
+
+def test_stall_timeout_is_configurable() -> None:
+    settings = LlmSettings()
+    assert settings.codex_stream_stall_timeout == 300.0
+    assert LlmSettings(STRIX_CODEX_STREAM_STALL_S="45").codex_stream_stall_timeout == 45.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What breaks

On the ChatGPT subscription backend (`STRIX_LLM=chatgpt/gpt-5.6-sol`), a deep scan freezes permanently. Every live agent stops mid-run, the token counters stop moving, and nothing recovers. It happened twice on 1.4.1, once after 143 requests and once after 226.

It isn't a rate limit, token expiry, or the sandbox. The backend answers in full and Strix never reads the response.

```
$ netstat -an -p tcp | grep CLOSE_WAIT     # 30 minutes after the last log line
Proto Recv-Q Send-Q  Local Address        Foreign Address       (state)
tcp4  625471      0  192.168.20.70.58563  104.18.32.47.443      CLOSE_WAIT   <- chatgpt.com
tcp4  365037      0  192.168.20.70.60933  172.64.155.209.443    CLOSE_WAIT
tcp4  356425      0  192.168.20.70.61478  172.64.155.209.443    CLOSE_WAIT
...                                        17 sockets, 4 MB unread
```

Seventeen sockets, one per still-`running` agent, each holding a completed response body in the kernel receive buffer that nothing ever consumed. The backend sent everything and closed, which is why they sit in `CLOSE_WAIT`. Meanwhile:

- `.state/agents.json` shows 17 agents `running`, `pending_counts` all 0, `errors: {}`
- every tool call in the transcript is `status: completed`, so the agents were waiting on the model rather than the sandbox
- the event loop is alive and healthy, and the local viewer keeps serving `/api/run` every 0.5 s
- the thread pool is idle, with 13 workers parked on an empty queue, no lock contention and no fd exhaustion

## Why no timeout fires

`_CodexResponsesModel` forces `stream=True` on every request, including from the non-streaming `get_response` path, and drains the SSE stream through `_guarded()`.

An httpx read timeout only runs while a read is pending. Once the response headers arrive and nothing pulls the body, no read is outstanding, so no timer is ever armed. `LLM_TIMEOUT` and the client's own read timeout are both inert, `strix.core.execution`'s transient-retry path never sees an exception to act on, and the agent waits forever on a connection the backend has already finished with.

`_NonStreamingModel`'s docstring already names this shape for third-party gateways ("stalling mid-stream so the whole turn waits out the read timeout"). On the codex path the turn doesn't get that far. There is no read timeout to wait out.

## The fix

Put a wall-clock deadline on the two places the codex stream can park:

1. opening the stream (request send plus response headers)
2. every subsequent event pulled off it

On expiry, raise `openai.APITimeoutError`, which `_is_transient_model_error` already classifies as retryable, so the turn replays with backoff instead of hanging. Closing the abandoned stream also releases the leaked socket. `_aclose` gets its own short bound so teardown can't inherit the stall.

Configurable via `STRIX_CODEX_STREAM_STALL_S`, default 300 s, `0` disables it and restores current behaviour. That default is generous on purpose: roughly 10x the longest legitimate silence I measured between events on `gpt-5.6-sol` at high reasoning effort. The failure it catches is unbounded, not slow.

## Before / after

```
before:  agent parked forever, 0 tokens, no log line, no error, socket in CLOSE_WAIT
after:   WARNING ChatGPT backend stream stalled during stream read: no data for 300s.
         Aborting so the turn can be replayed; raise STRIX_CODEX_STREAM_STALL_S to
         allow longer silences.
         -> turn replays (up to _MAX_TRANSIENT_MODEL_RETRIES), scan continues
```

Healthy streams are untouched: same events, same aggregation, same request payload.

## Tests

Added to `tests/test_codex_streaming.py`:

- `test_guarded_aborts_a_stalled_stream` proves a stream that goes silent raises instead of hanging, and that the stream gets closed rather than leaked
- `test_stalled_stream_error_is_retryable` asserts the raised error is the one `_is_transient_model_error` retries on
- `test_stall_deadline_off_by_default_for_direct_construction` keeps the wrapper unbounded unless a timeout is passed, and treats `0` as disabled
- `test_stall_deadline_does_not_disturb_a_healthy_stream` runs the existing local-backend test with a deadline set
- `test_stall_timeout_is_configurable` covers the setting default and its env override

## Scope

I kept this narrow, touching only `_CodexResponsesModel`, the one place Strix owns the model-stream chokepoint. A stall deadline further up, around `stream_events()`, would be wrong, because event gaps there are legitimate while a tool runs.

This bounds the hang. It doesn't claim to explain why the backend stops mid-stream in the first place. Today that produces a silent permanent freeze with nothing in the log; after this it produces a retry and a warning naming the phase.
