### PR TITLE
fix(sessions): open a sqlite connection per operation, not per thread

### DIFF
--- a/strix/core/sessions.py
+++ b/strix/core/sessions.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sqlite3
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, cast
 from weakref import WeakKeyDictionary
 
@@ -12,7 +14,7 @@ from agents.memory import SQLiteSession
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
     from pathlib import Path
 
     from agents.items import TResponseInputItem
@@ -22,9 +24,25 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _PooledConnectionSession(SQLiteSession):
+    @contextmanager
+    def _locked_connection(self) -> Iterator[sqlite3.Connection]:
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("SQLiteSession is closed")
+            if self._is_memory_db:
+                yield self._shared_connection
+                return
+            connection = sqlite3.connect(str(self.db_path), check_same_thread=False)
+            try:
+                yield connection
+            finally:
+                connection.close()
+
+
 def open_agent_session(agent_id: str, path: Path) -> SQLiteSession:
     path.parent.mkdir(parents=True, exist_ok=True)
-    return SQLiteSession(session_id=agent_id, db_path=path)
+    return _PooledConnectionSession(session_id=agent_id, db_path=path)
 
 
 async def seed_initial_input(session: Session, initial_input: Any) -> bool:

--- a/tests/test_session_fd.py
+++ b/tests/test_session_fd.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from strix.core.sessions import open_agent_session
+
+
+def _count_open_fds() -> int | None:
+    for path in (Path("/proc/self/fd"), Path("/dev/fd")):
+        if path.is_dir():
+            return len(list(path.iterdir()))
+    return None
+
+
+@pytest.mark.asyncio
+async def test_sessions_hold_no_descriptors_while_parked(tmp_path: Path) -> None:
+    """Descriptor use must track live operations, not the number of sessions.
+
+    The SDK keeps a connection per (session, pool thread) open for the session's
+    whole life. An agent parks rather than exits, so its session lives for the
+    scan, and fan-out multiplies those handles until the process runs out of file
+    descriptors (#1018). A session that is not mid-operation should hold none.
+    """
+    baseline = _count_open_fds()
+    if baseline is None:
+        pytest.skip("no /proc/self/fd or /dev/fd on this platform")
+
+    sessions = [open_agent_session(f"a{i}", tmp_path / f"s{i}.db") for i in range(60)]
+    try:
+        for _ in range(4):
+            await asyncio.gather(
+                *(s.add_items([{"role": "user", "content": "x"}]) for s in sessions)
+            )
+            await asyncio.gather(*(s.get_items() for s in sessions))
+        parked = _count_open_fds()
+        assert parked is not None
+        # 60 parked sessions, yet descriptors are back at the baseline.
+        assert parked - baseline <= 5, f"parked fds grew by {parked - baseline}"
+    finally:
+        for s in sessions:
+            s.close()
+
+
+@pytest.mark.asyncio
+async def test_in_flight_descriptors_track_concurrency_not_session_count(
+    tmp_path: Path,
+) -> None:
+    baseline = _count_open_fds()
+    if baseline is None:
+        pytest.skip("no /proc/self/fd or /dev/fd on this platform")
+
+    sessions = [open_agent_session(f"a{i}", tmp_path / f"s{i}.db") for i in range(200)]
+    peak = baseline
+    try:
+
+        async def sample() -> None:
+            nonlocal peak
+            for _ in range(500):
+                current = _count_open_fds()
+                if current is not None:
+                    peak = max(peak, current)
+                await asyncio.sleep(0)
+
+        async def load() -> None:
+            for _ in range(4):
+                await asyncio.gather(
+                    *(s.add_items([{"role": "user", "content": "x"}]) for s in sessions)
+                )
+
+        await asyncio.gather(load(), sample())
+        # 200 sessions, but peak is bounded by the thread pool, well under 200.
+        assert peak - baseline < 100, f"in-flight fds peaked at +{peak - baseline}"
+    finally:
+        for s in sessions:
+            s.close()
+
+
+@pytest.mark.asyncio
+async def test_history_survives_the_per_operation_connection(tmp_path: Path) -> None:
+    session = open_agent_session("agent-1", tmp_path / "agents.db")
+    try:
+        for i in range(30):
+            await session.add_items([{"role": "user", "content": f"m{i}"}])
+        items = [cast("dict[str, Any]", i) for i in await session.get_items()]
+        assert [i["content"] for i in items] == [f"m{i}" for i in range(30)]
+    finally:
+        session.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sessions_sharing_one_file_stay_consistent(tmp_path: Path) -> None:
+    db = tmp_path / "shared.db"
+    sessions = [open_agent_session(f"a{i}", db) for i in range(10)]
+    try:
+        await asyncio.gather(
+            *(s.add_items([{"role": "user", "content": s.session_id}]) for s in sessions)
+        )
+        # Each session sees only its own row despite sharing the file.
+        for s in sessions:
+            items = [cast("dict[str, Any]", i) for i in await s.get_items()]
+            assert [i["content"] for i in items] == [s.session_id]
+    finally:
+        for s in sessions:
+            s.close()
+
+
+@pytest.mark.asyncio
+async def test_a_closed_session_refuses_operations(tmp_path: Path) -> None:
+    session = open_agent_session("agent-1", tmp_path / "agents.db")
+    await session.add_items([{"role": "user", "content": "x"}])
+    session.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        await session.add_items([{"role": "user", "content": "y"}])


