### PR TITLE
fix(report): write the executive report atomically

### DIFF
--- a/strix/report/writer.py
+++ b/strix/report/writer.py
@@ -179,17 +179,24 @@ def write_vulnerabilities(
 
 def _atomic_write_text(path: Path, payload: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        dir=str(path.parent),
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        delete=False,
-    ) as tmp:
-        tmp.write(payload)
-        tmp_path = Path(tmp.name)
-    tmp_path.replace(path)
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=str(path.parent),
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+            tmp.write(payload)
+        assert tmp_path is not None
+        tmp_path.replace(path)
+    except Exception:  # leave no temp file behind on any failure
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def render_vulnerability_md(report: dict[str, Any]) -> str:  # noqa: PLR0912, PLR0915

--- a/strix/report/writer.py
+++ b/strix/report/writer.py
@@ -114,12 +114,14 @@ def write_run_record(run_dir: Path, run_record: dict[str, Any]) -> None:
 
 
 def write_executive_report(run_dir: Path, final_scan_result: str) -> None:
-    path = run_dir / "penetration_test_report.md"
-    with path.open("w", encoding="utf-8") as f:
-        f.write("# Security Penetration Test Report\n\n")
-        f.write(f"**Generated:** {datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S UTC')}\n\n")
-        f.write(f"{final_scan_result}\n")
-    logger.info("Saved final penetration test report to: %s", path)
+    report_path = run_dir / "penetration_test_report.md"
+    payload = (
+        "# Security Penetration Test Report\n\n"
+        f"**Generated:** {datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S UTC')}\n\n"
+        f"{final_scan_result}\n"
+    )
+    _atomic_write_text(report_path, payload)
+    logger.info("Saved final penetration test report to: %s", report_path)
 
 
 def write_vulnerabilities(

--- a/tests/test_report_writer.py
+++ b/tests/test_report_writer.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import csv
 import json
 import tempfile
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any, Self
 
 import pytest
 
@@ -16,10 +17,6 @@ from strix.report.writer import (
     write_run_record,
     write_vulnerabilities,
 )
-
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _sample_report(**overrides: Any) -> dict[str, Any]:
@@ -197,3 +194,55 @@ def test_write_executive_report_failure_preserves_previous_report(
         write_executive_report(tmp_path, "new content")
 
     assert target.read_text(encoding="utf-8") == "previous report"
+
+
+def test_write_executive_report_write_failure_preserves_previous_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "penetration_test_report.md"
+    target.write_text("previous report", encoding="utf-8")
+
+    temp_path = tmp_path / ".penetration_test_report.md.stub.tmp"
+    temp_path.touch()
+
+    class _FailingTempFile:
+        name = str(temp_path)
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def write(self, _payload: str) -> int:
+            raise OSError("disk full")
+
+    monkeypatch.setattr(
+        tempfile,
+        "NamedTemporaryFile",
+        lambda *_args, **_kwargs: _FailingTempFile(),
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        write_executive_report(tmp_path, "new content")
+
+    assert target.read_text(encoding="utf-8") == "previous report"
+    assert not temp_path.exists()  # the partial temp file is cleaned up
+
+
+def test_write_executive_report_replace_failure_preserves_previous_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "penetration_test_report.md"
+    target.write_text("previous report", encoding="utf-8")
+
+    def _failing_replace(_self: Path, _destination: Path) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "replace", _failing_replace)
+
+    with pytest.raises(OSError, match="disk full"):
+        write_executive_report(tmp_path, "new content")
+
+    assert target.read_text(encoding="utf-8") == "previous report"
+    assert not list(tmp_path.glob(".*.tmp"))  # no orphaned temp files

--- a/tests/test_report_writer.py
+++ b/tests/test_report_writer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+import tempfile
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -179,3 +180,20 @@ def test_write_executive_report_writes_markdown(tmp_path: Path) -> None:
     content = (tmp_path / "penetration_test_report.md").read_text(encoding="utf-8")
     assert "# Security Penetration Test Report" in content
     assert "Scan complete. No critical issues." in content
+
+
+def test_write_executive_report_failure_preserves_previous_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "penetration_test_report.md"
+    target.write_text("previous report", encoding="utf-8")
+
+    def _disk_full(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", _disk_full)
+
+    with pytest.raises(OSError, match="disk full"):
+        write_executive_report(tmp_path, "new content")
+
+    assert target.read_text(encoding="utf-8") == "previous report"


### PR DESCRIPTION
## Summary
`write_executive_report` previously opened the report file with `"w"`, truncating the existing report *before* rendering. If rendering or an intermediate write failed, the previous report was left corrupted or empty.

This change builds the full report payload in memory first, then writes it via the existing `_atomic_write_text` helper (temp file + atomic `os.replace`), so a failure during rendering preserves the previous report.

## Review feedback addressed
- `_atomic_write_text` now removes the temp file on any failure (write or replace), so a failed run leaves no orphaned `.penetration_test_report.md.*.tmp` artifact.
- Regression coverage now injects failure at all three points — temp-file creation, mid-write, and `replace()` — each asserting the previous report survives and no temp file is left behind.

## Testing
- `pytest tests/test_report_writer.py` (14 tests) passes.
- ruff + bandit clean; mypy clean on changed files.

Fixes #828
