### PR TITLE
fix: bound Caido loginAsGuest retry to wall-clock boot deadline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,8 @@ ignore = [
 # args they intentionally ignore.
 "tests/test_viewer_auth.py" = ["S105", "S106", "ARG001"]
 "tests/test_codex_auth.py" = ["S105", "S106", "SLF001"]
+# Test doubles return a fixture guest token.
+"tests/test_caido_bootstrap.py" = ["S105"]
 # Hatchling loads the build hook by path, not as an importable package.
 "scripts/tui_sidecar_hook.py" = ["INP001"]
 # Stdlib HTTP handler overrides (do_GET/do_POST).

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -112,6 +112,8 @@ class RuntimeSettings(BaseSettings):
     backend: str = Field(default="docker", alias="STRIX_RUNTIME_BACKEND")
     # Max screenshot/image tool outputs kept live per agent context (0 = none).
     max_context_images: int = Field(default=3, ge=0, alias="STRIX_MAX_CONTEXT_IMAGES")
+    # Wall-clock budget (s) for Caido to come up; sandbox boot can take minutes on loaded hosts.
+    caido_boot_wait_s: int = Field(default=300, ge=1, alias="STRIX_CAIDO_BOOT_WAIT_S")
 
 
 class TelemetrySettings(BaseSettings):

--- a/strix/runtime/caido_bootstrap.py
+++ b/strix/runtime/caido_bootstrap.py
@@ -13,6 +13,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import time
 from typing import TYPE_CHECKING
 
 from caido_sdk_client import Client, TokenAuthOptions
@@ -35,16 +36,27 @@ async def _login_as_guest(
     session: BaseSandboxSession,
     *,
     container_url: str,
-    attempts: int = 10,
+    boot_wait_s: int = 300,
 ) -> str:
     """``session.exec`` curl to fetch a guest token; retry until ready.
 
     Caido's GraphQL listener may not be up the instant the container
     starts. The retry loop also doubles as the Caido readiness probe —
     no separate TCP healthcheck needed.
+
+    The loop is bounded by a wall-clock deadline (``boot_wait_s``), not
+    a fixed attempt count: on a loaded host the sandbox entrypoint's
+    ``chown -R`` over the pre-installed toolchain can delay ``caido-cli``
+    by many minutes, and a fixed 10-attempt backoff (~68s) aborts the
+    scan before the listener exists. Fast hosts still fail fast because
+    the first attempts use the same short backoff; slow hosts wait the
+    full budget instead of giving up early.
     """
+    deadline = time.monotonic() + boot_wait_s
+    attempt = 0
     last_err: str | None = None
-    for i in range(1, attempts + 1):
+    while True:
+        attempt += 1
         result = await session.exec(
             "curl",
             "-fsS",
@@ -74,10 +86,14 @@ async def _login_as_guest(
         else:
             stderr = result.stderr.decode("utf-8", errors="replace")[:200]
             last_err = f"curl exit {result.exit_code}: {stderr}"
-        logger.debug("loginAsGuest attempt %d/%d failed: %s", i, attempts, last_err)
-        await asyncio.sleep(min(2.0 * i, 8.0))
+        logger.debug("loginAsGuest attempt %d failed: %s", attempt, last_err)
 
-    raise RuntimeError(f"loginAsGuest failed after {attempts} attempts: {last_err}")
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        await asyncio.sleep(min(2.0 * attempt, 8.0, remaining))
+
+    raise RuntimeError(f"loginAsGuest failed after {boot_wait_s}s ({attempt} attempts): {last_err}")
 
 
 async def bootstrap_caido(
@@ -85,11 +101,16 @@ async def bootstrap_caido(
     *,
     host_url: str,
     container_url: str,
+    boot_wait_s: int = 300,
 ) -> Client:
     """Connect to the in-container Caido sidecar and select a fresh project."""
     logger.info("Bootstrapping Caido client (host=%s, container=%s)", host_url, container_url)
 
-    access_token = await _login_as_guest(session, container_url=container_url)
+    access_token = await _login_as_guest(
+        session,
+        container_url=container_url,
+        boot_wait_s=boot_wait_s,
+    )
 
     client = Client(host_url, auth=TokenAuthOptions(token=access_token))
     await client.connect()

--- a/strix/runtime/session_manager.py
+++ b/strix/runtime/session_manager.py
@@ -183,6 +183,7 @@ async def create_or_reuse(
         session,
         host_url=host_caido_url,
         container_url=container_caido_url,
+        boot_wait_s=load_settings().runtime.caido_boot_wait_s,
     )
 
     bundle = {
@@ -212,7 +213,7 @@ async def cleanup(scan_id: str) -> None:
     if caido_client is not None:
         try:
             await caido_client.aclose()
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.debug("cleanup(%s): caido_client.aclose() raised", scan_id, exc_info=True)
 
     client = bundle["client"]
@@ -229,5 +230,5 @@ async def cleanup(scan_id: str) -> None:
     if docker_client is not None:
         try:
             docker_client.close()
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.debug("cleanup(%s): docker_client.close() raised", scan_id, exc_info=True)

--- a/tests/test_caido_bootstrap.py
+++ b/tests/test_caido_bootstrap.py
@@ -1,0 +1,84 @@
+"""Tests for Caido bootstrap readiness and the wall-clock boot budget."""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from strix.config.settings import RuntimeSettings
+from strix.runtime.caido_bootstrap import _login_as_guest
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class _FakeResult:
+    def __init__(
+        self,
+        *,
+        ok: bool,
+        stdout: str = "",
+        stderr: bytes = b"",
+        exit_code: int = 0,
+    ) -> None:
+        self._ok = ok
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = exit_code
+
+    def ok(self) -> bool:
+        return self._ok
+
+
+_SUCCESS_TOKEN = _FakeResult(
+    ok=True,
+    stdout='{"data":{"loginAsGuest":{"token":{"accessToken":"guest-token"}}}}',
+)
+_FAIL_CURL = _FakeResult(ok=False, exit_code=7, stderr=b"curl: (7) Failed to connect")
+
+
+class _FakeSession:
+    def __init__(self, responses: Sequence[_FakeResult]) -> None:
+        self.responses = list(responses)
+        self.calls = 0
+
+    async def exec(self, *_args: object, **_kwargs: object) -> _FakeResult:
+        self.calls += 1
+        return self.responses[min(self.calls - 1, len(self.responses) - 1)]
+
+
+async def test_login_as_guest_returns_token_once_ready() -> None:
+    session = _FakeSession([_FAIL_CURL, _FAIL_CURL, _SUCCESS_TOKEN])
+
+    token = await _login_as_guest(session, container_url="http://127.0.0.1:48080")
+
+    assert token == "guest-token"
+    assert session.calls == 3
+
+
+async def test_login_as_guest_aborts_at_wall_clock_deadline() -> None:
+    # Always-failing session. The loop is bounded by boot_wait_s, not by a
+    # fixed attempt count, so a tiny budget must produce far fewer than the
+    # old 10 attempts while still raising.
+    session = _FakeSession([_FAIL_CURL])
+    started = time.monotonic()
+
+    with pytest.raises(RuntimeError, match=r"failed after 0\.5s \(\d+ attempts\)") as exc_info:
+        await _login_as_guest(session, container_url="http://127.0.0.1:48080", boot_wait_s=0.5)
+
+    elapsed = time.monotonic() - started
+    assert elapsed < 5.0, "wall-clock budget was not enforced"
+    attempts = int(re.search(r"\((\d+) attempts\)", str(exc_info.value)).group(1))
+    assert attempts < 10
+
+
+def test_caido_boot_wait_s_env_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIX_CAIDO_BOOT_WAIT_S", "600")
+
+    settings = RuntimeSettings()
+
+    assert settings.caido_boot_wait_s == 600


### PR DESCRIPTION
Fixes #1036

## Problem

`loginAsGuest` retried a fixed 10 attempts. During a slow sandbox boot (e.g. `chown -R` before `caido-cli` is ready), 10 attempts can be exhausted in ~68s while the target is still booting, so boot fails even though it would have succeeded moments later.

## Fix

Bound the retry loop by a **wall-clock deadline** instead of a fixed attempt count:

- Retry `loginAsGuest` until `time.monotonic() + boot_wait_s` elapses, with exponential backoff between attempts.
- On timeout, raise a clear error reporting the total wait and attempt count.
- Plumb the deadline through `session_manager`, exposed as `RuntimeSettings.caido_boot_wait_s` (env alias `STRIX_CAIDO_BOOT_WAIT_S`, default 300s).

## Verification

- `tests/test_caido_bootstrap.py` — 3 new tests, `pytest` 3/3 PASS
- `ruff check` + `ruff format --check` clean