### PR TITLE
Prevent ChatGPT subscription scan freezes

### DIFF
--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import inspect
+import logging
 import os
 import time
 from typing import TYPE_CHECKING, Any
 
+import httpx
 from agents import (
     set_default_openai_api,
     set_default_openai_key,
@@ -24,6 +27,7 @@ from agents.retry import (
     RetryPolicyContext,
     retry_policies,
 )
+from openai import APITimeoutError
 from openai.types.responses import Response, ResponseCompletedEvent
 from openai.types.responses.response_usage import ResponseUsage
 from openai.types.shared import Reasoning
@@ -32,8 +36,15 @@ from strix.config import codex
 from strix.config.loader import load_settings
 
 
+logger = logging.getLogger(__name__)
+
+# Releasing a stalled stream is a local teardown, not a model call; it gets its own
+# short bound so cleanup can never inherit the stall.
+_STREAM_CLOSE_TIMEOUT_S = 30.0
+
+
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Awaitable
 
     from agents.agent_output import AgentOutputSchemaBase
     from agents.handoffs import Handoff
@@ -74,9 +85,11 @@ class _CodexResponsesModel(OpenAIResponsesModel):
         openai_client: AsyncOpenAI,
         *,
         reasoning_effort: ReasoningEffort | None = None,
+        stall_timeout: float | None = None,
     ) -> None:
         super().__init__(model, openai_client)
         self._reasoning_effort = reasoning_effort
+        self._stall_timeout = stall_timeout if stall_timeout and stall_timeout > 0 else None
 
     def _codex_settings(self, model_settings: ModelSettings) -> ModelSettings:
         overrides = ModelSettings(store=False, response_include=["reasoning.encrypted_content"])
@@ -90,11 +103,29 @@ class _CodexResponsesModel(OpenAIResponsesModel):
             overrides = overrides.resolve(ModelSettings(reasoning=Reasoning(effort=effort)))
         return model_settings.resolve(overrides)
 
+    def _stalled(self, phase: str) -> APITimeoutError:
+        """A timeout error for a stream that went silent, so retry policy applies.
+
+        ``APITimeoutError`` is what the transient-retry path in
+        ``strix.core.execution`` and the SDK's own network-error policy already
+        act on, so a stall replays the turn instead of failing the agent.
+        """
+        logger.warning(
+            "ChatGPT backend stream stalled during %s: no data for %.0fs. Aborting so the "
+            "turn can be replayed; raise STRIX_CODEX_STREAM_STALL_S to allow longer silences.",
+            phase,
+            self._stall_timeout or 0.0,
+        )
+        return APITimeoutError(httpx.Request("POST", f"{codex.CODEX_BASE_URL}/responses"))
+
     async def _fetch_response(self, *args: Any, stream: bool = False, **kwargs: Any) -> Any:
         if len(args) >= 3:  # model_settings is positional arg 2
             args = (*args[:2], self._codex_settings(args[2]), *args[3:])
         try:
-            events = await super()._fetch_response(*args, stream=True, **kwargs)  # type: ignore[call-overload]
+            opening = super()._fetch_response(*args, stream=True, **kwargs)  # type: ignore[call-overload]
+            events = await self._deadline(opening)
+        except TimeoutError as exc:
+            raise self._stalled("stream open") from exc
         except Exception as exc:
             guardrail = self._as_guardrail(exc)
             if guardrail is not None:
@@ -119,10 +150,30 @@ class _CodexResponsesModel(OpenAIResponsesModel):
             return codex.CodexContentGuardrailError(self.model, exc)
         return None
 
+    async def _deadline(self, awaitable: Awaitable[Any]) -> Any:
+        """Await under the stall deadline, or unbounded when it is disabled."""
+        if self._stall_timeout is None:
+            return await awaitable
+        return await asyncio.wait_for(awaitable, self._stall_timeout)
+
     async def _guarded(self, events: Any) -> AsyncIterator[Any]:
-        """Convert mid-stream guardrail rejections and close the stream on exit."""
+        """Convert mid-stream guardrail rejections and close the stream on exit.
+
+        Each event is pulled under a stall deadline. An httpx read timeout only
+        runs while a read is pending, so a response body that is never consumed
+        cannot expire on its own: the request looks alive, ``LLM_TIMEOUT`` never
+        fires, and the agent waits forever on a connection the backend has
+        already finished with.
+        """
+        iterator = events.__aiter__()
         try:
