### PR TITLE
fix(tools): coerce an empty-string list/dict argument to an empty container

### DIFF
--- a/strix/agents/factory.py
+++ b/strix/agents/factory.py
@@ -160,7 +160,9 @@ def _schema_types(spec: dict[str, Any]) -> set[str]:
 def _decode_structured(value: str, types: set[str]) -> Any:
     stripped = value.strip()
     if not stripped:
-        return value
+        # An empty string is the model's "no value" for a list/dict param; give it
+        # the empty container so it validates instead of failing the type check.
+        return [] if "array" in types else {}
     try:
         decoded = json.loads(stripped)
     except json.JSONDecodeError:

--- a/tests/test_agent_factory_tool_arguments.py
+++ b/tests/test_agent_factory_tool_arguments.py
@@ -70,13 +70,35 @@ async def test_encoded_list_is_decoded_for_an_array_parameter(schema: dict[str, 
         "auth",
         "Endpoint /admin leaks user data, and session tokens never expire",
         '"auth"',
-        "",
     ],
 )
 async def test_free_form_strings_are_never_split_into_an_array(value: str) -> None:
     parsed = await _roundtrip(_ARRAY, {"tags": value})
 
     assert parsed["tags"] == value
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("schema", [_ARRAY, _NULLABLE_ARRAY])
+@pytest.mark.parametrize("value", ["", "   "])
+async def test_empty_string_becomes_an_empty_array(schema: dict[str, Any], value: str) -> None:
+    parsed = await _roundtrip(schema, {"tags": value})
+
+    assert parsed["tags"] == []
+
+
+@pytest.mark.asyncio
+async def test_empty_string_becomes_an_empty_object() -> None:
+    parsed = await _roundtrip(_OBJECT, {"modifications": ""})
+
+    assert parsed["modifications"] == {}
+
+
+@pytest.mark.asyncio
+async def test_empty_string_for_a_string_parameter_is_untouched() -> None:
+    parsed = await _roundtrip(_STRING, {"todos": ""})
+
+    assert parsed["todos"] == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Symptom

```
list_notes
  An error occurred while running the tool. ... Error: Invalid JSON input for tool list_notes:
  1 validation error for list_notes_args
  tags
    Input should be a valid list [type=list_type, input_value='', input_type=str]
```

The model called `list_notes(tags="")` — an empty string for an array parameter — and the call was rejected before the tool ran.

## Why #957 didn't cover it

#957 added shape coercion (`_coerce_argument`) that reshapes a tool argument to its schema's type before Pydantic validates. It decodes an encoded container (`'["a"]'` → `["a"]`) and, deliberately, passes everything else through so a genuine type mismatch still surfaces rather than being guessed at. An empty string fell into "everything else":

```python
def _decode_structured(value, types):
    stripped = value.strip()
    if not stripped:
        return value          # "" for an array param -> still "" -> fails validation
```

Its test even pinned this: `test_free_form_strings_are_never_split_into_an_array` listed `""` among the values asserted to pass through unchanged. That was the wrong call for the empty case specifically — an empty string is not a free-form tag the model meant to keep, it's "no value," and passing it through hard-fails.

## Fix

An empty (or whitespace-only) string for a list/dict parameter becomes the empty container of that type:

```python
    if not stripped:
        return [] if "array" in types else {}
```

Deliberately narrow, consistent with #957's conservatism:

- `""` / `"   "` for an array param → `[]`; for an object param → `{}`
- a non-empty non-JSON string (`"auth, idor"`) is still passed through untouched, so a real mismatch still surfaces — the model is not guessed into a split
- `""` for an actual string param is still kept as `""` (this branch only runs for array/object params)

`list_notes(tags="")` now returns `{"success": true, "notes": [...]}` instead of the validation error, verified against the real wrapped tool.

## Tests

`tests/test_agent_factory_tool_arguments.py`:

- `""` removed from the passthrough set (it no longer passes through)
- empty and whitespace strings → `[]` for array (and nullable-array) params
- empty string → `{}` for object params
- empty string still untouched for a string param

880 tests pass. ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)