### PR DESCRIPTION
Closes #1018.

## The failure

A scan that fans out to many agents (the report: 36 agents, ~30 concurrent) exhausts the process file-descriptor limit. SQLite reports `unable to open database file` first, then every atomic write to `agents.json` / `vulnerabilities.csv` and every Docker exec fails with `OSError: [Errno 24] Too many open files`. 30 of 36 agents crash and the scan is lost.

## Root cause

The SDK's `SQLiteSession` opens connections **per thread** (`threading.local()`) and keeps each one until the session is closed. Two facts turn that into unbounded growth:

- Every session operation runs on asyncio's default thread pool, which grows to `min(32, cpu+4)` threads, so one session opens a connection per pool thread it ever runs on.
- An agent **parks** rather than exits — it can be resumed — so its session stays open for the whole scan. Sessions are closed only at scan teardown.

So open connections grow as `live_sessions × pool_threads`, and WAL adds a `-wal` and `-shm` fd to each. Dozens of parked agents against the pool cross the 1024 default `RLIMIT_NOFILE`.

## The fix

A `SQLiteSession` subclass opens the connection for the duration of **one operation** and closes it after. Descriptor use then tracks how many operations run at once — the size of the thread pool — not how many sessions exist, and a parked session holds **none**. It is safe because the base class already serializes every operation behind the session lock, and the connection never outlives its operation, so it is never shared across threads. There is no cap — a scan can fan out to any number of agents.

## Measured, before vs after

Real open file descriptors (`/dev/fd`), driving concurrent load:

| | 25 sessions | 200 sessions | crash at fd limit 256 |
| --- | --- | --- | --- |
| SDK base (per-thread) | +547 fds | — | dies at 40 (`unable to open database file`, the reported symptom) |
| shared per-session | +75 fds | — | dies at 120 |
| **this fix (per-op)** | **+0 parked / peak 53** | **+0 parked / peak 53** | **survives 1000** |

The peak tracks the thread pool, not the session count; parked sessions return to baseline. (A *sequential* workload hides the leak entirely — the ops land on one pool thread — which is why it only surfaced under real fan-out.)

## Tests

`tests/test_session_fd.py`, new:

- parked sessions hold no descriptors (60 sessions, fds back at baseline)
- in-flight descriptors track concurrency, not session count (200 sessions, bounded peak)
- history survives the per-operation connection
- concurrent sessions sharing one file stay consistent
- a closed session refuses operations

872 tests pass. ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
