### PR TITLE
docs: add OrcaRouter provider guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -35,6 +35,7 @@
               "llm-providers/openai",
               "llm-providers/anthropic",
               "llm-providers/openrouter",
+              "llm-providers/orcarouter",
               "llm-providers/vertex",
               "llm-providers/bedrock",
               "llm-providers/azure",

--- a/docs/llm-providers/orcarouter.mdx
+++ b/docs/llm-providers/orcarouter.mdx
@@ -1,0 +1,44 @@
+---
+title: "OrcaRouter"
+description: "Configure Strix with models via OrcaRouter"
+---
+
+[OrcaRouter](https://www.orcarouter.ai) routes each request to the best model across 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, and more, through a single OpenAI-compatible API.
+
+## Setup
+
+```bash
+export STRIX_LLM="openai/openai/gpt-5.5"
+export LLM_API_BASE="https://api.orcarouter.ai/v1"
+export LLM_API_KEY="sk-orca-..."
+```
+
+## Available Models
+
+Access any model on OrcaRouter using the format `openai/<provider>/<model>`:
+
+| Model | Configuration |
+|-------|---------------|
+| OrcaRouter Auto | `openai/orcarouter/auto` |
+| GPT-5.5 | `openai/openai/gpt-5.5` |
+| Claude Sonnet 4.6 | `openai/anthropic/claude-sonnet-4.6` |
+| Gemini 3 Pro | `openai/google/gemini-3.1-pro-preview` |
+| DeepSeek V4 Flash | `openai/deepseek/deepseek-v4-flash` |
+
+## Get API Key
+
+1. Go to [orcarouter.ai](https://www.orcarouter.ai)
+2. Sign in and navigate to **API Keys**
+3. Create a new API key (starts with `sk-orca-`)
+
+## Notes
+
+- Model IDs are namespaced by provider (`openai/`, `anthropic/`, `google/`, ...). Keep the full `<provider>/<model>` id after the `openai/` prefix — OrcaRouter rejects bare model names.
+- `orcarouter/auto` is an adaptive router, not a model: it picks an upstream per request. Its candidate pool can include models without tool-calling support, so for agentic scans pin a specific model such as `openai/gpt-5.5`.
+
+## Benefits
+
+- **Adaptive routing** — `orcarouter/auto` selects the best upstream per request with no client-side logic
+- **Single API** — Access OpenAI, Anthropic, Google, DeepSeek, and more
+- **OpenAI-compatible** — Drop-in replacement using `LLM_API_BASE`
+- **Gateway-level security** — It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

--- a/docs/llm-providers/overview.mdx
+++ b/docs/llm-providers/overview.mdx
@@ -43,6 +43,9 @@ See the [Local Models guide](/llm-providers/local) for setup instructions and re
   <Card title="OpenRouter" href="/llm-providers/openrouter">
     Access 100+ models through a single API.
   </Card>
+  <Card title="OrcaRouter" href="/llm-providers/orcarouter">
+    Adaptive routing across 150+ models.
+  </Card>
   <Card title="Google Vertex AI" href="/llm-providers/vertex">
     Gemini 3 models via Google Cloud.
   </Card>


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a documented LLM provider. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single endpoint and API key, with adaptive routing via `orcarouter/auto`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

This is a docs-only change that adds OrcaRouter to the LLM provider guides, mirroring the existing OpenRouter and Novita AI pages:

- `docs/llm-providers/orcarouter.mdx`: new provider guide (setup, available models, API key steps, notes, benefits)
- `docs/llm-providers/overview.mdx`: OrcaRouter card in the provider guides group
- `docs/docs.json`: nav entry under LLM Providers

OrcaRouter is configured as an OpenAI-compatible endpoint, the same shape as the existing Novita AI guide:

```bash
export STRIX_LLM="openai/openai/gpt-5.5"
export LLM_API_BASE="https://api.orcarouter.ai/v1"
export LLM_API_KEY="sk-orca-..."
```

## Why a docs entry rather than a code change

Strix's LLM layer is a generic LiteLLM passthrough with no provider registry — the same way OpenRouter and Novita AI are documented rather than hardcoded. OrcaRouter works through the existing OpenAI-compatible path (`openai/` prefix + `LLM_API_BASE`), so a docs entry makes it discoverable without touching routing code.

## Verification

- **Live API (through strix's own runtime path)**: ran the documented config via `configure_sdk_model_defaults` + `StrixProvider().get_model()`, which returned `ORCA-OK` for `openai/openai/gpt-5.5`, `openai/orcarouter/auto`, and `openai/orcarouter/fusion-mini`. A bare `openai/gpt-5.5` (missing the namespaced id) correctly fails with `503 No available channel for model gpt-5.5`, matching the note in the page.
- **Local checks**: `ruff check` and `ruff format --check` pass; `pytest` on the LLM/config tests (test_config_loader, test_models, test_llm_extra_headers, test_provider_hints, test_disable_streaming) → 102 passed, 1 failed (`test_persist_current_sets_0600_mode`, a POSIX file-mode assertion that does not hold on Windows and is unrelated to this docs-only change).
- `docs.json` validated as JSON.
