### PR TITLE
fix(tui): use single space after ordered-list marker

### DIFF
--- a/strix/interface/tui/internal/render/agent_message.go
+++ b/strix/interface/tui/internal/render/agent_message.go
@@ -100,7 +100,7 @@ func applyMarkdownStyles(text string) string {
 		case strings.HasPrefix(line, "- "), strings.HasPrefix(line, "* "):
 			out.WriteString(Col(Green).Render("• ") + inlineFormat(line[2:]))
 		case len(line) > 2 && line[0] >= '0' && line[0] <= '9' && (line[1:3] == ". " || line[1:3] == ") "):
-			out.WriteString(Col(Green).Render(string(line[0])+". ") + inlineFormat(line[2:]))
+			out.WriteString(Col(Green).Render(line[:2]+" ") + inlineFormat(line[3:]))
 		case line == "---" || line == "***" || line == "___":
 			out.WriteString(Col(Green).Render(strings.Repeat("─", 40)))
 		default:

--- a/strix/interface/tui/internal/render/markdown_test.go
+++ b/strix/interface/tui/internal/render/markdown_test.go
@@ -72,6 +72,19 @@ func TestNonTablePipeLinesAreLeftAlone(t *testing.T) {
 	}
 }
 
+func TestMarkdownOrderedListsUseSingleSpaceAfterMarker(t *testing.T) {
+	out := renderAssistantMarkdown("1. hello\n2) world")
+	plain := ansi.Strip(out)
+	for _, want := range []string{"1. hello", "2) world"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("ordered list item %q missing: %q", want, plain)
+		}
+	}
+	if strings.Contains(plain, "1.  hello") || strings.Contains(plain, "2)  world") {
+		t.Fatalf("double space after the list marker: %q", plain)
+	}
+}
+
 func TestInlineFormatKeepsNonEmphasisMarkers(t *testing.T) {
 	literal := []string{
 		"ls *.py *.go",


### PR DESCRIPTION
## Summary
When rendering ordered lists in the TUI, `applyMarkdownStyles` rendered the marker as `line[0]+". "` (e.g. `1. `) and then emitted the content from `line[2:]` — which still began with a space for `. ` markers, producing a visible double space (`1.  item`).

The marker is now rendered from `line[:2]` (e.g. `1.` / `1)`) followed by a single space, and the content is rendered from `line[3:]`. Bonus: `1) item` now renders as `1)` instead of `1.`.

## Testing
- New `TestMarkdownOrderedListsUseSingleSpaceAfterMarker` in `markdown_test.go`.
- `go test ./internal/render/ -run "TestMarkdown|TestInline"` passes.

Fixes #684
