### PR TITLE
Create credential files with owner-only permissions

### DIFF
--- a/strix/config/codex.py
+++ b/strix/config/codex.py
@@ -21,6 +21,7 @@ import time
 import urllib.parse
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from strix.utils.secret_files import write_secret_text
 
 import requests
 
@@ -67,14 +68,7 @@ def _read_store() -> dict[str, Any]:
 
 
 def _write_store(data: dict[str, Any]) -> None:
-    AUTH_PATH.parent.mkdir(parents=True, exist_ok=True)
-    tmp = AUTH_PATH.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    with contextlib.suppress(OSError):
-        tmp.chmod(0o600)
-    tmp.replace(AUTH_PATH)
-    with contextlib.suppress(OSError):
-        AUTH_PATH.chmod(0o600)
+    write_secret_text(AUTH_PATH, json.dumps(data, indent=2))
 
 
 def read_record() -> dict[str, Any] | None:

--- a/strix/config/codex.py
+++ b/strix/config/codex.py
@@ -21,9 +21,10 @@ import time
 import urllib.parse
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from strix.utils.secret_files import write_secret_text
 
 import requests
+
+from strix.utils.secret_files import write_secret_text
 
 
 if TYPE_CHECKING:

--- a/strix/config/loader.py
+++ b/strix/config/loader.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
 import os
@@ -12,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import AliasChoices, BaseModel
 
 from strix.config.settings import Settings
+from strix.utils.secret_files import write_secret_text
 
 
 if TYPE_CHECKING:
@@ -71,9 +71,7 @@ def persist_current() -> None:
                     env_block[alias.upper()] = value
                     break
 
-    target.write_text(json.dumps({"env": env_block}, indent=2), encoding="utf-8")
-    with contextlib.suppress(OSError):
-        target.chmod(0o600)
+    write_secret_text(target, json.dumps({"env": env_block}, indent=2))
 
 
 def _aliases_for(finfo: FieldInfo) -> list[str]:

--- a/strix/interface/viewer/auth.py
+++ b/strix/interface/viewer/auth.py
@@ -22,6 +22,7 @@ from typing import Any
 import requests
 
 from strix.config.loader import load_settings
+from strix.utils.secret_files import write_secret_text
 
 
 logger = logging.getLogger(__name__)
@@ -115,15 +116,8 @@ def is_verified() -> bool:
 
 def write_auth(email: str, token: str, verified_at: str) -> None:
     """Atomically persist the auth record with 0600 permissions."""
-    AUTH_PATH.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps({"email": email, "token": token, "verified_at": verified_at})
-    tmp = AUTH_PATH.with_suffix(".json.tmp")
-    tmp.write_text(payload, encoding="utf-8")
-    with contextlib.suppress(OSError):
-        tmp.chmod(0o600)
-    tmp.replace(AUTH_PATH)
-    with contextlib.suppress(OSError):
-        AUTH_PATH.chmod(0o600)
+    write_secret_text(AUTH_PATH, payload)
 
 
 def forget() -> None:

--- a/strix/utils/secret_files.py
+++ b/strix/utils/secret_files.py
@@ -1,5 +1,3 @@
-"""Helpers for writing files that hold secrets."""
-
 from __future__ import annotations
 
 import contextlib
@@ -15,16 +13,9 @@ SECRET_FILE_MODE = 0o600
 
 
 def write_secret_text(path: Path, text: str) -> None:
-    """Atomically write *text* to *path*, readable only by the owner.
-
-    The mode is applied at creation rather than by a later ``chmod``, which
-    would leave the contents world-readable in between.
-    """
     path.parent.mkdir(parents=True, exist_ok=True)
 
     tmp = path.with_suffix(path.suffix + ".tmp")
-    # O_CREAT does not apply the mode to an existing file, so a temporary left
-    # by an interrupted write must be replaced rather than truncated.
     with contextlib.suppress(FileNotFoundError):
         tmp.unlink()
 

--- a/strix/utils/secret_files.py
+++ b/strix/utils/secret_files.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import contextlib
 import os
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 SECRET_FILE_MODE = 0o600

