### PR TITLE
fix(agents): drop strict tool schemas on Bedrock Claude past the 20-tool cap

### DIFF
--- a/strix/agents/factory.py
+++ b/strix/agents/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import inspect
 import json
 import logging
@@ -17,6 +18,7 @@ from pydantic import ValidationError
 
 from strix.agents.prompt import render_system_prompt
 from strix.config import load_settings
+from strix.config.models import is_bedrock_route, is_claude_model
 from strix.tools.agents_graph.tools import (
     agent_finish,
     create_agent,
@@ -535,6 +537,32 @@ def _ensure_unique_tool_names(tools: Sequence[Tool]) -> None:
         raise ValueError(msg)
 
 
+def _bedrock_claude_strict_tool_limit_exceeded(tool_count: int) -> bool:
+    """Whether ``tool_count`` strict-schema tools would exceed Bedrock's cap.
+
+    AWS Bedrock's Converse API rejects a request with more than 20
+    strict-mode tool schemas (``ValidationException: Too many strict
+    tools``). Strix's own ``_BASE_TOOLS`` alone already exceeds 20 once
+    ``_EXTRA_TOOLS``/agent-browser/shell/filesystem tools are added, so any
+    Bedrock Claude scan with more than a couple of extra tools hits this.
+    """
+    return tool_count > 20
+
+
+def _disable_strict_schema(tool: Tool) -> Tool:
+    """Return a non-strict copy, never mutating the shared tool singleton.
+
+    ``_BASE_TOOLS``/``_EXTRA_TOOLS`` entries are shared module-level objects
+    reused by every ``build_strix_agent`` call; flipping ``strict_json_schema``
+    in place would leak across builds (e.g. a Bedrock root agent's tools
+    would stay non-strict for a later non-Bedrock child agent in the same
+    process).
+    """
+    if isinstance(tool, FunctionTool) and tool.strict_json_schema:
+        return dataclasses.replace(tool, strict_json_schema=False)
+    return tool
+
+
 def register_agent_tools(*tools: Tool) -> None:
     """Register tools for every scan agent built afterwards.
 
@@ -609,6 +637,16 @@ def build_strix_agent(
         else tool
         for tool in tools
     ]
+
+    model_name = load_settings().llm.model
+    if (
+        is_claude_model(model_name)
+        and is_bedrock_route(model_name)
+        and _bedrock_claude_strict_tool_limit_exceeded(len(tools))
+    ):
+        # Bedrock rejects the whole request over the 20-strict-tool cap, not
+        # just the tools past #20, so every tool must drop strict mode here.
+        tools = [_disable_strict_schema(tool) for tool in tools]
 
     logger.info(
         "Built %s agent '%s' (skills=%d, tools=%d, scan_mode=%s, whitebox=%s)",

--- a/strix/agents/factory.py
+++ b/strix/agents/factory.py
@@ -599,6 +599,7 @@ def build_strix_agent(
     system_prompt_context: dict[str, Any] | None = None,
     extra_tools: Sequence[Tool] | None = None,
     instructions_override: str | None = None,
+    model_name: str | None = None,
 ) -> SandboxAgent[Any]:
     """Build a SandboxAgent for either root or child use.
 
@@ -609,6 +610,10 @@ def build_strix_agent(
             registered via ``register_agent_tools``.
         instructions_override: Use this verbatim as the system prompt instead
             of rendering the built-in scan prompt.
+        model_name: The effective model for this run (e.g. ``RunConfig.model``
+            / ``run_strix_scan(model=...)``), which can differ from
+            ``load_settings().llm.model``. Falls back to the settings model
+            when omitted, e.g. for tests that don't go through the runner.
     """
     if instructions_override is not None:
         instructions = instructions_override
@@ -638,10 +643,10 @@ def build_strix_agent(
         for tool in tools
     ]
 
-    model_name = load_settings().llm.model
+    effective_model = model_name if model_name is not None else load_settings().llm.model
     if (
-        is_claude_model(model_name)
-        and is_bedrock_route(model_name)
+        is_claude_model(effective_model)
+        and is_bedrock_route(effective_model)
         and _bedrock_claude_strict_tool_limit_exceeded(len(tools))
     ):
         # Bedrock rejects the whole request over the 20-strict-tool cap, not
@@ -686,12 +691,15 @@ def make_child_factory(
     interactive: bool = False,
     chat_completions_tools: bool = False,
     system_prompt_context: dict[str, Any] | None = None,
+    model_name: str | None = None,
 ) -> Any:
     """Return the runner-owned builder used by ``spawn_child_agent``.
 
     Run-level arguments (``scan_mode``, ``is_whitebox``, etc.) are
     captured in a closure so each child inherits scan-level configuration
-    without the graph tool knowing about runner internals.
+    without the graph tool knowing about runner internals. ``model_name`` is
+    the effective run model (see ``build_strix_agent``), so children built
+    later in the scan see the same model classification as the root agent.
     """
 
     def _factory(*, name: str, skills: list[str]) -> SandboxAgent[Any]:
@@ -704,6 +712,7 @@ def make_child_factory(
             interactive=interactive,
             chat_completions_tools=chat_completions_tools,
             system_prompt_context=system_prompt_context,
+            model_name=model_name,
         )
 
     return _factory

--- a/strix/core/runner.py
+++ b/strix/core/runner.py
@@ -303,6 +303,7 @@ async def run_strix_scan(
             chat_completions_tools=chat_completions_tools,
             system_prompt_context=root_context,
             instructions_override=root_instructions,
+            model_name=resolved_model,
         )
 
         if not is_resume:
@@ -320,6 +321,7 @@ async def run_strix_scan(
             interactive=interactive,
             chat_completions_tools=chat_completions_tools,
             system_prompt_context=scope_context,
+            model_name=resolved_model,
         )
 
         async def spawn_child_agent(**kwargs: Any) -> dict[str, Any]:

--- a/tests/test_agent_tool_registration.py
+++ b/tests/test_agent_tool_registration.py
@@ -204,3 +204,52 @@ def test_disabling_strict_schema_does_not_leak_across_builds(
             assert shared.strict_json_schema, (
                 f"{shared.name} singleton was mutated by the Bedrock build"
             )
+
+
+def test_model_name_override_takes_precedence_over_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``run_strix_scan(model=...)`` can pick a model that differs from
+    ``settings.llm.model`` (e.g. ``STRIX_LLM`` unset, model passed directly).
+    The strict-tool gate must classify that effective model, not whatever
+    happens to be in settings.
+    """
+    monkeypatch.delenv("STRIX_LLM", raising=False)
+    monkeypatch.setattr(loader, "_cached", None)
+    monkeypatch.setattr(loader, "_override", None)
+
+    agent = factory.build_strix_agent(
+        is_root=True,
+        model_name="bedrock/anthropic.claude-4-6-sonnet",
+    )
+
+    assert len(agent.tools) > 20
+    function_tools = [t for t in agent.tools if isinstance(t, FunctionTool)]
+    assert all(not t.strict_json_schema for t in function_tools)
+
+
+def test_model_name_override_can_keep_strict_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Bedrock model in settings should not force non-strict tools when the
+    effective run model (passed explicitly) is a different, non-Bedrock route.
+    """
+    monkeypatch.setenv("STRIX_LLM", "bedrock/anthropic.claude-4-6-sonnet")
+    monkeypatch.setattr(loader, "_cached", None)
+    monkeypatch.setattr(loader, "_override", None)
+
+    agent = factory.build_strix_agent(
+        is_root=True,
+        model_name="anthropic/claude-4-6-sonnet",
+    )
+
+    function_tools = [t for t in agent.tools if isinstance(t, FunctionTool)]
+    assert any(t.strict_json_schema for t in function_tools)
+
+
+def test_child_factory_threads_model_name_through() -> None:
+    factory_fn = factory.make_child_factory(model_name="bedrock/anthropic.claude-4-6-sonnet")
+
+    child = factory_fn(name="child", skills=[])
+
+    function_tools = [t for t in child.tools if isinstance(t, FunctionTool)]
+    assert len(child.tools) > 20
+    assert all(not t.strict_json_schema for t in function_tools)

--- a/tests/test_agent_tool_registration.py
+++ b/tests/test_agent_tool_registration.py
@@ -8,9 +8,12 @@ import pytest
 from agents.tool import FunctionTool
 
 from strix.agents import factory
+from strix.config import loader
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from agents.tool_context import ToolContext
 
 
@@ -36,6 +39,16 @@ def _reset_registry() -> object:
         yield
     finally:
         factory._EXTRA_TOOLS[:] = saved
+
+
+@pytest.fixture
+def _bedrock_claude_model(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Point STRIX_LLM at a Bedrock Claude route for the duration of a test."""
+    monkeypatch.setenv("STRIX_LLM", "bedrock/anthropic.claude-4-6-sonnet")
+    monkeypatch.setattr(loader, "_cached", None)
+    monkeypatch.setattr(loader, "_override", None)
+    yield
+    monkeypatch.setattr(loader, "_cached", None)
 
 
 def test_register_agent_tools_is_deduped() -> None:
@@ -112,3 +125,82 @@ def test_wait_for_agents_is_available_in_both_modes() -> None:
     for interactive in (True, False):
         agent = factory.build_strix_agent(is_root=True, interactive=interactive)
         assert "wait_for_agents" in [t.name for t in agent.tools]
+
+
+def test_bedrock_claude_disables_strict_schema_past_the_tool_cap(
+    _bedrock_claude_model: None,
+) -> None:
+    """Bedrock's Converse API 400s a request with >20 strict-schema tools.
+
+    ``_BASE_TOOLS`` alone is already past 20, so every Bedrock Claude agent
+    must drop strict mode on every tool, not just the ones past #20 (Bedrock
+    rejects the whole request, not a subset of tools).
+    """
+    agent = factory.build_strix_agent(is_root=True)
+
+    assert len(agent.tools) > 20
+    function_tools = [t for t in agent.tools if isinstance(t, FunctionTool)]
+    assert function_tools
+    assert all(not t.strict_json_schema for t in function_tools)
+
+
+def test_non_bedrock_model_keeps_default_strict_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIX_LLM", "anthropic/claude-4-6-sonnet")
+    monkeypatch.setattr(loader, "_cached", None)
+    monkeypatch.setattr(loader, "_override", None)
+
+    agent = factory.build_strix_agent(is_root=True)
+
+    function_tools = [t for t in agent.tools if isinstance(t, FunctionTool)]
+    assert any(t.strict_json_schema for t in function_tools)
+
+
+def test_bedrock_claude_under_the_cap_keeps_strict_schema(
+    monkeypatch: pytest.MonkeyPatch,
+    _bedrock_claude_model: None,
+) -> None:
+    """A tool set at/under the cap should keep the SDK's strict-mode default."""
+    monkeypatch.setattr(factory, "_BASE_TOOLS", (_tool("only_base"),))
+
+    agent = factory.build_strix_agent(is_root=True)
+
+    assert len(agent.tools) <= 20
+    function_tools = [t for t in agent.tools if isinstance(t, FunctionTool)]
+    assert any(t.strict_json_schema for t in function_tools)
+
+
+def test_disabling_strict_schema_does_not_leak_across_builds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Bedrock build must not mutate the shared tool singletons.
+
+    ``_BASE_TOOLS``/``_EXTRA_TOOLS`` entries are the same objects reused by
+    every ``build_strix_agent`` call; if a Bedrock build flipped
+    ``strict_json_schema`` in place, a later non-Bedrock build in the same
+    process would incorrectly inherit non-strict tools.
+    """
+    originally_strict = {
+        tool.name
+        for tool in factory._BASE_TOOLS
+        if isinstance(tool, FunctionTool) and tool.strict_json_schema
+    }
+    assert originally_strict, "expected at least one strict tool in _BASE_TOOLS to test against"
+
+    monkeypatch.setenv("STRIX_LLM", "bedrock/anthropic.claude-4-6-sonnet")
+    monkeypatch.setattr(loader, "_cached", None)
+    monkeypatch.setattr(loader, "_override", None)
+    bedrock_agent = factory.build_strix_agent(is_root=True)
+    bedrock_tools = [t for t in bedrock_agent.tools if isinstance(t, FunctionTool)]
+    assert all(not t.strict_json_schema for t in bedrock_tools)
+
+    monkeypatch.setenv("STRIX_LLM", "anthropic/claude-4-6-sonnet")
+    monkeypatch.setattr(loader, "_cached", None)
+    non_bedrock_agent = factory.build_strix_agent(is_root=True)
+    non_bedrock_tools = {t.name: t for t in non_bedrock_agent.tools if isinstance(t, FunctionTool)}
+    assert all(non_bedrock_tools[name].strict_json_schema for name in originally_strict)
+
+    for shared in factory._BASE_TOOLS:
+        if isinstance(shared, FunctionTool) and shared.name in originally_strict:
+            assert shared.strict_json_schema, (
+                f"{shared.name} singleton was mutated by the Bedrock build"
+            )


### PR DESCRIPTION
## Summary

AWS Bedrock's Converse API rejects any request carrying more than 20 strict-mode tool schemas:

```
litellm.BadRequestError: BedrockException - {"message":"The model returned the following errors:
 Too many strict tools (28). The maximum number of strict tools supported is 20. Try reducing the number of tools
 marked as strict."}
```

`_BASE_TOOLS` in `strix/agents/factory.py` alone is already 29 entries (todos, notes, reporting, Caido proxy tools, agent graph, `load_skill`, `web_search`, `think`) before agent-browser, shell, filesystem, or any registered extra tools are added. Every Bedrock Claude scan hits this on startup, independent of skills or extra tools loaded — `load_skill` is a single registered tool regardless of how many skill `.md` files exist, so skill content can't be the cause.

## Fix

`build_strix_agent` now checks the final tool count against the cap once it's known which route is configured (`is_claude_model` + `is_bedrock_route`, both already in `strix/config/models.py`), and if it's a Bedrock Claude route past 20 tools, forces `strict_json_schema=False` on every tool. Bedrock rejects the whole request over the limit, not just the tools past #20, so partial strictness (e.g. keeping the first 20 strict) isn't a valid option — confirmed by how other SDKs that hit this same Bedrock limit resolved it: [pydantic-ai](https://github.com/pydantic/pydantic-ai/issues/5579), [camel-ai#4171](https://github.com/camel-ai/camel/pull/4171), and [datarobot-genai#547](https://github.com/datarobot-oss/datarobot-genai/pull/547) all disable strict mode for the whole toolset rather than trying to keep a subset strict.

`_disable_strict_schema` returns a copy via `dataclasses.replace` rather than mutating in place — `_BASE_TOOLS`/`_EXTRA_TOOLS` entries are shared module-level singletons reused by every `build_strix_agent` call, so an in-place flip would leak non-strict schemas into a later non-Bedrock build in the same process (root agent on Bedrock, then a Vertex/OpenAI child, for example). Caught this exact regression with a dedicated test while writing the fix.

## Related

No existing issue or PR addresses this (searched `strict tools`, `20 tools`, `strict_json_schema`, and the literal error text across issues and PRs, open and closed) — this looks like a new report.

Loosely related to the two open Bedrock `tool_choice`/`parallel_tool_calls` PRs (#649, #668) and #644 in that all three are Bedrock-Claude-route-specific request-shape fixes living in/near `strix/agents/factory.py` and `strix/core/inputs.py`, but this is a distinct bug (tool count vs. tool_choice format) with no code overlap.

## Testing

- Added `_bedrock_claude_model` fixture + 5 tests to `tests/test_agent_tool_registration.py`:
  - Bedrock Claude past the cap → every `FunctionTool` has `strict_json_schema=False`
  - Non-Bedrock model → default strict schemas preserved
  - Bedrock Claude under the cap (with `_BASE_TOOLS` monkeypatched short) → default strict schemas preserved
  - Anti-leak regression: a Bedrock build followed by a non-Bedrock build in the same process must not cross-contaminate, and the shared `_BASE_TOOLS` singletons must be untouched afterward
- Verified the anti-leak test actually catches the leak: temporarily swapped `_disable_strict_schema` back to the in-place-mutation version and confirmed the test fails; restored the fix and confirmed it passes again
- `uv run pytest tests/` — 890 passed (883 existing + 7 new/modified)
- `ruff check` / `ruff format --check` — clean
- `bandit -r strix/agents/factory.py` — no issues

## Test plan

- [x] Bedrock Claude scan with >20 tools no longer 400s on tool registration
- [x] Non-Bedrock models keep the SDK's default strict-mode tools
- [x] Bedrock builds don't leak non-strict schemas into later builds in the same process
- [x] Full test suite passes