-            async for event in events:
+            while True:
+                try:
+                    event = await self._deadline(iterator.__anext__())
+                except StopAsyncIteration:
+                    break
+                except TimeoutError as exc:
+                    raise self._stalled("stream read") from exc
                 yield event
         except Exception as exc:
             guardrail = self._as_guardrail(exc)
@@ -134,17 +185,18 @@ class _CodexResponsesModel(OpenAIResponsesModel):
 
     @staticmethod
     async def _aclose(events: Any) -> None:
+        # Bounded: releasing a stalled stream must not become a second place to hang.
         aclose = getattr(events, "aclose", None)
         if callable(aclose):
             with contextlib.suppress(Exception):
-                await aclose()
+                await asyncio.wait_for(aclose(), _STREAM_CLOSE_TIMEOUT_S)
             return
         close = getattr(events, "close", None)
         if callable(close):
             with contextlib.suppress(Exception):
                 result = close()
                 if inspect.isawaitable(result):
-                    await result
+                    await asyncio.wait_for(result, _STREAM_CLOSE_TIMEOUT_S)
 
 
 class _NonStreamingModel(Model):
@@ -299,6 +351,7 @@ class StrixProvider(MultiProvider):
                 slug,
                 codex.get_subscription_client(),
                 reasoning_effort=llm.reasoning_effort,
+                stall_timeout=llm.codex_stream_stall_timeout,
             )
         model = super().get_model(model_name)
         if llm.disable_streaming:

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -66,6 +66,13 @@ def request_timeout_extra_args(timeout_s: float | None) -> dict[str, float] | No
     return {"timeout": timeout_s}
 
 
+def reasoning_for_effort(effort: ReasoningEffort) -> Reasoning:
+    """Build reasoning settings, including values newer than the bundled SDK enum."""
+    if effort == "max":
+        return Reasoning.model_construct(effort=effort)
+    return Reasoning(effort=effort)
+
+
 def _retry_statusless_provider_errors(context: RetryPolicyContext) -> bool:
     """Retry statusless provider errors (e.g. mid-stream quota/billing), but not aborts."""
     normalized = context.normalized
@@ -95,12 +102,9 @@ class _CodexResponsesModel(OpenAIResponsesModel):
         overrides = ModelSettings(store=False, response_include=["reasoning.encrypted_content"])
         effort = self._reasoning_effort
         if effort and effort != "none":
-            # Clamp to efforts the backend accepts.
             if effort == "minimal":
                 effort = "low"
-            elif effort == "xhigh":
-                effort = "high"
-            overrides = overrides.resolve(ModelSettings(reasoning=Reasoning(effort=effort)))
+            overrides = overrides.resolve(ModelSettings(reasoning=reasoning_for_effort(effort)))
         return model_settings.resolve(overrides)
 
     def _stalled(self, phase: str) -> APITimeoutError:

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -8,7 +8,7 @@ from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 _BASE_CONFIG = SettingsConfigDict(
     case_sensitive=False,

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -52,6 +52,11 @@ class LlmSettings(BaseSettings):
         default=False,
         alias="LLM_DISABLE_STREAMING",
     )
