### PR TITLE
fix(runner): resume after a user interrupt instead of failing

### DIFF
--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import io
 import json
@@ -446,6 +447,13 @@ async def run_strix_scan(
             with contextlib.suppress(Exception):
                 await coordinator.set_status(root_id, "stopped")
         return None
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        logger.info("Scan %s interrupted by the user", scan_id)
+        if root_id is not None:
+            await coordinator.cancel_descendants(root_id)
+            with contextlib.suppress(Exception):
+                await coordinator.set_status(root_id, "running")
+        raise
     except BaseException:
         logger.exception("Strix scan %s failed", scan_id)
         if root_id is not None:

--- a/tests/test_runner_interrupt.py
+++ b/tests/test_runner_interrupt.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+import types
+from typing import Any
+
+import pytest
+from agents import ModelSettings
+
+import strix.tools.notes.tools as notes_tools
+import strix.tools.todo.tools as todo_tools
+from strix.core import runner
+from strix.core.agents import AgentCoordinator
+from strix.runtime import session_manager
+
+
+def _wire_runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    monkeypatch.setattr(runner, "run_dir_for", lambda _scan_id: tmp_path)
+    monkeypatch.setattr(runner, "runtime_state_dir", lambda _run_dir: tmp_path)
+    monkeypatch.setattr(runner, "setup_scan_logging", lambda _run_dir: lambda: None)
+    monkeypatch.setattr(runner, "set_scan_id", lambda _scan_id: None)
+
+    settings = types.SimpleNamespace(
+        llm=types.SimpleNamespace(
+            model="openai/gpt-4o",
+            reasoning_effort="high",
+            force_required_tool_choice=False,
+            timeout=300,
+            prompt_cache=True,
+            extra_headers=None,
+        ),
+        runtime=types.SimpleNamespace(max_context_images=3),
+    )
+    monkeypatch.setattr(runner, "load_settings", lambda: settings)
+    monkeypatch.setattr(runner, "configure_sdk_model_defaults", lambda _settings: None)
+    monkeypatch.setattr(
+        runner, "uses_chat_completions_tool_schema", lambda _model, _settings: False
+    )
+    monkeypatch.setattr(todo_tools, "hydrate_todos_from_disk", lambda _state_dir: None)
+    monkeypatch.setattr(notes_tools, "hydrate_notes_from_disk", lambda _state_dir: None)
+
+    async def _create_or_reuse(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"client": object(), "session": object(), "caido_client": None}
+
+    async def _cleanup(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(session_manager, "create_or_reuse", _create_or_reuse)
+    monkeypatch.setattr(session_manager, "cleanup", _cleanup)
+    monkeypatch.setattr(runner, "build_root_task", lambda _scan_config: "task")
+    monkeypatch.setattr(runner, "build_scope_context", lambda _scan_config: "")
+    monkeypatch.setattr(runner, "make_model_settings", lambda *_a, **_k: ModelSettings())
+    monkeypatch.setattr(runner, "build_strix_agent", lambda **_kwargs: object())
+    monkeypatch.setattr(runner, "make_child_factory", lambda **_kwargs: lambda **_k: object())
+    monkeypatch.setattr(runner, "open_agent_session", lambda _root_id, _db: object())
+
+
+def _root_status(coordinator: AgentCoordinator) -> str:
+    roots = [aid for aid, parent in coordinator.parent_of.items() if parent is None]
+    assert len(roots) == 1
+    return coordinator.statuses[roots[0]]
+
+
+@pytest.mark.parametrize("interrupt", [KeyboardInterrupt, asyncio.CancelledError])
+@pytest.mark.asyncio
+async def test_user_interrupt_leaves_the_root_running_for_resume(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any, interrupt: type[BaseException]
+) -> None:
+    _wire_runner(monkeypatch, tmp_path)
+
+    async def _interrupt(*_args: Any, **_kwargs: Any) -> None:
+        raise interrupt()
+
+    monkeypatch.setattr(runner, "run_agent_loop", _interrupt)
+    coordinator = AgentCoordinator()
+
+    with pytest.raises(interrupt):
+        await runner.run_strix_scan(
+            scan_config={"targets": [], "scan_mode": "deep"},
+            scan_id="scan-test",
+            image="img",
+            coordinator=coordinator,
+        )
+
+    assert _root_status(coordinator) == "running"
+
+
+@pytest.mark.asyncio
+async def test_a_real_crash_still_marks_root_failed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    _wire_runner(monkeypatch, tmp_path)
+
+    async def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(runner, "run_agent_loop", _boom)
+    coordinator = AgentCoordinator()
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await runner.run_strix_scan(
+            scan_config={"targets": [], "scan_mode": "deep"},
+            scan_id="scan-test",
+            image="img",
+            coordinator=coordinator,
+        )
+
+    assert _root_status(coordinator) == "failed"


### PR DESCRIPTION
## Symptom

After quitting a scan and running `strix --resume <run>`, the resumed scan comes up **"Agent Failed"** immediately and does nothing.

## Root cause

Traced from a real run (`dvwa_3ae5`). The first run was quit ~21s in; its log ends with:

```
strix.core.runner: Strix scan dvwa_3ae5 failed
Traceback (most recent call last):
  ...
  File "strix/core/execution.py", line 676, in _run_cycle
    async for event in stream.stream_events():
  ...
asyncio.exceptions.CancelledError
strix.core.agents: agent.status 3ee8470d=failed
```

Quitting the TUI cancels the scan task (`runtime.py` → `scan_task.cancel()`), raising `asyncio.CancelledError` inside the running agent. It fell through to `run_strix_scan`'s `except BaseException`, which does `set_status(root_id, "failed")`. The `finally` snapshots that, so `.state/agents.json` persists `{root: "failed"}`. Resume restores it and shows a crashed root that won't run.

The sibling stop paths — `BudgetExceededError`, `RateLimitError` — already set `"stopped"`. Only the user-quit path was mislabeled a failure.

## Fix

Catch `asyncio.CancelledError` and `KeyboardInterrupt` (headless ctrl-c) before the catch-all, leave the root `"running"`, and re-raise. A genuine exception still marks the root `"failed"`.

Leaving it `running` (rather than `stopped`) means resume *continues* instead of parking: `start_parked = interactive and is_resume and root_status != "running"`, so a `running` root is re-driven straight from its session history the moment the scan resumes — which is what a user who quit and typed `--resume` expects. (`stopped` would have parked it waiting for a nudge, like the budget/rate-limit stops.)

I checked the other clean-stop types aren't also mislabeled: `BudgetPausedError` is suppressed inside `execution.py` and never reaches the runner, and `SubagentBudgetReservedError` is child-scoped. `CancelledError` and `KeyboardInterrupt` are the only user-interrupt types that reach `run_strix_scan`.

## Tests

`tests/test_runner_interrupt.py`, new:

- `CancelledError` and `KeyboardInterrupt` each leave the root `running` and propagate
- a `RuntimeError` still leaves the root `failed` (so this isn't "never fail")

875 tests pass. ruff and mypy clean.

Note: this prevents new runs from persisting a failed-on-quit root; an existing run already snapshotted as failed stays that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
