### PR TITLE
perf(tui): cache terminal-state tool widgets in BaseToolRenderer

### DIFF
--- a/strix/interface/tui/renderers/agents_graph_renderer.py
+++ b/strix/interface/tui/renderers/agents_graph_renderer.py
@@ -13,7 +13,7 @@ class ViewAgentGraphRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "agents-graph-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         status = tool_data.get("status", "unknown")
 
         text = Text()
@@ -30,7 +30,7 @@ class CreateAgentRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "agents-graph-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
         status = tool_data.get("status", "unknown")
 
@@ -56,7 +56,7 @@ class SendMessageToAgentRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "agents-graph-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
         status = tool_data.get("status", "unknown")
 
@@ -84,7 +84,7 @@ class AgentFinishRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "agents-graph-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
 
         result_summary = args.get("result_summary", "")
@@ -122,7 +122,7 @@ class WaitForMessageRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "agents-graph-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
         status = tool_data.get("status", "unknown")
 
@@ -146,7 +146,7 @@ class StopAgentRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "agents-graph-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
         result = tool_data.get("result")
         status = tool_data.get("status", "unknown")

--- a/strix/interface/tui/renderers/base_renderer.py
+++ b/strix/interface/tui/renderers/base_renderer.py
@@ -4,13 +4,36 @@ from typing import Any, ClassVar
 from textual.widgets import Static
 
 
+_TERMINAL_STATUSES = ("completed", "failed", "error")
+_CACHE_SIZE_LIMIT = 200
+
+
 class BaseToolRenderer(ABC):
     tool_name: ClassVar[str] = ""
     css_classes: ClassVar[list[str]] = ["tool-call"]
+    _cache: ClassVar[dict[tuple[str, str, str], Static]] = {}
+
+    @classmethod
+    def render(cls, tool_data: dict[str, Any]) -> Static:
+        status = tool_data.get("status", "")
+        call_id = tool_data.get("call_id")
+        if status not in _TERMINAL_STATUSES or not call_id:
+            return cls._build(tool_data)
+
+        key = (cls.tool_name, str(call_id), status)
+        cached = cls._cache.get(key)
+        if cached is not None:
+            return cached
+
+        widget = cls._build(tool_data)
+        if len(cls._cache) > _CACHE_SIZE_LIMIT:
+            cls._cache.clear()
+        cls._cache[key] = widget
+        return widget
 
     @classmethod
     @abstractmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         pass
 
     @classmethod

--- a/strix/interface/tui/renderers/filesystem_renderer.py
+++ b/strix/interface/tui/renderers/filesystem_renderer.py
@@ -173,7 +173,7 @@ class ApplyPatchRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "file-edit-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
         result = tool_data.get("result")
         status = tool_data.get("status", "completed")
@@ -239,7 +239,7 @@ class ViewImageRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "file-edit-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
         result = tool_data.get("result")
         status = tool_data.get("status", "completed")

--- a/strix/interface/tui/renderers/finish_renderer.py
+++ b/strix/interface/tui/renderers/finish_renderer.py
@@ -16,7 +16,7 @@ class FinishScanRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "finish-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
 
         executive_summary = args.get("executive_summary", "")

--- a/strix/interface/tui/renderers/load_skill_renderer.py
+++ b/strix/interface/tui/renderers/load_skill_renderer.py
@@ -13,7 +13,7 @@ class LoadSkillRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "load-skill-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
         status = tool_data.get("status", "completed")
 

--- a/strix/interface/tui/renderers/notes_renderer.py
+++ b/strix/interface/tui/renderers/notes_renderer.py
@@ -20,7 +20,7 @@ class CreateNoteRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "notes-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
 
         title = args.get("title", "")
@@ -55,7 +55,7 @@ class DeleteNoteRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "notes-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:  # noqa: ARG003
+    def _build(cls, tool_data: dict[str, Any]) -> Static:  # noqa: ARG003
         text = Text()
         text.append("◇ ", style="#fbbf24")
         text.append("note removed", style="dim")
@@ -70,7 +70,7 @@ class UpdateNoteRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "notes-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
 
         title = args.get("title")
@@ -102,7 +102,7 @@ class ListNotesRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "notes-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         result = tool_data.get("result")
 
         text = Text()
@@ -151,7 +151,7 @@ class GetNoteRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "notes-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         result = tool_data.get("result")
 
         text = Text()