--- a/strix/utils/secret_files.py
+++ b/strix/utils/secret_files.py
@@ -1,0 +1,39 @@
+"""Helpers for writing files that hold secrets."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from pathlib import Path
+
+
+SECRET_FILE_MODE = 0o600
+SECRET_DIR_MODE = 0o700
+
+
+def write_secret_text(path: Path, text: str) -> None:
+    """Atomically write *text* to *path*, readable only by the owner.
+
+    The mode is applied at creation rather than by a later ``chmod``, which
+    would leave the contents world-readable in between.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError):
+        path.parent.chmod(SECRET_DIR_MODE)
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    # O_CREAT does not apply the mode to an existing file, so a temporary left
+    # by an interrupted write must be replaced rather than truncated.
+    with contextlib.suppress(FileNotFoundError):
+        tmp.unlink()
+
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, SECRET_FILE_MODE)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+        raise
+
+    tmp.replace(path)

--- a/strix/utils/secret_files.py
+++ b/strix/utils/secret_files.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
 
 
 SECRET_FILE_MODE = 0o600
-SECRET_DIR_MODE = 0o700
 
 
 def write_secret_text(path: Path, text: str) -> None:
@@ -22,8 +21,6 @@ def write_secret_text(path: Path, text: str) -> None:
     would leave the contents world-readable in between.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    with contextlib.suppress(OSError):
-        path.parent.chmod(SECRET_DIR_MODE)
 
     tmp = path.with_suffix(path.suffix + ".tmp")
     # O_CREAT does not apply the mode to an existing file, so a temporary left

--- a/tests/test_secret_files.py
+++ b/tests/test_secret_files.py
@@ -1,5 +1,3 @@
-"""Secret files must never exist on disk under a permissive mode."""
-
 from __future__ import annotations
 
 import json
@@ -17,7 +15,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-# Windows does not model POSIX permission bits.
 posix_only = pytest.mark.skipif(
     sys.platform == "win32", reason="POSIX permission bits are not modelled on Windows"
 )
@@ -39,7 +36,6 @@ def test_file_is_owner_only(tmp_path: Path) -> None:
 
 @posix_only
 def test_a_permissive_umask_cannot_widen_the_file(tmp_path: Path) -> None:
-    """Under umask 0 the old code produced a 0666 file."""
     previous = os.umask(0)
     try:
         target = tmp_path / "auth.json"
@@ -51,7 +47,6 @@ def test_a_permissive_umask_cannot_widen_the_file(tmp_path: Path) -> None:
 
 @posix_only
 def test_a_stale_temporary_does_not_leak_its_mode(tmp_path: Path) -> None:
-    """O_CREAT does not apply a mode to a file that already exists."""
     target = tmp_path / "auth.json"
     stale = target.with_suffix(target.suffix + ".tmp")
     stale.write_text("leftover", encoding="utf-8")

--- a/tests/test_secret_files.py
+++ b/tests/test_secret_files.py
@@ -6,11 +6,15 @@ import json
 import os
 import stat
 import sys
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from strix.utils.secret_files import SECRET_DIR_MODE, SECRET_FILE_MODE, write_secret_text
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 # Windows does not model POSIX permission bits.
@@ -23,7 +27,7 @@ def test_content_round_trips(tmp_path: Path) -> None:
     target = tmp_path / "nested" / "auth.json"
     payload = json.dumps({"token": "s3cret", "refresh": "r3fresh"})
     write_secret_text(target, payload)
-    assert json.loads(target.read_text(encoding="utf-8"))["token"] == "s3cret"
+    assert json.loads(target.read_text(encoding="utf-8"))["token"] == "s3cret"  # noqa: S105
 
 
 @posix_only

--- a/tests/test_secret_files.py
+++ b/tests/test_secret_files.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from strix.utils.secret_files import SECRET_DIR_MODE, SECRET_FILE_MODE, write_secret_text
+from strix.utils.secret_files import SECRET_FILE_MODE, write_secret_text
 
 
 if TYPE_CHECKING:
