### PR TITLE
fix(config): preserve file-backed settings during persistence

### DIFF
--- a/strix/config/loader.py
+++ b/strix/config/loader.py
@@ -54,22 +54,26 @@ def apply_config_override(path: Path) -> None:
 
 
 def persist_current() -> None:
-    """Write currently-set env vars to the active config file (0o600)."""
+    """Write explicitly configured values to the active config file (0o600)."""
     s = load_settings()
     target = _override or _DEFAULT_PATH
     target.parent.mkdir(parents=True, exist_ok=True)
 
-    env_block: dict[str, str] = {}
+    env_block: dict[str, Any] = {}
     for sub_name in s.model_fields:
         sub_model = getattr(s, sub_name)
         if not isinstance(sub_model, BaseModel):
             continue
-        for finfo in type(sub_model).model_fields.values():
-            for alias in _aliases_for(finfo):
+        for field_name, finfo in type(sub_model).model_fields.items():
+            aliases = _aliases_for(finfo)
+            for alias in aliases:
                 value = os.environ.get(alias.upper())
                 if value:
                     env_block[alias.upper()] = value
                     break
+            else:
+                if aliases and field_name in sub_model.model_fields_set:
+                    env_block[aliases[0].upper()] = getattr(sub_model, field_name)
 
     write_secret_text(target, json.dumps({"env": env_block}, indent=2))
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -208,6 +208,36 @@ def test_persist_current_writes_env_block(tmp_path: Path, monkeypatch: pytest.Mo
     }
 
 
+def test_persist_current_preserves_file_backed_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "cli-config.json"
+    target.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "STRIX_LLM": "file-model",
+                    "LLM_API_KEY": "file-key",
+                    "LLM_API_BASE": "https://example.invalid/v1",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.invalid/v1")
+    loader.apply_config_override(target)
+
+    loader.persist_current()
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {
+        "env": {
+            "STRIX_LLM": "file-model",
+            "LLM_API_KEY": "file-key",
+            "OPENAI_BASE_URL": "https://example.invalid/v1",
+        }
+    }
+
+
 def test_persist_current_sets_0600_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("STRIX_LLM", "persisted-model")
     target = tmp_path / "cli-config.json"


### PR DESCRIPTION
## Summary

Fix configuration persistence so settings loaded from `cli-config.json` are not discarded when Strix saves its active configuration.

The change:

- Preserves explicitly configured file-backed values.
- Maintains environment-variable precedence.
- Writes only one effective alias for each setting, preventing stale alias conflicts.
- Avoids persisting unconfigured Pydantic defaults.
- Adds regression coverage for the `OPENAI_BASE_URL` overwrite scenario.

## Problem

`persist_current()` previously rebuilt the configuration exclusively from `os.environ`. Settings loaded from JSON existed in the Pydantic model but not necessarily in the process environment.

Because Strix exports the resolved API base as `OPENAI_BASE_URL`, a populated config could consequently be reduced to:

```json
{
  "env": {
    "OPENAI_BASE_URL": "https://proxy.example"
  }
}
```

## Result

Given:

```json
{
  "env": {
    "STRIX_LLM": "openai/example",
    "LLM_API_KEY": "sk-example",
    "LLM_API_BASE": "https://proxy.example"
  }
}
```

Strix now preserves all effective settings:

```json
{
  "env": {
    "STRIX_LLM": "openai/example",
    "LLM_API_KEY": "sk-example",
    "OPENAI_BASE_URL": "https://proxy.example"
  }
}
```