### PR TITLE
fix(llm): omit parallel_tool_calls on tool-less calls (Azure OpenAI 400)

### DIFF
--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -133,9 +133,18 @@ def make_model_settings(
     request_timeout: float | None = None,
     prompt_cache: bool = True,
     extra_headers: dict[str, str] | None = None,
+    with_tools: bool = True,
 ) -> ModelSettings:
+    """Build the per-request ``ModelSettings`` for one model call.
+
+    ``with_tools`` must be False for the tool-less calls (warm-up, compaction,
+    dedupe). ``parallel_tool_calls`` is only meaningful alongside a tool list,
+    and Azure OpenAI rejects the request outright when it is sent without one —
+    the native OpenAI route silently tolerates it, so the difference only shows
+    up on Azure deployments.
+    """
     model_settings = ModelSettings(
-        parallel_tool_calls=False,
+        parallel_tool_calls=False if with_tools else None,
         retry=DEFAULT_MODEL_RETRY,
         include_usage=True,
         extra_args=request_timeout_extra_args(request_timeout),

--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -388,6 +388,7 @@ async def warm_up_llm(show_model_warning: bool = True) -> None:
                     request_timeout=llm.timeout,
                     prompt_cache=False,
                     extra_headers=llm.extra_headers,
+                    with_tools=False,
                 ),
                 tools=[],
                 output_schema=None,
@@ -419,6 +420,7 @@ async def warm_up_llm(show_model_warning: bool = True) -> None:
                 request_timeout=llm.timeout,
                 prompt_cache=False,
                 extra_headers=settings.dedupe.extra_headers,
+                with_tools=False,
             )
             if deduper_extra:
                 merged = {**(deduper_settings.extra_args or {}), **deduper_extra}

--- a/strix/llm/compaction.py
+++ b/strix/llm/compaction.py
@@ -294,6 +294,7 @@ async def _summarize(model: str, prompt: str, max_tokens: int) -> str | None:
         request_timeout=llm.timeout,
         prompt_cache=False,
         extra_headers=llm.extra_headers,
+        with_tools=False,
     ).resolve(ModelSettings(max_tokens=max_tokens))
     try:
         response = (

--- a/strix/report/dedupe.py
+++ b/strix/report/dedupe.py
@@ -62,6 +62,7 @@ def _dedupe_model_settings(
         # must never receive the main endpoint's credentials. A dedicated model
         # gets its own DEDUPE_LLM_EXTRA_HEADERS instead.
         extra_headers=dedupe.extra_headers if dedupe.model else llm.extra_headers,
+        with_tools=False,
     )
     extra = _dedupe_extra_args(dedupe)
     if extra:

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -307,3 +307,20 @@ def test_make_model_settings_timeout_survives_reasoning_resolve() -> None:
 
     assert settings.extra_args is not None
     assert settings.extra_args["timeout"] == 120.0
+
+
+def test_make_model_settings_sets_parallel_tool_calls_when_tools_are_sent() -> None:
+    settings = make_model_settings(None, model_name="openai/gpt-5.4")
+
+    assert settings.parallel_tool_calls is False
+
+
+def test_make_model_settings_omits_parallel_tool_calls_without_tools() -> None:
+    """Azure OpenAI 400s on ``parallel_tool_calls`` sent without a tool list.
+
+    The tool-less calls (warm-up, compaction, dedupe) must leave it unset so the
+    field is dropped from the request rather than sent as ``false``.
+    """
+    settings = make_model_settings(None, model_name="azure/gpt-5.4", with_tools=False)
+
+    assert settings.parallel_tool_calls is None


### PR DESCRIPTION
## Problem

`make_model_settings` sets `parallel_tool_calls=False` unconditionally, but the parameter is only valid alongside a tool list. Azure OpenAI rejects it outright:

```
BadRequestError - Invalid value for 'parallel_tool_calls':
'parallel_tool_calls' is only allowed when 'tools' are specified.
```

The native OpenAI route silently tolerates it, so the divergence only surfaces on Azure deployments — where it currently makes Strix unusable end to end. `warm_up_llm` fails before any scan starts, so `strix --target ...` exits 1 with `LLM CONNECTION FAILED`.

## Scope

Four call paths send no tools, and all four break on Azure:

| Call site | When | Impact |
|---|---|---|
| `warm_up_llm`, main model | startup | blocks the scan (`sys.exit(1)`) |
| `warm_up_llm`, dedupe model | startup | blocks the scan |
| `compaction._summarize` | context overflow, mid-scan | summarization fails |
| `dedupe._dedupe_model_settings` | per vulnerability report | dedupe fails |

Only the agent loop in `core/runner.py` carries tools and is unaffected — so fixing the warm-up alone would still leave a scan that dies the first time context fills or a finding is recorded.

## Change

Add an explicit `with_tools` keyword to `make_model_settings`, defaulting to the current behaviour, and set it `False` at the four tool-less call sites. `ModelSettings` drops `None` fields, so the parameter is simply not sent rather than sent as `false`.

No behaviour change on any existing route: every tool-carrying call keeps `parallel_tool_calls=False`.

## Verification

Reproduced and confirmed fixed against a live Azure OpenAI deployment (`azure/gpt-5.4`, Entra ID auth):

- **Before:** warm-up 400s, scan never starts.
- **After:** warm-up succeeds, sandbox comes up, root agent registers, scan proceeds.

Two regression tests added in `tests/test_inputs.py` covering both branches.

`ruff check` / `ruff format` / `mypy` clean on all changed files. Full suite: 628 passed, with one pre-existing order-dependent failure in `tests/test_execution.py::test_finish_scan_bypasses_active_agent_guard_after_reserve` that reproduces on `main` without this change (it passes in isolation; `tests/test_cost_tracking.py` leaves an uninitialised `ReportState` in the module-level global).