@@ -35,13 +35,6 @@ def test_file_is_owner_only(tmp_path: Path) -> None:
     target = tmp_path / "auth.json"
     write_secret_text(target, "{}")
     assert stat.S_IMODE(target.stat().st_mode) == SECRET_FILE_MODE
-
-
-@posix_only
-def test_directory_is_owner_only(tmp_path: Path) -> None:
-    target = tmp_path / "created" / "auth.json"
-    write_secret_text(target, "{}")
-    assert stat.S_IMODE(target.parent.stat().st_mode) == SECRET_DIR_MODE
 
 
 @posix_only

--- a/tests/test_secret_files.py
+++ b/tests/test_secret_files.py
@@ -1,0 +1,73 @@
+"""Secret files must never exist on disk under a permissive mode."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from strix.utils.secret_files import SECRET_DIR_MODE, SECRET_FILE_MODE, write_secret_text
+
+
+# Windows does not model POSIX permission bits.
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX permission bits are not modelled on Windows"
+)
+
+
+def test_content_round_trips(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "auth.json"
+    payload = json.dumps({"token": "s3cret", "refresh": "r3fresh"})
+    write_secret_text(target, payload)
+    assert json.loads(target.read_text(encoding="utf-8"))["token"] == "s3cret"
+
+
+@posix_only
+def test_file_is_owner_only(tmp_path: Path) -> None:
+    target = tmp_path / "auth.json"
+    write_secret_text(target, "{}")
+    assert stat.S_IMODE(target.stat().st_mode) == SECRET_FILE_MODE
+
+
+@posix_only
+def test_directory_is_owner_only(tmp_path: Path) -> None:
+    target = tmp_path / "created" / "auth.json"
+    write_secret_text(target, "{}")
+    assert stat.S_IMODE(target.parent.stat().st_mode) == SECRET_DIR_MODE
+
+
+@posix_only
+def test_a_permissive_umask_cannot_widen_the_file(tmp_path: Path) -> None:
+    """Under umask 0 the old code produced a 0666 file."""
+    previous = os.umask(0)
+    try:
+        target = tmp_path / "auth.json"
+        write_secret_text(target, "{}")
+        assert stat.S_IMODE(target.stat().st_mode) == SECRET_FILE_MODE
+    finally:
+        os.umask(previous)
+
+
+@posix_only
+def test_a_stale_temporary_does_not_leak_its_mode(tmp_path: Path) -> None:
+    """O_CREAT does not apply a mode to a file that already exists."""
+    target = tmp_path / "auth.json"
+    stale = target.with_suffix(target.suffix + ".tmp")
+    stale.write_text("leftover", encoding="utf-8")
+    stale.chmod(0o666)
+
+    write_secret_text(target, "{}")
+    assert stat.S_IMODE(target.stat().st_mode) == SECRET_FILE_MODE
+
+
+def test_overwriting_an_existing_record_keeps_it_restricted(tmp_path: Path) -> None:
+    target = tmp_path / "auth.json"
+    write_secret_text(target, json.dumps({"v": 1}))
+    write_secret_text(target, json.dumps({"v": 2}))
+    assert json.loads(target.read_text(encoding="utf-8"))["v"] == 2
+    if sys.platform != "win32":
+        assert stat.S_IMODE(target.stat().st_mode) == SECRET_FILE_MODE


### PR DESCRIPTION
Credential files were written with `write_text` and then chmod'd to 0600:

```python
tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
with contextlib.suppress(OSError):
    tmp.chmod(0o600)
```

Two problems. The file exists with the default umask (usually 0644) between the write and the chmod, so the token is briefly readable by any local user. And the chmod is suppressed, so if it fails the file just stays 0644 with nothing reported.

Adds `strix/utils/secret_files.py` with `write_secret_text`, which opens with `O_CREAT | O_EXCL` and mode 0600 so the file never exists with wider permissions, and uses it for the viewer auth file and the env block.

Tests in `tests/test_secret_files.py`. The permission assertions are POSIX-only and skip on Windows, which is where I ran them — 2 passed, 4 skipped locally.