### PR TITLE
fix(interface): refuse container-runtime dirs and docker.sock mounts

### DIFF
--- a/strix/interface/utils.py
+++ b/strix/interface/utils.py
@@ -1328,6 +1328,12 @@ _FORBIDDEN_MOUNT_TREES = frozenset(
         "/lib",
         "/lib64",
         "/nix/store",
+        "/run",
+        "/var/run",
+        "/private/var/run",
+        "/var/lib/docker",
+        "/var/lib/containers",
+        "/var/lib/containerd",
         "/run/current-system/sw",
         "/Applications",
         "/Library",
@@ -1336,6 +1342,16 @@ _FORBIDDEN_MOUNT_TREES = frozenset(
         "/boot",
         "/proc",
         "/sys",
+    }
+)
+
+# Direct children that indicate a container-runtime API socket directory.
+_FORBIDDEN_RUNTIME_SOCKET_NAMES = frozenset(
+    {
+        "docker.sock",
+        "podman.sock",
+        "containerd.sock",
+        "crio.sock",
     }
 )
 
@@ -1416,6 +1432,23 @@ def check_mountable_dir(path: Path) -> None:
         raise ValueError(
             f"Refusing to mount '{resolved}' into the sandbox: '{credential}' "
             "holds credentials, not code."
+        )
+
+    try:
+        socket_child = next(
+            (
+                entry.name
+                for entry in resolved.iterdir()
+                if entry.name.casefold() in _FORBIDDEN_RUNTIME_SOCKET_NAMES
+            ),
+            None,
+        )
+    except OSError:
+        socket_child = None
+    if socket_child is not None:
+        raise ValueError(
+            f"Refusing to mount '{resolved}' into the sandbox: '{socket_child}' "
+            "exposes a container runtime API, not a codebase."
         )
 
 

--- a/tests/test_local_sources.py
+++ b/tests/test_local_sources.py
@@ -166,6 +166,21 @@ def test_check_mountable_dir_rejects_system_subdirs() -> None:
         check_mountable_dir(system_subdir)
 
 
+def test_check_mountable_dir_rejects_var_run() -> None:
+    var_run = next((p for p in (Path("/var/run"), Path("/private/var/run")) if p.is_dir()), None)
+    if var_run is None:
+        pytest.skip("no /var/run on this platform")
+    with pytest.raises(ValueError, match="Refusing to mount"):
+        check_mountable_dir(var_run)
+
+
+def test_check_mountable_dir_rejects_runtime_socket_dir(tmp_path: Path) -> None:
+    sock = tmp_path / "docker.sock"
+    sock.write_text("")
+    with pytest.raises(ValueError, match="container runtime API"):
+        check_mountable_dir(tmp_path)
+
+
 def test_check_mountable_dir_accepts_a_project_under_the_home_root(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
Fixes #1058.

`check_mountable_dir` already refuses system trees and credential directory names (including `.docker`), but still admitted:

- `/run`, `/var/run`, and Darwin `/private/var/run` ( `/var` is exact-root only)
- common container data roots under `/var/lib/{docker,containers,containerd}`
- directories whose direct children include `docker.sock` / `podman.sock` / `containerd.sock` / `crio.sock`

Those paths are bind-mounted writable into the sandbox. Mounting a host Docker/Podman API socket is classic host control from inside the sandbox.

## Attacker model
An operator (or poisoned target list) points `--target` at `/var/run` or a directory that contains `docker.sock`. The sandbox already has shell and elevated network caps, so the socket becomes host Docker API access.

## Threat-model note
This tightens an admission control the product already claims to enforce for system mounts. Distinct from #1054 / #1055 (workspace mounts skipping admission).

## Test plan
- [x] `test_check_mountable_dir_rejects_var_run`
- [x] `test_check_mountable_dir_rejects_runtime_socket_dir`
- [x] Full `tests/test_local_sources.py` green locally (28 passed)
- [x] Revert-tested: removing the new denylist entries fails the two new tests


Made with [Cursor](https://cursor.com)