### PR TITLE
fix(llm): prevent ChatGPT subscription scan freezes

### DIFF
--- a/strix/llm/context_budget.py
+++ b/strix/llm/context_budget.py
@@ -17,7 +17,14 @@ logger = logging.getLogger(__name__)
 
 # LiteLLM keys models without the routing prefix users type (``openai/``,
 # ``litellm/``, ``ollama/`` ...). Strip a leading provider segment on lookup.
-_STRIPPABLE_PREFIXES = ("openai/", "litellm/", "any-llm/", "ollama/", "ollama_chat/")
+_STRIPPABLE_PREFIXES = (
+    "openai/",
+    "chatgpt/",
+    "litellm/",
+    "any-llm/",
+    "ollama/",
+    "ollama_chat/",
+)
 
 _DEFAULT_OUTPUT_TOKENS = 8_192
 
@@ -38,7 +45,11 @@ def _safe_get_model_info(model: str) -> dict[str, Any] | None:
 
 @lru_cache(maxsize=128)
 def _model_info(model: str) -> dict[str, int]:
-    for candidate in (model, _lookup_key(model)):
+    lookup_key = _lookup_key(model)
+    # Provider-qualified ChatGPT lookups may start a synchronous device-login
+    # poll. LiteLLM keys the metadata by the underlying model slug.
+    candidates = (lookup_key,) if model.startswith("chatgpt/") else (model, lookup_key)
+    for candidate in candidates:
         info = _safe_get_model_info(candidate)
         if info is not None:
             return {

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -21,6 +21,24 @@ def test_context_window_strips_provider_prefix() -> None:
     assert context_budget.context_window("openai/gpt-4o") == 128_000
 
 
+def test_context_window_chatgpt_prefix_skips_provider_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context_budget._model_info.cache_clear()
+    calls: list[str] = []
+
+    def _model_info(model: str) -> dict[str, int]:
+        calls.append(model)
+        return {"max_input_tokens": 1_050_000, "max_output_tokens": 128_000}
+
+    monkeypatch.setattr("strix.llm.context_budget.litellm.get_model_info", _model_info)
+    try:
+        assert context_budget.context_window("chatgpt/gpt-5.6-luna") == 1_050_000
+        assert calls == ["gpt-5.6-luna"]
+    finally:
+        context_budget._model_info.cache_clear()
+
+
 def test_context_window_unmapped_uses_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     context_budget._model_info.cache_clear()
 


### PR DESCRIPTION
## Root cause

ChatGPT subscription scans can freeze during context sizing. `context_window("chatgpt/...")` passes the provider-qualified name to LiteLLM, which treats the metadata lookup as an authentication path and may start a synchronous device-code poll on Strix's scan loop.

A thread dump from a stalled run showed the scan loop inside LiteLLM's authorization poll, reached from `context_window()`.

## Change

Strip the `chatgpt/` prefix before asking LiteLLM for model metadata. The lookup then uses the underlying model slug and never enters provider authentication.

## Checks

- `uv run pytest tests/test_context_budget.py tests/test_compaction.py` (21 passed)
- `uv run ruff check strix/llm/context_budget.py tests/test_context_budget.py`
- `uv run ruff format --check strix/llm/context_budget.py tests/test_context_budget.py`
- `uv run mypy strix/llm/context_budget.py`