--- a/strix/interface/tui/renderers/proxy_renderer.py
+++ b/strix/interface/tui/renderers/proxy_renderer.py
@@ -41,7 +41,7 @@ class ListRequestsRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "proxy-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
+    def _build(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
         args = tool_data.get("args", {})
         result = tool_data.get("result")
         status = tool_data.get("status", "running")
@@ -118,7 +118,7 @@ class ViewRequestRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "proxy-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
+    def _build(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
         args = tool_data.get("args", {})
         result = tool_data.get("result")
         status = tool_data.get("status", "running")
@@ -205,7 +205,7 @@ class RepeatRequestRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "proxy-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
+    def _build(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
         args = tool_data.get("args", {})
         result = tool_data.get("result")
         status = tool_data.get("status", "running")
@@ -303,7 +303,7 @@ class ListSitemapRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "proxy-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
+    def _build(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
         args = tool_data.get("args", {})
         result = tool_data.get("result")
         status = tool_data.get("status", "running")
@@ -387,7 +387,7 @@ class ViewSitemapEntryRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "proxy-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912
+    def _build(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912
         args = tool_data.get("args", {})
         result = tool_data.get("result")
         status = tool_data.get("status", "running")
@@ -452,7 +452,7 @@ class ScopeRulesRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "proxy-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
+    def _build(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
         args = tool_data.get("args", {})
         result = tool_data.get("result")
         status = tool_data.get("status", "running")

--- a/strix/interface/tui/renderers/reporting_renderer.py
+++ b/strix/interface/tui/renderers/reporting_renderer.py
@@ -87,7 +87,7 @@ class CreateVulnerabilityReportRenderer(BaseToolRenderer):
         return "#6b7280"
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
+    def _build(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
         args = tool_data.get("args", {})
         result = tool_data.get("result", {})
 
@@ -319,7 +319,7 @@ class CreateDependencyReportRenderer(BaseToolRenderer):
         return Static(padded, classes=cls.get_css_classes("failed"))
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
+    def _build(cls, tool_data: dict[str, Any]) -> Static:  # noqa: PLR0912, PLR0915
         args = tool_data.get("args", {})
         result = tool_data.get("result", {})
 
@@ -460,7 +460,7 @@ class ListReportsRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "reporting-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         result = _coerce_dict(tool_data.get("result"))
 
         text = Text()
@@ -512,7 +512,7 @@ class GetReportRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "reporting-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         result = _coerce_dict(tool_data.get("result"))
 
         text = Text()

--- a/strix/interface/tui/renderers/shell_renderer.py
+++ b/strix/interface/tui/renderers/shell_renderer.py
@@ -207,7 +207,7 @@ class ExecCommandRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "terminal-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
         status = tool_data.get("status", "unknown")
         result = tool_data.get("result")
@@ -243,7 +243,7 @@ class WriteStdinRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "terminal-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
         status = tool_data.get("status", "unknown")
         result = tool_data.get("result")

--- a/strix/interface/tui/renderers/thinking_renderer.py
+++ b/strix/interface/tui/renderers/thinking_renderer.py
@@ -13,7 +13,7 @@ class ThinkRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "thinking-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
         thought = args.get("thought", "")
 

--- a/strix/interface/tui/renderers/todo_renderer.py
+++ b/strix/interface/tui/renderers/todo_renderer.py
@@ -45,7 +45,7 @@ class CreateTodoRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "todo-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         result = tool_data.get("result")
 
         text = Text()
@@ -76,7 +76,7 @@ class ListTodosRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "todo-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         result = tool_data.get("result")
 
         text = Text()
@@ -107,7 +107,7 @@ class UpdateTodoRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "todo-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         result = tool_data.get("result")
 
         text = Text()
@@ -138,7 +138,7 @@ class MarkTodoDoneRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "todo-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         result = tool_data.get("result")
 
         text = Text()
@@ -169,7 +169,7 @@ class MarkTodoPendingRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "todo-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         result = tool_data.get("result")
 
         text = Text()
@@ -200,7 +200,7 @@ class DeleteTodoRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "todo-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         result = tool_data.get("result")
 
         text = Text()

--- a/strix/interface/tui/renderers/web_search_renderer.py
+++ b/strix/interface/tui/renderers/web_search_renderer.py
@@ -13,7 +13,7 @@ class WebSearchRenderer(BaseToolRenderer):
     css_classes: ClassVar[list[str]] = ["tool-call", "web-search-tool"]
 
     @classmethod
-    def render(cls, tool_data: dict[str, Any]) -> Static:
+    def _build(cls, tool_data: dict[str, Any]) -> Static:
         args = tool_data.get("args", {})
         query = args.get("query", "")
 


### PR DESCRIPTION
## Summary

`render_tool_widget()` re-renders every tool event from scratch on every UI
tick via whichever `BaseToolRenderer` subclass is registered for that tool,
including completed/failed/error events whose content will never change
again.

- `BaseToolRenderer.render()` becomes a concrete template method that caches
  the rendered widget by `(tool_name, call_id, status)` for terminal statuses
  (`completed`/`failed`/`error`) only, capped at 200 entries.
- Actual widget construction moves to a new abstract `_build()` that every
  subclass implements instead (mechanical rename, no behavior change in any
  individual renderer).
- Non-terminal (e.g. `"running"`) tool events always re-render live since
  their content can keep streaming/updating.

## Details

`dd29d99` already added a shared class-level cache to `AgentMessageRenderer`
for chat markdown rendering (Pygments/markdown parsing), but that only
covers the chat-message path, not tool-widget rendering, which fans out
across ~12 renderer files with no shared choke point. This mirrors the same
caching pattern for that path.

Split out from #494 (`fix/tui-cpu-lockup-clean`) since it's an independent,
orthogonal improvement to the waiting-state CPU fix there.

(Previously opened as #948 and closed — that revision carried a leftover
duplicate render cache in app.py from a branching mistake, now fixed.)

## Test plan

- [x] Full test suite passes (`pytest tests/`), matching `main`'s baseline
- [x] `ruff check` and `mypy` clean on all touched files
- [ ] Manually confirm completed tool widgets (shell, filesystem, proxy, etc.) still render correctly and aren't stale after a status change