### PR TITLE
fix(test): use real Settings object in runner root prompt tests

### DIFF
--- a/tests/test_runner_root_prompt.py
+++ b/tests/test_runner_root_prompt.py
@@ -6,7 +6,6 @@ flow through to the root agent's ``build_strix_agent`` call.
 
 from __future__ import annotations
 
-import types
 from typing import Any
 
 import httpx
@@ -16,6 +15,7 @@ from openai import RateLimitError
 
 import strix.tools.notes.tools as notes_tools
 import strix.tools.todo.tools as todo_tools
+from strix.config.settings import Settings
 from strix.core import runner
 from strix.core.agents import AgentCoordinator
 from strix.runtime import session_manager
@@ -42,17 +42,14 @@ def _patch_engine_scaffold(
     monkeypatch.setattr(runner, "setup_scan_logging", lambda _run_dir: lambda: None)
     monkeypatch.setattr(runner, "set_scan_id", lambda _scan_id: None)
 
-    settings = types.SimpleNamespace(
-        llm=types.SimpleNamespace(
-            model="openai/gpt-4o",
-            reasoning_effort="high",
-            force_required_tool_choice=False,
-            timeout=300,
-            prompt_cache=True,
-            extra_headers=None,
-        ),
-        runtime=types.SimpleNamespace(max_context_images=3),
-    )
+    settings = Settings()
+    settings.llm.model = "openai/gpt-4o"
+    settings.llm.reasoning_effort = "high"
+    settings.llm.force_required_tool_choice = False
+    settings.llm.timeout = 300
+    settings.llm.prompt_cache = True
+    settings.llm.extra_headers = None
+    settings.runtime.max_context_images = 3
     monkeypatch.setattr(runner, "load_settings", lambda: settings)
     monkeypatch.setattr(runner, "configure_sdk_model_defaults", lambda _settings: None)
     monkeypatch.setattr(

--- a/tests/test_runner_root_prompt.py
+++ b/tests/test_runner_root_prompt.py
@@ -6,6 +6,7 @@ flow through to the root agent's ``build_strix_agent`` call.
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 import httpx
@@ -19,6 +20,30 @@ from strix.config.settings import Settings
 from strix.core import runner
 from strix.core.agents import AgentCoordinator
 from strix.runtime import session_manager
+
+
+_SETTINGS_ENV_PREFIXES = (
+    "STRIX_",
+    "LLM_",
+    "OPENAI_",
+    "DEDUPE_LLM_",
+    "LITELLM_",
+    "OLLAMA_",
+    "PERPLEXITY_",
+    "POSTMAN_",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop ambient settings env vars so Settings() builds deterministically.
+
+    A malformed unrelated value (e.g. a non-JSON LLM_EXTRA_HEADERS) would
+    otherwise make Settings() raise before the fields under test are assigned.
+    """
+    for key in list(os.environ):
+        if key.startswith(_SETTINGS_ENV_PREFIXES):
+            monkeypatch.delenv(key, raising=False)
 
 
 def _make_rate_limit_error() -> RateLimitError:


### PR DESCRIPTION
## Summary
`_patch_engine_scaffold` in `tests/test_runner_root_prompt.py` faked the settings with a hand-rolled `SimpleNamespace` stub. The root agent reads settings fields (e.g. `llm.model`, `runtime.max_context_images`) directly, so a structurally different stub can silently diverge from the real `Settings` and mask regressions.

This change builds a real `strix.config.settings.Settings` and assigns only the fields under test, so the test exercises the actual configuration object.

## Review feedback addressed
- An autouse fixture now clears ambient settings env vars (`STRIX_*`, `LLM_*`, `OPENAI_*`, `DEDUPE_LLM_*`, etc.) before `Settings()` is constructed, so an unrelated malformed value (e.g. a non-JSON `LLM_EXTRA_HEADERS`) can no longer make the fixture raise. Verified by running the suite with deliberately malformed values exported.

## Testing
- `pytest tests/test_runner_root_prompt.py` (4 tests) passes.
- ruff + bandit clean; mypy clean on the file.

Fixes #832