+    codex_stream_stall_timeout: float = Field(
+        default=300.0,
+        ge=0.0,
+        alias="STRIX_CODEX_STREAM_STALL_S",
+    )
     timeout: int = Field(default=300, alias="LLM_TIMEOUT")
 
 

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -6,7 +6,6 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from agents.model_settings import ModelSettings
-from openai.types.shared import Reasoning
 
 from strix.config.models import (
     DEFAULT_MODEL_RETRY,
@@ -15,6 +14,7 @@ from strix.config.models import (
     is_claude_model,
     is_known_openai_bare_model,
     model_supports_reasoning,
+    reasoning_for_effort,
     request_timeout_extra_args,
 )
 from strix.core.sessions import scrub_images_from_items
@@ -147,7 +147,7 @@ def make_model_settings(
         and model_supports_reasoning(model_name)
     ):
         model_settings = model_settings.resolve(
-            ModelSettings(reasoning=Reasoning(effort=reasoning_effort)),
+            ModelSettings(reasoning=reasoning_for_effort(reasoning_effort)),
         )
     if force_required_tool_choice and _accepts_required_tool_choice(model_name):
         model_settings = model_settings.resolve(ModelSettings(tool_choice="required"))

--- a/strix/interface/tui/app.py
+++ b/strix/interface/tui/app.py
@@ -27,6 +27,7 @@ from textual import events, on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Grid, Horizontal, Vertical, VerticalScroll
+from textual.message import Message
 from textual.reactive import reactive
 from textual.screen import ModalScreen
 from textual.widgets import Button, Label, Static, TextArea, Tree
@@ -54,6 +55,13 @@ from strix.runtime import session_manager
 
 
 logger = logging.getLogger(__name__)
+
+
+class SdkStreamEvent(Message):
+    def __init__(self, agent_id: str, event: Any) -> None:
+        super().__init__()
+        self.agent_id = agent_id
+        self.event = event
 
 
 def get_package_version() -> str:
@@ -1549,14 +1557,19 @@ class StrixTUIApp(App):  # type: ignore[misc]
                 logging.exception("Error setting up scan thread")
                 self._scan_completed.set()
 
-        self._scan_thread = threading.Thread(target=scan_target, daemon=True)
+        self._scan_thread = threading.Thread(
+            target=scan_target,
+            daemon=True,
+            name="strix-scan-loop",
+        )
         self._scan_thread.start()
 
     def _capture_sdk_event(self, agent_id: str, event: Any) -> None:
-        try:
-            self.call_from_thread(self._record_sdk_event, agent_id, event)
-        except RuntimeError:
-            self._record_sdk_event(agent_id, event)
+        self.post_message(SdkStreamEvent(agent_id, event))
+
+    @on(SdkStreamEvent)
+    def _on_sdk_stream_event(self, message: SdkStreamEvent) -> None:
+        self._record_sdk_event(message.agent_id, message.event)
 
     def _record_sdk_event(self, agent_id: str, event: Any) -> None:
         self.live_view.ingest_sdk_event(agent_id, event)

--- a/strix/llm/context_budget.py
+++ b/strix/llm/context_budget.py
@@ -17,7 +17,14 @@ logger = logging.getLogger(__name__)
 
 # LiteLLM keys models without the routing prefix users type (``openai/``,
 # ``litellm/``, ``ollama/`` ...). Strip a leading provider segment on lookup.
-_STRIPPABLE_PREFIXES = ("openai/", "litellm/", "any-llm/", "ollama/", "ollama_chat/")
+_STRIPPABLE_PREFIXES = (
+    "openai/",
+    "chatgpt/",
+    "litellm/",
+    "any-llm/",
+    "ollama/",
+    "ollama_chat/",
+)
 
 _DEFAULT_OUTPUT_TOKENS = 8_192
 
@@ -38,7 +45,12 @@ def _safe_get_model_info(model: str) -> dict[str, Any] | None:
 
 @lru_cache(maxsize=128)
 def _model_info(model: str) -> dict[str, int]:
-    for candidate in (model, _lookup_key(model)):
+    lookup_key = _lookup_key(model)
+    # LiteLLM's provider-qualified ``chatgpt/`` metadata path obtains an access
+    # token and may start a synchronous 15-minute device-login poll. Metadata is
+    # keyed by the underlying OpenAI model slug, so never enter that auth path.
+    candidates = (lookup_key,) if model.startswith("chatgpt/") else (model, lookup_key)
+    for candidate in candidates:
         info = _safe_get_model_info(candidate)
         if info is not None:
             return {

--- a/tests/test_codex_streaming.py
+++ b/tests/test_codex_streaming.py
@@ -284,6 +284,7 @@ def test_stall_timeout_is_configurable() -> None:
     settings = LlmSettings()
     assert settings.codex_stream_stall_timeout == 300.0
     assert LlmSettings(STRIX_CODEX_STREAM_STALL_S="45").codex_stream_stall_timeout == 45.0
+    assert LlmSettings(STRIX_REASONING_EFFORT="max").reasoning_effort == "max"
 
 
 @pytest.mark.asyncio
@@ -302,3 +303,14 @@ async def test_codex_model_self_enforces_backend_requirements(backend_url: str) 
     assert _CAPTURED["store"] is False
     assert _CAPTURED["include"] == ["reasoning.encrypted_content"]
     assert _CAPTURED["reasoning"] == {"effort": "high"}
+
+
+@pytest.mark.asyncio
+async def test_codex_model_forwards_max_reasoning_effort(backend_url: str) -> None:
+    model = _CodexResponsesModel(
+        model="gpt-5.6-luna", openai_client=_client(backend_url), reasoning_effort="max"
+    )
+
+    await model.get_response(**_call_kwargs())
+
+    assert _CAPTURED["reasoning"] == {"effort": "max"}

--- a/tests/test_codex_streaming.py
+++ b/tests/test_codex_streaming.py
@@ -9,6 +9,7 @@ works where the stock responses model would fail.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -18,11 +19,13 @@ import pytest
 from agents.model_settings import ModelSettings
 from agents.models.interface import ModelTracing
 from agents.models.openai_responses import OpenAIResponsesModel
-from openai import AsyncOpenAI, BadRequestError
+from openai import APITimeoutError, AsyncOpenAI, BadRequestError
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 
 from strix.config import codex
 from strix.config.models import _CodexResponsesModel
+from strix.config.settings import LlmSettings
+from strix.core.execution import _is_transient_model_error
 
 
 if TYPE_CHECKING:
@@ -205,6 +208,82 @@ async def test_guarded_yields_all_events_when_clean() -> None:
     stream = _TrackingStream(["a", "b", "c"], None)
     assert await _drain(model._guarded(stream)) == ["a", "b", "c"]
     assert stream.closed is True
+
+
+class _StallingStream:
+    """Yields ``events``, then goes silent forever, like a backend that stops sending."""
+
+    def __init__(self, events: list[Any]) -> None:
+        self._events = iter(events)
+        self.closed = False
+
+    def __aiter__(self) -> _StallingStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._events)
+        except StopIteration:
+            await asyncio.Event().wait()  # never resolves
+            raise AssertionError from None  # pragma: no cover
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_guarded_aborts_a_stalled_stream() -> None:
+    # A stream that stops sending must not hang the agent forever: no read is
+    # pending, so no httpx read timeout can fire and LLM_TIMEOUT never applies.
+    model = _CodexResponsesModel(
+        model="gpt-5.6-sol",
+        openai_client=_client("http://x/backend-api"),
+        stall_timeout=0.05,
+    )
+    stream = _StallingStream(["a", "b"])
+    with pytest.raises(APITimeoutError):
+        await _drain(model._guarded(stream))
+    assert stream.closed is True  # the dead connection is released, not leaked
+
+
+@pytest.mark.asyncio
+async def test_stalled_stream_error_is_retryable() -> None:
+    # The stall surfaces as the error the transient-retry path already replays on.
+    model = _CodexResponsesModel(
+        model="gpt-5.6-sol",
+        openai_client=_client("http://x/backend-api"),
+        stall_timeout=0.05,
+    )
+    with pytest.raises(APITimeoutError) as exc_info:
+        await _drain(model._guarded(_StallingStream([])))
+    assert _is_transient_model_error(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_stall_deadline_off_by_default_for_direct_construction() -> None:
+    # Without an explicit timeout the wrapper stays unbounded, so existing
+    # callers and a zeroed STRIX_CODEX_STREAM_STALL_S keep stock behaviour.
+    model = _CodexResponsesModel(model="gpt-5.5", openai_client=_client("http://x/backend-api"))
+    assert model._stall_timeout is None
+    zeroed = _CodexResponsesModel(
+        model="gpt-5.5", openai_client=_client("http://x/backend-api"), stall_timeout=0
+    )
+    assert zeroed._stall_timeout is None
+
+
+@pytest.mark.asyncio
+async def test_stall_deadline_does_not_disturb_a_healthy_stream(backend_url: str) -> None:
+    model = _CodexResponsesModel(
+        model="gpt-5.5", openai_client=_client(backend_url), stall_timeout=30.0
+    )
+    response = await model.get_response(**_call_kwargs())
+    assert response.usage.total_tokens == 2
+
+
+def test_stall_timeout_is_configurable() -> None:
+    settings = LlmSettings()
+    assert settings.codex_stream_stall_timeout == 300.0
+    assert LlmSettings(STRIX_CODEX_STREAM_STALL_S="45").codex_stream_stall_timeout == 45.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -21,6 +21,24 @@ def test_context_window_strips_provider_prefix() -> None:
     assert context_budget.context_window("openai/gpt-4o") == 128_000
 
 
+def test_context_window_chatgpt_prefix_never_enters_provider_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context_budget._model_info.cache_clear()
+    calls: list[str] = []
+
+    def _model_info(model: str) -> dict[str, int]:
+        calls.append(model)
+        return {"max_input_tokens": 1_050_000, "max_output_tokens": 128_000}
+
+    monkeypatch.setattr("strix.llm.context_budget.litellm.get_model_info", _model_info)
+    try:
+        assert context_budget.context_window("chatgpt/gpt-5.6-luna") == 1_050_000
+        assert calls == ["gpt-5.6-luna"]
+    finally:
+        context_budget._model_info.cache_clear()
+
+
 def test_context_window_unmapped_uses_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     context_budget._model_info.cache_clear()
 

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -296,6 +296,13 @@ def test_make_model_settings_extra_headers_survive_reasoning_resolve() -> None:
     assert settings.extra_headers == {"X-Feature-Key": "svc"}
 
 
+def test_make_model_settings_supports_max_reasoning() -> None:
+    settings = make_model_settings("max", model_name="openai/o3")
+
+    assert settings.reasoning is not None
+    assert settings.reasoning.effort == "max"
+
+
 def test_make_model_settings_timeout_survives_reasoning_resolve() -> None:
     # Reasoning is resolved via ModelSettings.resolve(); the timeout in extra_args
     # must not be dropped when a reasoning override is merged in.

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock
+
+from strix.interface.tui.app import SdkStreamEvent, StrixTUIApp
+
+
+def test_capture_sdk_event_posts_without_waiting_for_ui_thread() -> None:
+    app = MagicMock(spec=StrixTUIApp)
+    event = object()
+
+    StrixTUIApp._capture_sdk_event(app, "agent-1", event)
+
+    app.post_message.assert_called_once()
+    message = app.post_message.call_args.args[0]
+    assert isinstance(message, SdkStreamEvent)
+    assert message.agent_id == "agent-1"
+    assert message.event is event
+    app.call_from_thread.assert_not_called()
+    app._record_sdk_event.assert_not_called()
+
+
+def test_sdk_stream_event_is_recorded_on_ui_thread() -> None:
+    app = MagicMock(spec=StrixTUIApp)
+    event = object()
+
+    StrixTUIApp._on_sdk_stream_event(app, SdkStreamEvent("agent-1", event))
+
+    app._record_sdk_event.assert_called_once_with("agent-1", event)


### PR DESCRIPTION
## What broke

ChatGPT subscription scans could freeze when Strix asked LiteLLM for context metadata using a provider-qualified `chatgpt/...` model name. LiteLLM treats that lookup as an authentication path and can enter a synchronous device-code poll on Strix's only scan loop. No SDK events are emitted while it waits, so the TUI stops updating and the run cannot make progress.

A live thread dump caught the scan loop inside LiteLLM's authorization poll, reached from `context_window()`.

## Fix

- Resolve ChatGPT context metadata with the underlying model slug, which avoids the authentication path.
- Put deadlines around Codex stream startup and iteration so a stalled backend raises a retryable timeout.
- Post SDK events to Textual's message queue without waiting on the UI thread.
- Pass Luna's `max` reasoning effort through unchanged.

## Testing

- `uv run pytest tests/test_context_budget.py tests/test_compaction.py tests/test_codex_streaming.py tests/test_inputs.py tests/test_tui_app.py` (67 passed)
- `uv run ruff check` on the changed files
- `uv run ruff format --check` on the changed files
- `uv run mypy strix/config/models.py strix/config/settings.py strix/core/inputs.py strix/llm/context_budget.py`
