### PR TITLE
feat(runtime): support pull-never sandbox images

### DIFF
--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -1,169 +1,17 @@
----
-title: "Configuration"
-description: "Environment variables for Strix"
----
-
-Configure Strix using environment variables or a config file.
-
-## LLM Configuration
-
-<ParamField path="STRIX_LLM" type="string" required>
-  Model name in LiteLLM format (e.g., `openai/gpt-5.4`, `anthropic/claude-sonnet-4-6`).
-</ParamField>
-
-<ParamField path="LLM_API_KEY" type="string">
-  API key for your LLM provider. Not required for local models or cloud provider auth (Vertex AI, AWS Bedrock).
-</ParamField>
-
-<ParamField path="LLM_API_BASE" type="string">
-  Custom API base URL. Also accepts `OPENAI_API_BASE`, `LITELLM_BASE_URL`, or `OLLAMA_API_BASE`.
-</ParamField>
-
-<ParamField path="LLM_EXTRA_HEADERS" type="string">
-  Extra HTTP headers sent on every LLM request, as a JSON object (e.g.
-  `{"X-Feature-Key":"value","X-Tenant":"acme"}`). Useful for OpenAI-compatible
-  gateways that require attribution or routing headers in addition to the bearer
-  token. The bearer token itself still comes from `LLM_API_KEY`. Applies to both
-  the LiteLLM and native OpenAI routing paths.
-</ParamField>
-
-<ParamField path="LLM_TIMEOUT" default="300" type="integer">
-  Request timeout in seconds for LLM calls.
-</ParamField>
-
-<ParamField path="STRIX_LLM_MAX_RETRIES" default="5" type="integer">
-  Maximum number of retries for LLM API calls on transient failures.
-</ParamField>
-
-<ParamField path="STRIX_REASONING_EFFORT" default="high" type="string">
-  Control thinking effort for reasoning models. Valid values: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`. Defaults to `medium` for quick scan mode.
-</ParamField>
-
-<ParamField path="STRIX_MEMORY_COMPRESSOR_TIMEOUT" default="30" type="integer">
-  Timeout in seconds for memory compression operations (context summarization).
-</ParamField>
-
-### Dedicated deduplication model
-
-Finding deduplication is a cheap, structured classification task. By default it
-runs on the main model, but you can route it to a smaller/cheaper model without
-affecting the agents that do the actual testing.
-
-<ParamField path="STRIX_DEDUPE_MODEL" type="string">
-  Model used to judge whether a candidate finding duplicates an existing report.
-  Falls back to `STRIX_LLM` when unset.
-</ParamField>
-
-<ParamField path="DEDUPE_LLM_API_KEY" type="string">
-  Optional provider key for the deduplication model.
-</ParamField>
-
-<ParamField path="DEDUPE_LLM_API_BASE" type="string">
-  Optional custom API base URL for the deduplication model. Use when the dedupe
-  model runs on a different endpoint than the main model.
-</ParamField>
-
-<ParamField path="DEDUPE_LLM_EXTRA_HEADERS" type="string">
-  Optional JSON object of extra HTTP headers sent on every deduplication-model
-  request, e.g. `{"X-Feature-Key":"value"}`. A dedicated dedupe model never
-  inherits `LLM_EXTRA_HEADERS`; set this when its endpoint needs custom headers.
-</ParamField>
-
-<ParamField path="STRIX_DEDUPE_REASONING_EFFORT" type="string">
-  Reasoning effort for the deduplication model. Defaults to the model's own
-  baseline when unset.
-</ParamField>
-
-## Optional Features
-
-<ParamField path="PERPLEXITY_API_KEY" type="string">
-  API key for Perplexity AI. Enables real-time web search during scans for OSINT and vulnerability research.
-</ParamField>
-
-<ParamField path="POSTMAN_API_KEY" type="string">
-  Postman API key (`PMAK-â€¦`). Enables fetching Postman collections by id as a target (`postman://<collection-uid>`), and Postman environments (`postman://<collection-uid>?env=<environment-uid>`) to resolve collection variables. Not needed when passing a local collection export file.
-</ParamField>
-
-<ParamField path="STRIX_TELEMETRY" default="1" type="string">
-  Telemetry toggle. Set to `0`, `false`, `no`, or `off` to disable telemetry (PostHog, Scarf, OTEL).
-</ParamField>
-
-<ParamField path="TRACELOOP_BASE_URL" type="string">
-  OTLP/Traceloop base URL for remote OpenTelemetry export. If unset, Strix keeps traces local only.
-</ParamField>
-
-<ParamField path="TRACELOOP_API_KEY" type="string">
-  API key used for remote trace export. Remote export is enabled only when both `TRACELOOP_BASE_URL` and `TRACELOOP_API_KEY` are set.
-</ParamField>
-
-<ParamField path="TRACELOOP_HEADERS" type="string">
-  Optional custom OTEL headers (JSON object or `key=value,key2=value2`). Useful for Langfuse or custom/self-hosted OTLP gateways.
-</ParamField>
-
-When remote OTEL vars are not set, Strix still writes complete run telemetry locally to:
-
-```bash
-strix_runs/<run_name>/events.jsonl
-```
-
-When remote vars are set, Strix dual-writes telemetry to both local JSONL and the remote OTEL endpoint.
-
-## Docker Configuration
-
-<ParamField path="STRIX_IMAGE" default="ghcr.io/usestrix/strix-sandbox:1.3.0" type="string">
-  Docker image to use for the sandbox container.
-</ParamField>
-
-<ParamField path="DOCKER_HOST" type="string">
-  Docker daemon socket path. Use for remote Docker hosts or custom configurations.
-</ParamField>
-
-<ParamField path="STRIX_RUNTIME_BACKEND" default="docker" type="string">
-  Runtime backend for the sandbox environment.
-</ParamField>
-
-## Sandbox Configuration
-
-<ParamField path="STRIX_SANDBOX_EXECUTION_TIMEOUT" default="120" type="integer">
-  Maximum execution time in seconds for sandbox operations.
-</ParamField>
-
-<ParamField path="STRIX_SANDBOX_CONNECT_TIMEOUT" default="10" type="integer">
-  Timeout in seconds for connecting to the sandbox container.
-</ParamField>
-
-## Config File
-
-Strix stores configuration in `~/.strix/cli-config.json`. You can also specify a custom config file:
-
-```bash
-strix --target ./app --config /path/to/config.json
-```
-
-**Config file format:**
-
-```json
-{
-  "env": {
-    "STRIX_LLM": "openai/gpt-5.4",
-    "LLM_API_KEY": "sk-...",
-    "STRIX_REASONING_EFFORT": "high"
-  }
-}
-```
-
-## Example Setup
-
-```bash
-# Required
-export STRIX_LLM="openai/gpt-5.4"
-export LLM_API_KEY="sk-..."
-
-# Optional: Enable web search
-export PERPLEXITY_API_KEY="pplx-..."
-
-# Optional: Custom timeouts
-export LLM_TIMEOUT="600"
-export STRIX_SANDBOX_EXECUTION_TIMEOUT="300"
-
-```
+­r‡^Ñf¥–Ø¦{[r‰İ°ë­¦ëKKKB]NˆÛÛ™šYİ\˜][Ûˆ‚™\ØÜš\[Ûˆ‘[š\›Û›Y[˜\šXX›\È›Üˆİš^‚‹KKB‚ÛÛ™šYİ\™Hİš^\Ú[™È[š\›Û›Y[˜\šXX›\ÈÜˆHÛÛ™šYÈš[K‚‚ˆÈÈHÛÛ™šYİ\˜][Û‚‚\˜[QšY[]H”Õ’VÓHˆ\OHœİš[™Èˆ™\]Z\™Y‚ˆ[Ù[˜[YH[ˆ]SH›Ü›X]
+K™Ë‹Ü[˜ZKÙÜMK[›ÜXËØÛ]YK\ÛÛ›™]MM˜
+K‚Ô\˜[QšY[‚‚\˜[QšY[]H“WĞTWÒÑVHˆ\OHœİš[™È‚ˆTHÙ^H›Üˆ[İ\ˆH›İšY\‹ˆ›İ™\]Z\™Y›ÜˆØØ[[Ù[ÈÜˆÛİY›İšY\ˆ]]
+™\^RKUÔÈ™Y›ØÚÊK‚Ô\˜[QšY[‚‚\˜[QšY[]H“WĞTWĞTÑHˆ\OHœİš[™È‚ˆİ\İÛHTH˜\ÙHT“ˆ[ÛÈXØÙ\ÈÔSRWĞTWĞTÑXUSWĞTÑWÕT“ÜˆÓSPWĞTWĞTÑX‚Ô\˜[QšY[‚‚\˜[QšY[]H“WÑVWÒPQT”Èˆ\OHœİš[™È‚ˆ^˜HXY\œÈÙ[Ûˆ]™\HH™\]Y\İ\ÈH”ÓÓˆØš™Xİ
+K™Ë‚ˆÈ–Q™X]\™KRÙ^Hˆ˜[YH‹–U[˜[ˆ˜XÛYHŸX
+Kˆ\ÙY[›ÜˆÜ[RKXÛÛ\]X›BˆØ]]Ø^\È]™\]Z\™H]šX][ÛˆÜˆ›İ][™ÈXY\œÈ[ˆY][ÛˆÈH™X\™\‚ˆÚÙ[‹ˆH™X\™\ˆÚÙ[ˆ]Ù[ˆİ[ÛÛY\Èœ›ÛHWĞTWÒÑVXˆ\Y\ÈÈ›İˆH]SH[™˜]]™HÜ[RH›İ][™È]Ë‚Ô\˜[QšY[‚‚\˜[QšY[]H“WÕSQSÕUˆY˜][HŒÌˆ\OHš[YÙ\ˆ‚ˆ™\]Y\İ[Y[İ][ˆÙXÛÛ™È›ÜˆHØ[Ë‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÓWÓPVÔ‘U’QTÈˆY˜][HHˆ\OHš[YÙ\ˆ‚ˆX^[][H[X™\ˆÙˆ™]šY\È›ÜˆHTHØ[ÈÛˆ˜[œÚY[˜Z[\™\Ë‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•ˆY˜][HšYÚˆ\OHœİš[™È‚ˆÛÛ›Û[šÚ[™ÈY™›Ü›Üˆ™X\ÛÛš[™È[Ù[Ëˆ˜[Y˜[Y\Îˆ›Û™XZ[š[X[İØYY][XYÚYÚX^ˆY˜][ÈÈYY][X›Üˆ]ZXÚÈØØ[ˆ[ÙK‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÓQSSÔ–WĞÓÓT‘TÔÓÔ—ÕSQSÕUˆY˜][HŒÌˆ\OHš[YÙ\ˆ‚ˆ[Y[İ][ˆÙXÛÛ™È›ÜˆY[[ÜHÛÛ\™\ÜÚ[ÛˆÜ\˜][ÛœÈ
+ÛÛ^İ[[X\š^˜][ÛŠK‚Ô\˜[QšY[‚‚ˆÈÈÈYXØ]YY\XØ][Ûˆ[Ù[‚‘š[™[™ÈY\XØ][Ûˆ\ÈHÚX\İXİ\™YÛ\ÜÚYšXØ][Ûˆ\ÚËˆHY˜][]œ[œÈÛˆHXZ[ˆ[Ù[][İHØ[ˆ›İ]H]ÈHÛX[\‹ØÚX\\ˆ[Ù[Ú]İ]˜Y™™Xİ[™ÈHYÙ[È]ÈHXİX[\İ[™Ë‚‚\˜[QšY[]H”Õ’VÑQTWÓSÑSˆ\OHœİš[™È‚ˆ[Ù[\ÙYÈYÙHÚ]\ˆHØ[™Y]Hš[™[™È\XØ]\È[ˆ^\İ[™È™\Ü‚ˆ˜[È˜XÚÈÈÕ’VÓXÚ[ˆ[œÙ]‚Ô\˜[QšY[‚‚\˜[QšY[]H‘QTWÓWĞTWÒÑVHˆ\OHœİš[™È‚ˆÜ[Û˜[›İšY\ˆÙ^H›ÜˆHY\XØ][Ûˆ[Ù[‚Ô\˜[QšY[‚‚\˜[QšY[]H‘QTWÓWĞTWĞTÑHˆ\OHœİš[™È‚ˆÜ[Û˜[İ\İÛHTH˜\ÙHT“›ÜˆHY\XØ][Ûˆ[Ù[ˆ\ÙHÚ[ˆHY\Bˆ[Ù[[œÈÛˆHY™™\™[[™Ú[[ˆHXZ[ˆ[Ù[‚Ô\˜[QšY[‚‚\˜[QšY[]H‘QTWÓWÑVWÒPQT”Èˆ\OHœİš[™È‚ˆÜ[Û˜[”ÓÓˆØš™XİÙˆ^˜HXY\œÈÙ[Ûˆ]™\HY\XØ][Û‹[[Ù[ˆ™\]Y\İK™ËˆÈ–Q™X]\™KRÙ^Hˆ˜[YHŸXˆHYXØ]YY\H[Ù[™]™\‚ˆ[š\š]ÈWÑVWÒPQT”ØÈÙ]\ÈÚ[ˆ]È[™Ú[™YYÈİ\İÛHXY\œË‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÑQTWÔ‘PTÓÓ’S‘×ÑQ‘“Ô•ˆ\OHœİš[™È‚ˆ™X\ÛÛš[™ÈY™›Ü›ÜˆHY\XØ][Ûˆ[Ù[ˆY˜][ÈÈH[Ù[	ÜÈİÛ‚ˆ˜\Ù[[™HÚ[ˆ[œÙ]‚Ô\˜[QšY[‚‚ˆÈÈÜ[Û˜[™X]\™\Â‚\˜[QšY[]H”T”VUWĞTWÒÑVHˆ\OHœİš[™È‚ˆTHÙ^H›Üˆ\œ^]HRKˆ[˜X›\È™X[][YHÙXˆÙX\˜Ú\š[™ÈØØ[œÈ›ÜˆÔÒS•[™[™\˜Xš[]H™\ÙX\˜Ú‚Ô\˜[QšY[‚‚\˜[QšY[]H”ÔÕPS—ĞTWÒÑVHˆ\OHœİš[™È‚ˆÜİX[ˆTHÙ^H
+PRËx )˜
+Kˆ[˜X›\È™]Ú[™ÈÜİX[ˆÛÛXİ[ÛœÈHY\ÈH\™Ù]
+ÜİX[‹ËÏÛÛXİ[Û‹]ZY˜
+K[™ÜİX[ˆ[š\›Û›Y[È
+ÜİX[‹ËÏÛÛXİ[Û‹]ZYÙ[O[š\›Û›Y[]ZY˜
+HÈ™\ÛÛ™HÛÛXİ[Ûˆ˜\šXX›\Ëˆ›İ™YYYÚ[ˆ\ÜÚ[™ÈHØØ[ÛÛXİ[Ûˆ^Üš[K‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÕSSQU–HˆY˜][HŒHˆ\OHœİš[™È‚ˆ[[Y]HÙÙÛKˆÙ]È˜[ÙX›ØÜˆÙ™˜È\ØX›H[[Y]H
+ÜİÙËØØ\™‹ÕS
+K‚Ô\˜[QšY[‚‚\˜[QšY[]H•PÑSÓÔĞTÑWÕT“ˆ\OHœİš[™È‚ˆÕÕ˜XÙ[ÛÜ˜\ÙHT“›Üˆ™[[İHÜ[•[[Y]H^ÜˆYˆ[œÙ]İš^ÙY\È˜XÙ\ÈØØ[Û›K‚Ô\˜[QšY[‚‚\˜[QšY[]H•PÑSÓÔĞTWÒÑVHˆ\OHœİš[™È‚ˆTHÙ^H\ÙY›Üˆ™[[İH˜XÙH^Üˆ™[[İH^Ü\È[˜X›YÛ›HÚ[ˆ›İPÑSÓÔĞTÑWÕT“[™PÑSÓÔĞTWÒÑVX\™HÙ]‚Ô\˜[QšY[‚‚\˜[QšY[]H•PÑSÓÔÒPQT”Èˆ\OHœİš[™È‚ˆÜ[Û˜[İ\İÛHÕSXY\œÈ
+”ÓÓˆØš™XİÜˆÙ^O]˜[YKÙ^L]˜[YL˜
+Kˆ\ÙY[›Üˆ[™Ù\ÙHÜˆİ\İÛKÜÙ[‹ZÜİYÕØ]]Ø^\Ë‚Ô\˜[QšY[‚‚•Ú[ˆ™[[İHÕS˜\œÈ\™H›İÙ]İš^İ[Üš]\ÈÛÛ\]H[ˆ[[Y]HØØ[HÎ‚‚˜˜\Úœİš^Ü[œËÏ[—Û˜[YO‹Ù]™[ËšœÛÛ›˜‚•Ú[ˆ™[[İH˜\œÈ\™HÙ]İš^X[]Üš]\È[[Y]HÈ›İØØ[”ÓÓ“[™H™[[İHÕS[™Ú[‚‚ˆÈÈØÚÙ\ˆÛÛ™šYİ\˜][Û‚‚\˜[QšY[]H”Õ’VÒSPQÑHˆY˜][H™ÚÜ‹š[Ëİ\Ù\İš^Üİš^\Ø[™›ŞŒKŒËŒˆ\OHœİš[™È‚ˆØÚÙ\ˆ[XYÙHÈ\ÙH›ÜˆHØ[™›ŞÛÛZ[™\‹‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÒSPQÑWÔSÔÓPÖHˆY˜][H˜]]Èˆ\OHœİš[™È‚ˆÛÛ›ÛÈØ[™›Ş[XYÙHXÜ]Z\Ú][Û‹ˆ\ÙH™]™\˜È™\]Z\™HH™[ØYY[XYÙBˆ[™˜Z[Ú]İ][[™ÈÚ[ˆ]\È[˜]˜Z[X›NÈ]]Ø™\Ù\™\ÈHY˜][ˆš\œİ\[ˆ[™Z]š[Ü‹ˆ\ÈÙ\È›İ™\İšXİ™]ÛÜšÈXØÙ\ÜÈœ›ÛHH[›š[™ÂˆØ[™›Ş‚Ô\˜[QšY[‚‚\˜[QšY[]H‘ĞÒÑT—ÒÔÕˆ\OHœİš[™È‚ˆØÚÙ\ˆY[[ÛˆÛØÚÙ]]ˆ\ÙH›Üˆ™[[İHØÚÙ\ˆÜİÈÜˆİ\İÛHÛÛ™šYİ\˜][ÛœË‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÔ•S•SQWĞPÒÑS‘ˆY˜][H™ØÚÙ\ˆˆ\OHœİš[™È‚ˆ[[YH˜XÚÙ[™›ÜˆHØ[™›Ş[š\›Û›Y[‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VĞĞRQ×Ğ“ÓÕÕĞRUÔÈˆY˜][HŒÌˆ\OHš[YÙ\ˆ‚ˆX^[][H[YH[ˆÙXÛÛ™ÈÈØZ]›ÜˆH[‹\Ø[™›ŞØZYÈ›ŞHÈ™XÛÛYH™XYK‚ˆ[˜Ü™X\ÙH\ÈÛˆÛİÈÜˆX]š[HØYYÛÛZ[™\ˆÜİË‚Ô\˜[QšY[‚‚ˆÈÈØ[™›ŞÛÛ™šYİ\˜][Û‚‚\˜[QšY[]H”Õ’VÔĞS‘“ÖÑVPÕUSÓ—ÕSQSÕUˆY˜][HŒLŒˆ\OHš[YÙ\ˆ‚ˆX^[][H^Xİ][Ûˆ[YH[ˆÙXÛÛ™È›ÜˆØ[™›ŞÜ\˜][ÛœË‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÔĞS‘“ÖĞÓÓ“‘PÕÕSQSÕUˆY˜][HŒLˆ\OHš[YÙ\ˆ‚ˆ[Y[İ][ˆÙXÛÛ™È›ÜˆÛÛ›™Xİ[™ÈÈHØ[™›ŞÛÛZ[™\‹‚Ô\˜[QšY[‚‚ˆÈÈÛÛ™šYÈš[B‚”İš^İÜ™\ÈÛÛ™šYİ\˜][Ûˆ[ˆ‹Ëœİš^ØÛKXÛÛ™šYËšœÛÛ˜ˆ[İHØ[ˆ[ÛÈÜXÚYHHİ\İÛHÛÛ™šYÈš[N‚‚˜˜\Úœİš^K]\™Ù]‹Ø\KXÛÛ™šYÈÜ]İËØÛÛ™šYËšœÛÛ‚˜‚ŠŠÛÛ™šYÈš[H›Ü›X]ŠŠ‚‚˜œÛÛ‚Âˆ™[ˆˆÂˆ”Õ’VÓHˆ›Ü[˜ZKÙÜMK‹ˆ“WĞTWÒÑVHˆœÚËK‹‹ˆ‹ˆ”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•ˆšYÚ‚ˆBŸB˜‚ˆÈÈ^[\HÙ]\‚˜˜\ÚˆÈ™\]Z\™Y™^ÜÕ’VÓOH›Ü[˜ZKÙÜMK‚™^ÜWĞTWÒÑVOHœÚËK‹‹ˆ‚‚ˆÈÜ[Û˜[ˆ[˜X›HÙXˆÙX\˜Ú™^ÜT”VUWĞTWÒÑVOHœK‹‹ˆ‚‚ˆÈÜ[Û˜[ˆİ\İÛH[Y[İ]Â™^ÜWÕSQSÕUHŒ‚™^ÜÕ’VÔĞS‘“ÖÑVPÕUSÓ—ÕSQSÕUHŒÌ‚‚˜

--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -1,17 +1,176 @@
-­r‡^Ñf¥–Ø¦{[r‰İ°ë­¦ëKKKB]NˆÛÛ™šYİ\˜][Ûˆ‚™\ØÜš\[Ûˆ‘[š\›Û›Y[˜\šXX›\È›Üˆİš^‚‹KKB‚ÛÛ™šYİ\™Hİš^\Ú[™È[š\›Û›Y[˜\šXX›\ÈÜˆHÛÛ™šYÈš[K‚‚ˆÈÈHÛÛ™šYİ\˜][Û‚‚\˜[QšY[]H”Õ’VÓHˆ\OHœİš[™Èˆ™\]Z\™Y‚ˆ[Ù[˜[YH[ˆ]SH›Ü›X]
-K™Ë‹Ü[˜ZKÙÜMK[›ÜXËØÛ]YK\ÛÛ›™]MM˜
-K‚Ô\˜[QšY[‚‚\˜[QšY[]H“WĞTWÒÑVHˆ\OHœİš[™È‚ˆTHÙ^H›Üˆ[İ\ˆH›İšY\‹ˆ›İ™\]Z\™Y›ÜˆØØ[[Ù[ÈÜˆÛİY›İšY\ˆ]]
-™\^RKUÔÈ™Y›ØÚÊK‚Ô\˜[QšY[‚‚\˜[QšY[]H“WĞTWĞTÑHˆ\OHœİš[™È‚ˆİ\İÛHTH˜\ÙHT“ˆ[ÛÈXØÙ\ÈÔSRWĞTWĞTÑXUSWĞTÑWÕT“ÜˆÓSPWĞTWĞTÑX‚Ô\˜[QšY[‚‚\˜[QšY[]H“WÑVWÒPQT”Èˆ\OHœİš[™È‚ˆ^˜HXY\œÈÙ[Ûˆ]™\HH™\]Y\İ\ÈH”ÓÓˆØš™Xİ
-K™Ë‚ˆÈ–Q™X]\™KRÙ^Hˆ˜[YH‹–U[˜[ˆ˜XÛYHŸX
-Kˆ\ÙY[›ÜˆÜ[RKXÛÛ\]X›BˆØ]]Ø^\È]™\]Z\™H]šX][ÛˆÜˆ›İ][™ÈXY\œÈ[ˆY][ÛˆÈH™X\™\‚ˆÚÙ[‹ˆH™X\™\ˆÚÙ[ˆ]Ù[ˆİ[ÛÛY\Èœ›ÛHWĞTWÒÑVXˆ\Y\ÈÈ›İˆH]SH[™˜]]™HÜ[RH›İ][™È]Ë‚Ô\˜[QšY[‚‚\˜[QšY[]H“WÕSQSÕUˆY˜][HŒÌˆ\OHš[YÙ\ˆ‚ˆ™\]Y\İ[Y[İ][ˆÙXÛÛ™È›ÜˆHØ[Ë‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÓWÓPVÔ‘U’QTÈˆY˜][HHˆ\OHš[YÙ\ˆ‚ˆX^[][H[X™\ˆÙˆ™]šY\È›ÜˆHTHØ[ÈÛˆ˜[œÚY[˜Z[\™\Ë‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•ˆY˜][HšYÚˆ\OHœİš[™È‚ˆÛÛ›Û[šÚ[™ÈY™›Ü›Üˆ™X\ÛÛš[™È[Ù[Ëˆ˜[Y˜[Y\Îˆ›Û™XZ[š[X[İØYY][XYÚYÚX^ˆY˜][ÈÈYY][X›Üˆ]ZXÚÈØØ[ˆ[ÙK‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÓQSSÔ–WĞÓÓT‘TÔÓÔ—ÕSQSÕUˆY˜][HŒÌˆ\OHš[YÙ\ˆ‚ˆ[Y[İ][ˆÙXÛÛ™È›ÜˆY[[ÜHÛÛ\™\ÜÚ[ÛˆÜ\˜][ÛœÈ
-ÛÛ^İ[[X\š^˜][ÛŠK‚Ô\˜[QšY[‚‚ˆÈÈÈYXØ]YY\XØ][Ûˆ[Ù[‚‘š[™[™ÈY\XØ][Ûˆ\ÈHÚX\İXİ\™YÛ\ÜÚYšXØ][Ûˆ\ÚËˆHY˜][]œ[œÈÛˆHXZ[ˆ[Ù[][İHØ[ˆ›İ]H]ÈHÛX[\‹ØÚX\\ˆ[Ù[Ú]İ]˜Y™™Xİ[™ÈHYÙ[È]ÈHXİX[\İ[™Ë‚‚\˜[QšY[]H”Õ’VÑQTWÓSÑSˆ\OHœİš[™È‚ˆ[Ù[\ÙYÈYÙHÚ]\ˆHØ[™Y]Hš[™[™È\XØ]\È[ˆ^\İ[™È™\Ü‚ˆ˜[È˜XÚÈÈÕ’VÓXÚ[ˆ[œÙ]‚Ô\˜[QšY[‚‚\˜[QšY[]H‘QTWÓWĞTWÒÑVHˆ\OHœİš[™È‚ˆÜ[Û˜[›İšY\ˆÙ^H›ÜˆHY\XØ][Ûˆ[Ù[‚Ô\˜[QšY[‚‚\˜[QšY[]H‘QTWÓWĞTWĞTÑHˆ\OHœİš[™È‚ˆÜ[Û˜[İ\İÛHTH˜\ÙHT“›ÜˆHY\XØ][Ûˆ[Ù[ˆ\ÙHÚ[ˆHY\Bˆ[Ù[[œÈÛˆHY™™\™[[™Ú[[ˆHXZ[ˆ[Ù[‚Ô\˜[QšY[‚‚\˜[QšY[]H‘QTWÓWÑVWÒPQT”Èˆ\OHœİš[™È‚ˆÜ[Û˜[”ÓÓˆØš™XİÙˆ^˜HXY\œÈÙ[Ûˆ]™\HY\XØ][Û‹[[Ù[ˆ™\]Y\İK™ËˆÈ–Q™X]\™KRÙ^Hˆ˜[YHŸXˆHYXØ]YY\H[Ù[™]™\‚ˆ[š\š]ÈWÑVWÒPQT”ØÈÙ]\ÈÚ[ˆ]È[™Ú[™YYÈİ\İÛHXY\œË‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÑQTWÔ‘PTÓÓ’S‘×ÑQ‘“Ô•ˆ\OHœİš[™È‚ˆ™X\ÛÛš[™ÈY™›Ü›ÜˆHY\XØ][Ûˆ[Ù[ˆY˜][ÈÈH[Ù[	ÜÈİÛ‚ˆ˜\Ù[[™HÚ[ˆ[œÙ]‚Ô\˜[QšY[‚‚ˆÈÈÜ[Û˜[™X]\™\Â‚\˜[QšY[]H”T”VUWĞTWÒÑVHˆ\OHœİš[™È‚ˆTHÙ^H›Üˆ\œ^]HRKˆ[˜X›\È™X[][YHÙXˆÙX\˜Ú\š[™ÈØØ[œÈ›ÜˆÔÒS•[™[™\˜Xš[]H™\ÙX\˜Ú‚Ô\˜[QšY[‚‚\˜[QšY[]H”ÔÕPS—ĞTWÒÑVHˆ\OHœİš[™È‚ˆÜİX[ˆTHÙ^H
-PRËx )˜
-Kˆ[˜X›\È™]Ú[™ÈÜİX[ˆÛÛXİ[ÛœÈHY\ÈH\™Ù]
-ÜİX[‹ËÏÛÛXİ[Û‹]ZY˜
-K[™ÜİX[ˆ[š\›Û›Y[È
-ÜİX[‹ËÏÛÛXİ[Û‹]ZYÙ[O[š\›Û›Y[]ZY˜
-HÈ™\ÛÛ™HÛÛXİ[Ûˆ˜\šXX›\Ëˆ›İ™YYYÚ[ˆ\ÜÚ[™ÈHØØ[ÛÛXİ[Ûˆ^Üš[K‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÕSSQU–HˆY˜][HŒHˆ\OHœİš[™È‚ˆ[[Y]HÙÙÛKˆÙ]È˜[ÙX›ØÜˆÙ™˜È\ØX›H[[Y]H
-ÜİÙËØØ\™‹ÕS
-K‚Ô\˜[QšY[‚‚\˜[QšY[]H•PÑSÓÔĞTÑWÕT“ˆ\OHœİš[™È‚ˆÕÕ˜XÙ[ÛÜ˜\ÙHT“›Üˆ™[[İHÜ[•[[Y]H^ÜˆYˆ[œÙ]İš^ÙY\È˜XÙ\ÈØØ[Û›K‚Ô\˜[QšY[‚‚\˜[QšY[]H•PÑSÓÔĞTWÒÑVHˆ\OHœİš[™È‚ˆTHÙ^H\ÙY›Üˆ™[[İH˜XÙH^Üˆ™[[İH^Ü\È[˜X›YÛ›HÚ[ˆ›İPÑSÓÔĞTÑWÕT“[™PÑSÓÔĞTWÒÑVX\™HÙ]‚Ô\˜[QšY[‚‚\˜[QšY[]H•PÑSÓÔÒPQT”Èˆ\OHœİš[™È‚ˆÜ[Û˜[İ\İÛHÕSXY\œÈ
-”ÓÓˆØš™XİÜˆÙ^O]˜[YKÙ^L]˜[YL˜
-Kˆ\ÙY[›Üˆ[™Ù\ÙHÜˆİ\İÛKÜÙ[‹ZÜİYÕØ]]Ø^\Ë‚Ô\˜[QšY[‚‚•Ú[ˆ™[[İHÕS˜\œÈ\™H›İÙ]İš^İ[Üš]\ÈÛÛ\]H[ˆ[[Y]HØØ[HÎ‚‚˜˜\Úœİš^Ü[œËÏ[—Û˜[YO‹Ù]™[ËšœÛÛ›˜‚•Ú[ˆ™[[İH˜\œÈ\™HÙ]İš^X[]Üš]\È[[Y]HÈ›İØØ[”ÓÓ“[™H™[[İHÕS[™Ú[‚‚ˆÈÈØÚÙ\ˆÛÛ™šYİ\˜][Û‚‚\˜[QšY[]H”Õ’VÒSPQÑHˆY˜][H™ÚÜ‹š[Ëİ\Ù\İš^Üİš^\Ø[™›ŞŒKŒËŒˆ\OHœİš[™È‚ˆØÚÙ\ˆ[XYÙHÈ\ÙH›ÜˆHØ[™›ŞÛÛZ[™\‹‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÒSPQÑWÔSÔÓPÖHˆY˜][H˜]]Èˆ\OHœİš[™È‚ˆÛÛ›ÛÈØ[™›Ş[XYÙHXÜ]Z\Ú][Û‹ˆ\ÙH™]™\˜È™\]Z\™HH™[ØYY[XYÙBˆ[™˜Z[Ú]İ][[™ÈÚ[ˆ]\È[˜]˜Z[X›NÈ]]Ø™\Ù\™\ÈHY˜][ˆš\œİ\[ˆ[™Z]š[Ü‹ˆ\ÈÙ\È›İ™\İšXİ™]ÛÜšÈXØÙ\ÜÈœ›ÛHH[›š[™ÂˆØ[™›Ş‚Ô\˜[QšY[‚‚\˜[QšY[]H‘ĞÒÑT—ÒÔÕˆ\OHœİš[™È‚ˆØÚÙ\ˆY[[ÛˆÛØÚÙ]]ˆ\ÙH›Üˆ™[[İHØÚÙ\ˆÜİÈÜˆİ\İÛHÛÛ™šYİ\˜][ÛœË‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÔ•S•SQWĞPÒÑS‘ˆY˜][H™ØÚÙ\ˆˆ\OHœİš[™È‚ˆ[[YH˜XÚÙ[™›ÜˆHØ[™›Ş[š\›Û›Y[‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VĞĞRQ×Ğ“ÓÕÕĞRUÔÈˆY˜][HŒÌˆ\OHš[YÙ\ˆ‚ˆX^[][H[YH[ˆÙXÛÛ™ÈÈØZ]›ÜˆH[‹\Ø[™›ŞØZYÈ›ŞHÈ™XÛÛYH™XYK‚ˆ[˜Ü™X\ÙH\ÈÛˆÛİÈÜˆX]š[HØYYÛÛZ[™\ˆÜİË‚Ô\˜[QšY[‚‚ˆÈÈØ[™›ŞÛÛ™šYİ\˜][Û‚‚\˜[QšY[]H”Õ’VÔĞS‘“ÖÑVPÕUSÓ—ÕSQSÕUˆY˜][HŒLŒˆ\OHš[YÙ\ˆ‚ˆX^[][H^Xİ][Ûˆ[YH[ˆÙXÛÛ™È›ÜˆØ[™›ŞÜ\˜][ÛœË‚Ô\˜[QšY[‚‚\˜[QšY[]H”Õ’VÔĞS‘“ÖĞÓÓ“‘PÕÕSQSÕUˆY˜][HŒLˆ\OHš[YÙ\ˆ‚ˆ[Y[İ][ˆÙXÛÛ™È›ÜˆÛÛ›™Xİ[™ÈÈHØ[™›ŞÛÛZ[™\‹‚Ô\˜[QšY[‚‚ˆÈÈÛÛ™šYÈš[B‚”İš^İÜ™\ÈÛÛ™šYİ\˜][Ûˆ[ˆ‹Ëœİš^ØÛKXÛÛ™šYËšœÛÛ˜ˆ[İHØ[ˆ[ÛÈÜXÚYHHİ\İÛHÛÛ™šYÈš[N‚‚˜˜\Úœİš^K]\™Ù]‹Ø\KXÛÛ™šYÈÜ]İËØÛÛ™šYËšœÛÛ‚˜‚ŠŠÛÛ™šYÈš[H›Ü›X]ŠŠ‚‚˜œÛÛ‚Âˆ™[ˆˆÂˆ”Õ’VÓHˆ›Ü[˜ZKÙÜMK‹ˆ“WĞTWÒÑVHˆœÚËK‹‹ˆ‹ˆ”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•ˆšYÚ‚ˆBŸB˜‚ˆÈÈ^[\HÙ]\‚˜˜\ÚˆÈ™\]Z\™Y™^ÜÕ’VÓOH›Ü[˜ZKÙÜMK‚™^ÜWĞTWÒÑVOHœÚËK‹‹ˆ‚‚ˆÈÜ[Û˜[ˆ[˜X›HÙXˆÙX\˜Ú™^ÜT”VUWĞTWÒÑVOHœK‹‹ˆ‚‚ˆÈÜ[Û˜[ˆİ\İÛH[Y[İ]Â™^ÜWÕSQSÕUHŒ‚™^ÜÕ’VÔĞS‘“ÖÑVPÕUSÓ—ÕSQSÕUHŒÌ‚‚˜
+---
+title: "Configuration"
+description: "Environment variables for Strix"
+---
+
+Configure Strix using environment variables or a config file.
+
+## LLM Configuration
+
+<ParamField path="STRIX_LLM" type="string" required>
+  Model name in LiteLLM format (e.g., `openai/gpt-5.4`, `anthropic/claude-sonnet-4-6`).
+</ParamField>
+
+<ParamField path="LLM_API_KEY" type="string">
+  API key for your LLM provider. Not required for local models or cloud provider auth (Vertex AI, AWS Bedrock).
+</ParamField>
+
+<ParamField path="LLM_API_BASE" type="string">
+  Custom API base URL. Also accepts `OPENAI_API_BASE`, `LITELLM_BASE_URL`, or `OLLAMA_API_BASE`.
+</ParamField>
+
+<ParamField path="LLM_EXTRA_HEADERS" type="string">
+  Extra HTTP headers sent on every LLM request, as a JSON object (e.g.
+  `{"X-Feature-Key":"value","X-Tenant":"acme"}`). Useful for OpenAI-compatible
+  gateways that require attribution or routing headers in addition to the bearer
+  token. The bearer token itself still comes from `LLM_API_KEY`. Applies to both
+  the LiteLLM and native OpenAI routing paths.
+</ParamField>
+
+<ParamField path="LLM_TIMEOUT" default="300" type="integer">
+  Request timeout in seconds for LLM calls.
+</ParamField>
+
+<ParamField path="STRIX_LLM_MAX_RETRIES" default="5" type="integer">
+  Maximum number of retries for LLM API calls on transient failures.
+</ParamField>
+
+<ParamField path="STRIX_REASONING_EFFORT" default="high" type="string">
+  Control thinking effort for reasoning models. Valid values: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`. Defaults to `medium` for quick scan mode.
+</ParamField>
+
+<ParamField path="STRIX_MEMORY_COMPRESSOR_TIMEOUT" default="30" type="integer">
+  Timeout in seconds for memory compression operations (context summarization).
+</ParamField>
+
+### Dedicated deduplication model
+
+Finding deduplication is a cheap, structured classification task. By default it
+runs on the main model, but you can route it to a smaller/cheaper model without
+affecting the agents that do the actual testing.
+
+<ParamField path="STRIX_DEDUPE_MODEL" type="string">
+  Model used to judge whether a candidate finding duplicates an existing report.
+  Falls back to `STRIX_LLM` when unset.
+</ParamField>
+
+<ParamField path="DEDUPE_LLM_API_KEY" type="string">
+  Optional provider key for the deduplication model.
+</ParamField>
+
+<ParamField path="DEDUPE_LLM_API_BASE" type="string">
+  Optional custom API base URL for the deduplication model. Use when the dedupe
+  model runs on a different endpoint than the main model.
+</ParamField>
+
+<ParamField path="DEDUPE_LLM_EXTRA_HEADERS" type="string">
+  Optional JSON object of extra HTTP headers sent on every deduplication-model
+  request, e.g. `{"X-Feature-Key":"value"}`. A dedicated dedupe model never
+  inherits `LLM_EXTRA_HEADERS`; set this when its endpoint needs custom headers.
+</ParamField>
+
+<ParamField path="STRIX_DEDUPE_REASONING_EFFORT" type="string">
+  Reasoning effort for the deduplication model. Defaults to the model's own
+  baseline when unset.
+</ParamField>
+
+## Optional Features
+
+<ParamField path="PERPLEXITY_API_KEY" type="string">
+  API key for Perplexity AI. Enables real-time web search during scans for OSINT and vulnerability research.
+</ParamField>
+
+<ParamField path="POSTMAN_API_KEY" type="string">
+  Postman API key (`PMAK-â€¦`). Enables fetching Postman collections by id as a target (`postman://<collection-uid>`), and Postman environments (`postman://<collection-uid>?env=<environment-uid>`) to resolve collection variables. Not needed when passing a local collection export file.
+</ParamField>
+
+<ParamField path="STRIX_TELEMETRY" default="1" type="string">
+  Telemetry toggle. Set to `0`, `false`, `no`, or `off` to disable telemetry (PostHog, Scarf, OTEL).
+</ParamField>
+
+<ParamField path="TRACELOOP_BASE_URL" type="string">
+  OTLP/Traceloop base URL for remote OpenTelemetry export. If unset, Strix keeps traces local only.
+</ParamField>
+
+<ParamField path="TRACELOOP_API_KEY" type="string">
+  API key used for remote trace export. Remote export is enabled only when both `TRACELOOP_BASE_URL` and `TRACELOOP_API_KEY` are set.
+</ParamField>
+
+<ParamField path="TRACELOOP_HEADERS" type="string">
+  Optional custom OTEL headers (JSON object or `key=value,key2=value2`). Useful for Langfuse or custom/self-hosted OTLP gateways.
+</ParamField>
+
+When remote OTEL vars are not set, Strix still writes complete run telemetry locally to:
+
+```bash
+strix_runs/<run_name>/events.jsonl
+```
+
+When remote vars are set, Strix dual-writes telemetry to both local JSONL and the remote OTEL endpoint.
+
+## Docker Configuration
+
+<ParamField path="STRIX_IMAGE" default="ghcr.io/usestrix/strix-sandbox:1.3.0" type="string">
+  Docker image to use for the sandbox container.
+</ParamField>
+
+<ParamField path="STRIX_IMAGE_PULL_POLICY" default="auto" type="string">
+  Controls sandbox image acquisition. Use `never` to require a preloaded image
+  and fail without pulling when it is unavailable; `auto` preserves the default
+  first-run pull behavior. This does not restrict network access from a running
+  sandbox.
+</ParamField>
+
+<ParamField path="DOCKER_HOST" type="string">
+  Docker daemon socket path. Use for remote Docker hosts or custom configurations.
+</ParamField>
+
+<ParamField path="STRIX_RUNTIME_BACKEND" default="docker" type="string">
+  Runtime backend for the sandbox environment.
+</ParamField>
+
+## Sandbox Configuration
+
+<ParamField path="STRIX_SANDBOX_EXECUTION_TIMEOUT" default="120" type="integer">
+  Maximum execution time in seconds for sandbox operations.
+</ParamField>
+
+<ParamField path="STRIX_SANDBOX_CONNECT_TIMEOUT" default="10" type="integer">
+  Timeout in seconds for connecting to the sandbox container.
+</ParamField>
+
+## Config File
+
+Strix stores configuration in `~/.strix/cli-config.json`. You can also specify a custom config file:
+
+```bash
+strix --target ./app --config /path/to/config.json
+```
+
+**Config file format:**
+
+```json
+{
+  "env": {
+    "STRIX_LLM": "openai/gpt-5.4",
+    "LLM_API_KEY": "sk-...",
+    "STRIX_REASONING_EFFORT": "high"
+  }
+}
+```
+
+## Example Setup
+
+```bash
+# Required
+export STRIX_LLM="openai/gpt-5.4"
+export LLM_API_KEY="sk-..."
+
+# Optional: Enable web search
+export PERPLEXITY_API_KEY="pplx-..."
+
+# Optional: Custom timeouts
+export LLM_TIMEOUT="600"
+export STRIX_SANDBOX_EXECUTION_TIMEOUT="300"
+
+```

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -1,161 +1,60 @@
-­r‡^Ñf¥–Ø¦{O,yÊ'vÃ®¶›­"""Strix application settings â€” pydantic-settings powered."""
-
-from __future__ import annotations
-
-from typing import Literal
-
-from pydantic import AliasChoices, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-
-ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
-
-DEFAULT_MAX_TURNS = 500
-
-_BASE_CONFIG = SettingsConfigDict(
-    case_sensitive=False,
-    populate_by_name=True,
-    extra="ignore",
-)
-
-
-class LlmSettings(BaseSettings):
-    model_config = _BASE_CONFIG
-
-    model: str | None = Field(default=None, alias="STRIX_LLM")
-    api_key: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices("LLM_API_KEY", "OPENAI_API_KEY"),
-        repr=False,
-    )
-    api_base: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices(
-            "LLM_API_BASE",
-            "OPENAI_API_BASE",
-            "OPENAI_BASE_URL",
-            "LITELLM_BASE_URL",
-            "OLLAMA_API_BASE",
-        ),
-    )
-    extra_headers: dict[str, str] | None = Field(
-        default=None,
-        alias="LLM_EXTRA_HEADERS",
-        repr=False,
-    )
-    reasoning_effort: ReasoningEffort = Field(default="high", alias="STRIX_REASONING_EFFORT")
-    force_required_tool_choice: bool = Field(
-        default=False,
-        alias="STRIX_FORCE_REQUIRED_TOOL_CHOICE",
-    )
-    prompt_cache: bool = Field(
-        default=True,
-        alias="STRIX_PROMPT_CACHE",
-    )
-    disable_streaming: bool = Field(
-        default=False,
-        alias="LLM_DISABLE_STREAMING",
-    )
-    timeout: int = Field(default=300, alias="LLM_TIMEOUT")
-    stream_idle_timeout: int = Field(default=300, ge=0, alias="LLM_STREAM_IDLE_TIMEOUT")
-    max_tool_calls_per_turn: int = Field(
-        default=32,
-        ge=0,
-        alias="LLM_MAX_TOOL_CALLS_PER_TURN",
-    )
-
-
-class DedupeSettings(BaseSettings):
-    model_config = _BASE_CONFIG
-
-    model: str | None = Field(default=None, alias="STRIX_DEDUPE_MODEL")
-    reasoning_effort: ReasoningEffort | None = Field(
-        default=None,
-        alias="STRIX_DEDUPE_REASONING_EFFORT",
-    )
-    api_key: str | None = Field(default=None, alias="DEDUPE_LLM_API_KEY", repr=False)
-    api_base: str | None = Field(default=None, alias="DEDUPE_LLM_API_BASE")
-    extra_headers: dict[str, str] | None = Field(
-        default=None,
-        alias="DEDUPE_LLM_EXTRA_HEADERS",
-        repr=False,
-    )
-
-
-class ContextSettings(BaseSettings):
-    """Context-window management: per-tool-output caps and history compaction."""
-
-    model_config = _BASE_CONFIG
-
-    auto_compact: bool = Field(default=True, alias="STRIX_CONTEXT_AUTO_COMPACT")
-    compact_buffer_tokens: int = Field(default=20_000, gt=0, alias="STRIX_CONTEXT_BUFFER_TOKENS")
-    keep_tokens: int = Field(default=8_000, gt=0, alias="STRIX_CONTEXT_KEEP_TOKENS")
-    fallback_context_tokens: int = Field(
-        default=200_000, gt=0, alias="STRIX_CONTEXT_FALLBACK_TOKENS"
-    )
-    summary_max_tokens: int = Field(default=4_096, gt=0, alias="STRIX_CONTEXT_SUMMARY_TOKENS")
-    tool_output_max_tokens: int = Field(default=8_000, gt=0, alias="STRIX_TOOL_OUTPUT_MAX_TOKENS")
-    tool_output_max_lines: int = Field(default=2_000, gt=0, alias="STRIX_TOOL_OUTPUT_MAX_LINES")
-    # Floor above the truncation-notice size so a preview always fits.
-    tool_output_max_bytes: int = Field(
-        default=50 * 1024, ge=1024, alias="STRIX_TOOL_OUTPUT_MAX_BYTES"
-    )
-
-
-class RuntimeSettings(BaseSettings):
-    model_config = _BASE_CONFIG
-
-    image: str = Field(
-        default="ghcr.io/usestrix/strix-sandbox:1.3.0",
-        alias="STRIX_IMAGE",
-    )
-    image_pull_policy: Literal["auto", "never"] = Field(
-        default="auto",
-        alias="STRIX_IMAGE_PULL_POLICY",
-    )
-    backend: str = Field(default="docker", alias="STRIX_RUNTIME_BACKEND")
-    caido_boot_wait_s: int = Field(default=300, gt=0, alias="STRIX_CAIDO_BOOT_WAIT_S")
-    # Max screenshot/image tool outputs kept live per agent context (0 = none).
-    max_context_images: int = Field(default=3, ge=0, alias="STRIX_MAX_CONTEXT_IMAGES")
-
-
-class TelemetrySettings(BaseSettings):
-    model_config = _BASE_CONFIG
-
-    enabled: bool = Field(default=True, alias="STRIX_TELEMETRY")
-
-
-class IntegrationSettings(BaseSettings):
-    model_config = _BASE_CONFIG
-
-    perplexity_api_key: str | None = Field(
-        default=None,
-        alias="PERPLEXITY_API_KEY",
-        repr=False,
-    )
-    postman_api_key: str | None = Field(
-        default=None,
-        alias="POSTMAN_API_KEY",
-        repr=False,
-    )
-
-
-class ViewerSettings(BaseSettings):
-    model_config = _BASE_CONFIG
-
-    # Base URL of the Strix relay the local viewer proxies to for email
-    # verification and encrypted report delivery. The browser never talks to
-    # the relay directly; the local server is the only caller.
-    app_url: str = Field(default="https://app.strix.ai", alias="STRIX_APP_URL")
-
-
-class Settings(BaseSettings):
-    model_config = _BASE_CONFIG
-
-    llm: LlmSettings = Field(default_factory=LlmSettings)
-    dedupe: DedupeSettings = Field(default_factory=DedupeSettings)
-    runtime: RuntimeSettings = Field(default_factory=RuntimeSettings)
-    context: ContextSettings = Field(default_factory=ContextSettings)
-    telemetry: TelemetrySettings = Field(default_factory=TelemetrySettings)
-    integrations: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    viewer: ViewerSettings = Field(default_factory=ViewerSettings)
+­r‡^Ñf¥–Ø¦{[r‰İ°ë­¦ëHˆˆ”İš^\XØ][ÛˆÙ][™ÜÈ8 %Y[XË\Ù][™ÜÈİÙ\™Yˆˆˆ‚‚™œ›ÛH×Ù]\™W×È[\Ü[››İ][ÛœÂ‚™œ›ÛH\[™È[\Ü]\˜[‚™œ›ÛHY[XÈ[\Ü[X\ĞÚÚXÙ\ËšY[™œ›ÛHY[X×ÜÙ][™ÜÈ[\Ü˜\ÙTÙ][™ÜËÙ][™ÜĞÛÛ™šYÑXİ‚‚”™X\ÛÛš[™ÑY™›ÜH]\˜[È››Û™H‹›Z[š[X[‹›İÈ‹›YY][H‹šYÚ‹YÚ‹›X^—B‚‘QUSÓPVÕT“”ÈHL‚—ĞTÑWĞÓÓ‘’QÈHÙ][™ÜĞÛÛ™šYÑXİ
+ˆØ\ÙWÜÙ[œÚ]]™OQ˜[ÙKˆÜ[]WØWÛ˜[YOUYKˆ^˜OHšYÛ›Ü™H‹ŠB‚‚˜Û\ÜÈTÙ][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆ[Ù[ˆİˆ›Û™HHšY[
+Y˜][S›Û™K[X\ÏH”Õ’VÓHŠBˆ\WÚÙ^Nˆİˆ›Û™HHšY[
+ˆY˜][S›Û™Kˆ˜[Y][Û—Ø[X\ÏP[X\ĞÚÚXÙ\Ê“WĞTWÒÑVH‹“ÔSRWĞTWÒÑVHŠKˆ™\Q˜[ÙKˆ
+Bˆ\WØ˜\ÙNˆİˆ›Û™HHšY[
+ˆY˜][S›Û™Kˆ˜[Y][Û—Ø[X\ÏP[X\ĞÚÚXÙ\Êˆ“WĞTWĞTÑH‹ˆ“ÔSRWĞTWĞTÑH‹ˆ“ÔSRWĞTÑWÕT“‹ˆ“USWĞTÑWÕT“‹ˆ“ÓSPWĞTWĞTÑH‹ˆ
+Kˆ
+Bˆ^˜WÚXY\œÎˆXİÜİ‹İ—H›Û™HHšY[
+ˆY˜][S›Û™Kˆ[X\ÏH“WÑVWÒPQT”È‹ˆ™\Q˜[ÙKˆ
+Bˆ™X\ÛÛš[™×ÙY™›Üˆ™X\ÛÛš[™ÑY™›ÜHšY[
+Y˜][HšYÚ‹[X\ÏH”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•ŠBˆ›Ü˜ÙWÜ™\]Z\™YİÛÛØÚÚXÙNˆ›ÛÛHšY[
+ˆY˜][Q˜[ÙKˆ[X\ÏH”Õ’VÑ“ÔÑWÔ‘TURT‘QÕÓÓĞÒÒPÑH‹ˆ
+Bˆ›Û\ØØXÚNˆ›ÛÛHšY[
+ˆY˜][UYKˆ[X\ÏH”Õ’VÔ“ÓTĞĞPÒH‹ˆ
+Bˆ\ØX›WÜİ™X[Z[™Îˆ›ÛÛHšY[
+ˆY˜][Q˜[ÙKˆ[X\ÏH“WÑTĞP“WÔÕ‘PSRS‘È‹ˆ
+Bˆ[Y[İ]ˆ[HšY[
+Y˜][LÌ[X\ÏH“WÕSQSÕUŠBˆİ™X[WÚYWİ[Y[İ]ˆ[HšY[
+Y˜][LÌÙOL[X\ÏH“WÔÕ‘PSWÒQWÕSQSÕUŠBˆX^İÛÛØØ[×Ü\—İ\›ˆ[HšY[
+ˆY˜][LÌ‹ˆÙOLˆ[X\ÏH“WÓPVÕÓÓĞĞS×ÔT—ÕT“ˆ‹ˆ
+B‚‚˜Û\ÜÈY\TÙ][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆ[Ù[ˆİˆ›Û™HHšY[
+Y˜][S›Û™K[X\ÏH”Õ’VÑQTWÓSÑSŠBˆ™X\ÛÛš[™×ÙY™›Üˆ™X\ÛÛš[™ÑY™›Ü›Û™HHšY[
+ˆY˜][S›Û™Kˆ[X\ÏH”Õ’VÑQTWÔ‘PTÓÓ’S‘×ÑQ‘“Ô•‹ˆ
+Bˆ\WÚÙ^Nˆİˆ›Û™HHšY[
+Y˜][S›Û™K[X\ÏH‘QTWÓWĞTWÒÑVH‹™\Q˜[ÙJBˆ\WØ˜\ÙNˆİˆ›Û™HHšY[
+Y˜][S›Û™K[X\ÏH‘QTWÓWĞTWĞTÑHŠBˆ^˜WÚXY\œÎˆXİÜİ‹İ—H›Û™HHšY[
+ˆY˜][S›Û™Kˆ[X\ÏH‘QTWÓWÑVWÒPQT”È‹ˆ™\Q˜[ÙKˆ
+B‚‚˜Û\ÜÈÛÛ^Ù][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆˆˆÛÛ^]Ú[™İÈX[˜YÙ[Y[ˆ\‹]ÛÛ[İ]]Ø\È[™\İÜHÛÛ\Xİ[Û‹ˆˆˆ‚‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆ]]×ØÛÛ\Xİˆ›ÛÛHšY[
+Y˜][UYK[X\ÏH”Õ’VĞÓÓ•VĞUU×ĞÓÓTPÕŠBˆÛÛ\XİØY™™\—İÚÙ[œÎˆ[HšY[
+Y˜][LŒÌİL[X\ÏH”Õ’VĞÓÓ•VĞ•Q‘‘T—ÕÒÑS”ÈŠBˆÙY\İÚÙ[œÎˆ[HšY[
+Y˜][NÌİL[X\ÏH”Õ’VĞÓÓ•VÒÑQTÕÒÑS”ÈŠBˆ˜[˜XÚ×ØÛÛ^İÚÙ[œÎˆ[HšY[
+ˆY˜][LŒÌİL[X\ÏH”Õ’VĞÓÓ•VÑSPÒ×ÕÒÑS”È‚ˆ
+Bˆİ[[X\WÛX^İÚÙ[œÎˆ[HšY[
+Y˜][MÌM‹İL[X\ÏH”Õ’VĞÓÓ•VÔÕSSPT–WÕÒÑS”ÈŠBˆÛÛÛİ]]ÛX^İÚÙ[œÎˆ[HšY[
+Y˜][NÌİL[X\ÏH”Õ’VÕÓÓÓÕUUÓPVÕÒÑS”ÈŠBˆÛÛÛİ]]ÛX^Û[™\Îˆ[HšY[
+Y˜][L—ÌİL[X\ÏH”Õ’VÕÓÓÓÕUUÓPVÓS‘TÈŠBˆÈ›ÛÜˆX›İ™HH[˜Ø][Û‹[›İXÙHÚ^™HÛÈH™]šY]È[Ø^\Èš]Ë‚ˆÛÛÛİ]]ÛX^Ø]\Îˆ[HšY[
+ˆY˜][ML
+ˆLÙOLL[X\ÏH”Õ’VÕÓÓÓÕUUÓPVĞ–UTÈ‚ˆ
+B‚‚˜Û\ÜÈ[[YTÙ][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆ[XYÙNˆİˆHšY[
+ˆY˜][H™ÚÜ‹š[Ëİ\Ù\İš^Üİš^\Ø[™›ŞŒKŒËŒ‹ˆ[X\ÏH”Õ’VÒSPQÑH‹ˆ
+Bˆ[XYÙWÜ[ÜÛXŞNˆ]\˜[È˜]]È‹›™]™\ˆ—HHšY[
+ˆY˜][H˜]]È‹ˆ[X\ÏH”Õ’VÒSPQÑWÔSÔÓPÖH‹ˆ
+Bˆ˜XÚÙ[™ˆİˆHšY[
+Y˜][H™ØÚÙ\ˆ‹[X\ÏH”Õ’VÔ•S•SQWĞPÒÑS‘ŠBˆØZY×Ø›ÛİİØZ]ÜÎˆ[HšY[
+Y˜][LÌİL[X\ÏH”Õ’VĞĞRQ×Ğ“ÓÕÕĞRUÔÈŠBˆÈX^ØÜ™Y[œÚİÚ[XYÙHÛÛİ]]ÈÙ\]™H\ˆYÙ[ÛÛ^
+H›Û™JK‚ˆX^ØÛÛ^Ú[XYÙ\Îˆ[HšY[
+Y˜][LËÙOL[X\ÏH”Õ’VÓPVĞÓÓ•VÒSPQÑTÈŠB‚‚˜Û\ÜÈ[[Y]TÙ][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆ[˜X›Yˆ›ÛÛHšY[
+Y˜][UYK[X\ÏH”Õ’VÕSSQU–HŠB‚‚˜Û\ÜÈ[YÜ˜][Û”Ù][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆ\œ^]WØ\WÚÙ^Nˆİˆ›Û™HHšY[
+ˆY˜][S›Û™Kˆ[X\ÏH”T”VUWĞTWÒÑVH‹ˆ™\Q˜[ÙKˆ
+BˆÜİX[—Ø\WÚÙ^Nˆİˆ›Û™HHšY[
+ˆY˜][S›Û™Kˆ[X\ÏH”ÔÕPS—ĞTWÒÑVH‹ˆ™\Q˜[ÙKˆ
+B‚‚˜Û\ÜÈšY]Ù\”Ù][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆÈ˜\ÙHT“ÙˆHİš^™[^HHØØ[šY]Ù\ˆ›ŞY\ÈÈ›Üˆ[XZ[ˆÈ™\šYšXØ][Ûˆ[™[˜Ü\Y™\Ü[]™\KˆHœ›İÜÙ\ˆ™]™\ˆ[ÜÈÂˆÈH™[^H\™XİNÈHØØ[Ù\™\ˆ\ÈHÛ›HØ[\‹‚ˆ\İ\›ˆİˆHšY[
+Y˜][HšÎ‹ËØ\œİš^˜ZH‹[X\ÏH”Õ’VĞTÕT“ŠB‚‚˜Û\ÜÈÙ][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆNˆTÙ][™ÜÈHšY[
+Y˜][Ù˜XİÜOSTÙ][™ÜÊBˆY\NˆY\TÙ][™ÜÈHšY[
+Y˜][Ù˜XİÜOQY\TÙ][™ÜÊBˆ[[YNˆ[[YTÙ][™ÜÈHšY[
+Y˜][Ù˜XİÜOT[[YTÙ][™ÜÊBˆÛÛ^ˆÛÛ^Ù][™ÜÈHšY[
+Y˜][Ù˜XİÜOPÛÛ^Ù][™ÜÊBˆ[[Y]Nˆ[[Y]TÙ][™ÜÈHšY[
+Y˜][Ù˜XİÜOU[[Y]TÙ][™ÜÊBˆ[YÜ˜][ÛœÎˆ[YÜ˜][Û”Ù][™ÜÈHšY[
+Y˜][Ù˜XİÜOR[YÜ˜][Û”Ù][™ÜÊBˆšY]Ù\ˆšY]Ù\”Ù][™ÜÈHšY[
+Y˜][Ù˜XİÜOUšY]Ù\”Ù][™ÜÊB

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -1,60 +1,160 @@
-­r‡^Ñf¥–Ø¦{[r‰İ°ë­¦ëHˆˆ”İš^\XØ][ÛˆÙ][™ÜÈ8 %Y[XË\Ù][™ÜÈİÙ\™Yˆˆˆ‚‚™œ›ÛH×Ù]\™W×È[\Ü[››İ][ÛœÂ‚™œ›ÛH\[™È[\Ü]\˜[‚™œ›ÛHY[XÈ[\Ü[X\ĞÚÚXÙ\ËšY[™œ›ÛHY[X×ÜÙ][™ÜÈ[\Ü˜\ÙTÙ][™ÜËÙ][™ÜĞÛÛ™šYÑXİ‚‚”™X\ÛÛš[™ÑY™›ÜH]\˜[È››Û™H‹›Z[š[X[‹›İÈ‹›YY][H‹šYÚ‹YÚ‹›X^—B‚‘QUSÓPVÕT“”ÈHL‚—ĞTÑWĞÓÓ‘’QÈHÙ][™ÜĞÛÛ™šYÑXİ
-ˆØ\ÙWÜÙ[œÚ]]™OQ˜[ÙKˆÜ[]WØWÛ˜[YOUYKˆ^˜OHšYÛ›Ü™H‹ŠB‚‚˜Û\ÜÈTÙ][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆ[Ù[ˆİˆ›Û™HHšY[
-Y˜][S›Û™K[X\ÏH”Õ’VÓHŠBˆ\WÚÙ^Nˆİˆ›Û™HHšY[
-ˆY˜][S›Û™Kˆ˜[Y][Û—Ø[X\ÏP[X\ĞÚÚXÙ\Ê“WĞTWÒÑVH‹“ÔSRWĞTWÒÑVHŠKˆ™\Q˜[ÙKˆ
-Bˆ\WØ˜\ÙNˆİˆ›Û™HHšY[
-ˆY˜][S›Û™Kˆ˜[Y][Û—Ø[X\ÏP[X\ĞÚÚXÙ\Êˆ“WĞTWĞTÑH‹ˆ“ÔSRWĞTWĞTÑH‹ˆ“ÔSRWĞTÑWÕT“‹ˆ“USWĞTÑWÕT“‹ˆ“ÓSPWĞTWĞTÑH‹ˆ
-Kˆ
-Bˆ^˜WÚXY\œÎˆXİÜİ‹İ—H›Û™HHšY[
-ˆY˜][S›Û™Kˆ[X\ÏH“WÑVWÒPQT”È‹ˆ™\Q˜[ÙKˆ
-Bˆ™X\ÛÛš[™×ÙY™›Üˆ™X\ÛÛš[™ÑY™›ÜHšY[
-Y˜][HšYÚ‹[X\ÏH”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•ŠBˆ›Ü˜ÙWÜ™\]Z\™YİÛÛØÚÚXÙNˆ›ÛÛHšY[
-ˆY˜][Q˜[ÙKˆ[X\ÏH”Õ’VÑ“ÔÑWÔ‘TURT‘QÕÓÓĞÒÒPÑH‹ˆ
-Bˆ›Û\ØØXÚNˆ›ÛÛHšY[
-ˆY˜][UYKˆ[X\ÏH”Õ’VÔ“ÓTĞĞPÒH‹ˆ
-Bˆ\ØX›WÜİ™X[Z[™Îˆ›ÛÛHšY[
-ˆY˜][Q˜[ÙKˆ[X\ÏH“WÑTĞP“WÔÕ‘PSRS‘È‹ˆ
-Bˆ[Y[İ]ˆ[HšY[
-Y˜][LÌ[X\ÏH“WÕSQSÕUŠBˆİ™X[WÚYWİ[Y[İ]ˆ[HšY[
-Y˜][LÌÙOL[X\ÏH“WÔÕ‘PSWÒQWÕSQSÕUŠBˆX^İÛÛØØ[×Ü\—İ\›ˆ[HšY[
-ˆY˜][LÌ‹ˆÙOLˆ[X\ÏH“WÓPVÕÓÓĞĞS×ÔT—ÕT“ˆ‹ˆ
-B‚‚˜Û\ÜÈY\TÙ][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆ[Ù[ˆİˆ›Û™HHšY[
-Y˜][S›Û™K[X\ÏH”Õ’VÑQTWÓSÑSŠBˆ™X\ÛÛš[™×ÙY™›Üˆ™X\ÛÛš[™ÑY™›Ü›Û™HHšY[
-ˆY˜][S›Û™Kˆ[X\ÏH”Õ’VÑQTWÔ‘PTÓÓ’S‘×ÑQ‘“Ô•‹ˆ
-Bˆ\WÚÙ^Nˆİˆ›Û™HHšY[
-Y˜][S›Û™K[X\ÏH‘QTWÓWĞTWÒÑVH‹™\Q˜[ÙJBˆ\WØ˜\ÙNˆİˆ›Û™HHšY[
-Y˜][S›Û™K[X\ÏH‘QTWÓWĞTWĞTÑHŠBˆ^˜WÚXY\œÎˆXİÜİ‹İ—H›Û™HHšY[
-ˆY˜][S›Û™Kˆ[X\ÏH‘QTWÓWÑVWÒPQT”È‹ˆ™\Q˜[ÙKˆ
-B‚‚˜Û\ÜÈÛÛ^Ù][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆˆˆÛÛ^]Ú[™İÈX[˜YÙ[Y[ˆ\‹]ÛÛ[İ]]Ø\È[™\İÜHÛÛ\Xİ[Û‹ˆˆˆ‚‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆ]]×ØÛÛ\Xİˆ›ÛÛHšY[
-Y˜][UYK[X\ÏH”Õ’VĞÓÓ•VĞUU×ĞÓÓTPÕŠBˆÛÛ\XİØY™™\—İÚÙ[œÎˆ[HšY[
-Y˜][LŒÌİL[X\ÏH”Õ’VĞÓÓ•VĞ•Q‘‘T—ÕÒÑS”ÈŠBˆÙY\İÚÙ[œÎˆ[HšY[
-Y˜][NÌİL[X\ÏH”Õ’VĞÓÓ•VÒÑQTÕÒÑS”ÈŠBˆ˜[˜XÚ×ØÛÛ^İÚÙ[œÎˆ[HšY[
-ˆY˜][LŒÌİL[X\ÏH”Õ’VĞÓÓ•VÑSPÒ×ÕÒÑS”È‚ˆ
-Bˆİ[[X\WÛX^İÚÙ[œÎˆ[HšY[
-Y˜][MÌM‹İL[X\ÏH”Õ’VĞÓÓ•VÔÕSSPT–WÕÒÑS”ÈŠBˆÛÛÛİ]]ÛX^İÚÙ[œÎˆ[HšY[
-Y˜][NÌİL[X\ÏH”Õ’VÕÓÓÓÕUUÓPVÕÒÑS”ÈŠBˆÛÛÛİ]]ÛX^Û[™\Îˆ[HšY[
-Y˜][L—ÌİL[X\ÏH”Õ’VÕÓÓÓÕUUÓPVÓS‘TÈŠBˆÈ›ÛÜˆX›İ™HH[˜Ø][Û‹[›İXÙHÚ^™HÛÈH™]šY]È[Ø^\Èš]Ë‚ˆÛÛÛİ]]ÛX^Ø]\Îˆ[HšY[
-ˆY˜][ML
-ˆLÙOLL[X\ÏH”Õ’VÕÓÓÓÕUUÓPVĞ–UTÈ‚ˆ
-B‚‚˜Û\ÜÈ[[YTÙ][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆ[XYÙNˆİˆHšY[
-ˆY˜][H™ÚÜ‹š[Ëİ\Ù\İš^Üİš^\Ø[™›ŞŒKŒËŒ‹ˆ[X\ÏH”Õ’VÒSPQÑH‹ˆ
-Bˆ[XYÙWÜ[ÜÛXŞNˆ]\˜[È˜]]È‹›™]™\ˆ—HHšY[
-ˆY˜][H˜]]È‹ˆ[X\ÏH”Õ’VÒSPQÑWÔSÔÓPÖH‹ˆ
-Bˆ˜XÚÙ[™ˆİˆHšY[
-Y˜][H™ØÚÙ\ˆ‹[X\ÏH”Õ’VÔ•S•SQWĞPÒÑS‘ŠBˆØZY×Ø›ÛİİØZ]ÜÎˆ[HšY[
-Y˜][LÌİL[X\ÏH”Õ’VĞĞRQ×Ğ“ÓÕÕĞRUÔÈŠBˆÈX^ØÜ™Y[œÚİÚ[XYÙHÛÛİ]]ÈÙ\]™H\ˆYÙ[ÛÛ^
-H›Û™JK‚ˆX^ØÛÛ^Ú[XYÙ\Îˆ[HšY[
-Y˜][LËÙOL[X\ÏH”Õ’VÓPVĞÓÓ•VÒSPQÑTÈŠB‚‚˜Û\ÜÈ[[Y]TÙ][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆ[˜X›Yˆ›ÛÛHšY[
-Y˜][UYK[X\ÏH”Õ’VÕSSQU–HŠB‚‚˜Û\ÜÈ[YÜ˜][Û”Ù][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆ\œ^]WØ\WÚÙ^Nˆİˆ›Û™HHšY[
-ˆY˜][S›Û™Kˆ[X\ÏH”T”VUWĞTWÒÑVH‹ˆ™\Q˜[ÙKˆ
-BˆÜİX[—Ø\WÚÙ^Nˆİˆ›Û™HHšY[
-ˆY˜][S›Û™Kˆ[X\ÏH”ÔÕPS—ĞTWÒÑVH‹ˆ™\Q˜[ÙKˆ
-B‚‚˜Û\ÜÈšY]Ù\”Ù][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆÈ˜\ÙHT“ÙˆHİš^™[^HHØØ[šY]Ù\ˆ›ŞY\ÈÈ›Üˆ[XZ[ˆÈ™\šYšXØ][Ûˆ[™[˜Ü\Y™\Ü[]™\KˆHœ›İÜÙ\ˆ™]™\ˆ[ÜÈÂˆÈH™[^H\™XİNÈHØØ[Ù\™\ˆ\ÈHÛ›HØ[\‹‚ˆ\İ\›ˆİˆHšY[
-Y˜][HšÎ‹ËØ\œİš^˜ZH‹[X\ÏH”Õ’VĞTÕT“ŠB‚‚˜Û\ÜÈÙ][™ÜÊ˜\ÙTÙ][™ÜÊN‚ˆ[Ù[ØÛÛ™šYÈHĞTÑWĞÓÓ‘’QÂ‚ˆNˆTÙ][™ÜÈHšY[
-Y˜][Ù˜XİÜOSTÙ][™ÜÊBˆY\NˆY\TÙ][™ÜÈHšY[
-Y˜][Ù˜XİÜOQY\TÙ][™ÜÊBˆ[[YNˆ[[YTÙ][™ÜÈHšY[
-Y˜][Ù˜XİÜOT[[YTÙ][™ÜÊBˆÛÛ^ˆÛÛ^Ù][™ÜÈHšY[
-Y˜][Ù˜XİÜOPÛÛ^Ù][™ÜÊBˆ[[Y]Nˆ[[Y]TÙ][™ÜÈHšY[
-Y˜][Ù˜XİÜOU[[Y]TÙ][™ÜÊBˆ[YÜ˜][ÛœÎˆ[YÜ˜][Û”Ù][™ÜÈHšY[
-Y˜][Ù˜XİÜOR[YÜ˜][Û”Ù][™ÜÊBˆšY]Ù\ˆšY]Ù\”Ù][™ÜÈHšY[
-Y˜][Ù˜XİÜOUšY]Ù\”Ù][™ÜÊB
+"""Strix application settings â€” pydantic-settings powered."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import AliasChoices, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+DEFAULT_MAX_TURNS = 500
+
+_BASE_CONFIG = SettingsConfigDict(
+    case_sensitive=False,
+    populate_by_name=True,
+    extra="ignore",
+)
+
+
+class LlmSettings(BaseSettings):
+    model_config = _BASE_CONFIG
+
+    model: str | None = Field(default=None, alias="STRIX_LLM")
+    api_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("LLM_API_KEY", "OPENAI_API_KEY"),
+        repr=False,
+    )
+    api_base: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "LLM_API_BASE",
+            "OPENAI_API_BASE",
+            "OPENAI_BASE_URL",
+            "LITELLM_BASE_URL",
+            "OLLAMA_API_BASE",
+        ),
+    )
+    extra_headers: dict[str, str] | None = Field(
+        default=None,
+        alias="LLM_EXTRA_HEADERS",
+        repr=False,
+    )
+    reasoning_effort: ReasoningEffort = Field(default="high", alias="STRIX_REASONING_EFFORT")
+    force_required_tool_choice: bool = Field(
+        default=False,
+        alias="STRIX_FORCE_REQUIRED_TOOL_CHOICE",
+    )
+    prompt_cache: bool = Field(
+        default=True,
+        alias="STRIX_PROMPT_CACHE",
+    )
+    disable_streaming: bool = Field(
+        default=False,
+        alias="LLM_DISABLE_STREAMING",
+    )
+    timeout: int = Field(default=300, alias="LLM_TIMEOUT")
+    stream_idle_timeout: int = Field(default=300, ge=0, alias="LLM_STREAM_IDLE_TIMEOUT")
+    max_tool_calls_per_turn: int = Field(
+        default=32,
+        ge=0,
+        alias="LLM_MAX_TOOL_CALLS_PER_TURN",
+    )
+
+
+class DedupeSettings(BaseSettings):
+    model_config = _BASE_CONFIG
+
+    model: str | None = Field(default=None, alias="STRIX_DEDUPE_MODEL")
+    reasoning_effort: ReasoningEffort | None = Field(
+        default=None,
+        alias="STRIX_DEDUPE_REASONING_EFFORT",
+    )
+    api_key: str | None = Field(default=None, alias="DEDUPE_LLM_API_KEY", repr=False)
+    api_base: str | None = Field(default=None, alias="DEDUPE_LLM_API_BASE")
+    extra_headers: dict[str, str] | None = Field(
+        default=None,
+        alias="DEDUPE_LLM_EXTRA_HEADERS",
+        repr=False,
+    )
+
+
+class ContextSettings(BaseSettings):
+    """Context-window management: per-tool-output caps and history compaction."""
+
+    model_config = _BASE_CONFIG
+
+    auto_compact: bool = Field(default=True, alias="STRIX_CONTEXT_AUTO_COMPACT")
+    compact_buffer_tokens: int = Field(default=20_000, gt=0, alias="STRIX_CONTEXT_BUFFER_TOKENS")
+    keep_tokens: int = Field(default=8_000, gt=0, alias="STRIX_CONTEXT_KEEP_TOKENS")
+    fallback_context_tokens: int = Field(
+        default=200_000, gt=0, alias="STRIX_CONTEXT_FALLBACK_TOKENS"
+    )
+    summary_max_tokens: int = Field(default=4_096, gt=0, alias="STRIX_CONTEXT_SUMMARY_TOKENS")
+    tool_output_max_tokens: int = Field(default=8_000, gt=0, alias="STRIX_TOOL_OUTPUT_MAX_TOKENS")
+    tool_output_max_lines: int = Field(default=2_000, gt=0, alias="STRIX_TOOL_OUTPUT_MAX_LINES")
+    # Floor above the truncation-notice size so a preview always fits.
+    tool_output_max_bytes: int = Field(
+        default=50 * 1024, ge=1024, alias="STRIX_TOOL_OUTPUT_MAX_BYTES"
+    )
+
+
+class RuntimeSettings(BaseSettings):
+    model_config = _BASE_CONFIG
+
+    image: str = Field(
+        default="ghcr.io/usestrix/strix-sandbox:1.3.0",
+        alias="STRIX_IMAGE",
+    )
+    image_pull_policy: Literal["auto", "never"] = Field(
+        default="auto",
+        alias="STRIX_IMAGE_PULL_POLICY",
+    )
+    backend: str = Field(default="docker", alias="STRIX_RUNTIME_BACKEND")
+    # Max screenshot/image tool outputs kept live per agent context (0 = none).
+    max_context_images: int = Field(default=3, ge=0, alias="STRIX_MAX_CONTEXT_IMAGES")
+
+
+class TelemetrySettings(BaseSettings):
+    model_config = _BASE_CONFIG
+
+    enabled: bool = Field(default=True, alias="STRIX_TELEMETRY")
+
+
+class IntegrationSettings(BaseSettings):
+    model_config = _BASE_CONFIG
+
+    perplexity_api_key: str | None = Field(
+        default=None,
+        alias="PERPLEXITY_API_KEY",
+        repr=False,
+    )
+    postman_api_key: str | None = Field(
+        default=None,
+        alias="POSTMAN_API_KEY",
+        repr=False,
+    )
+
+
+class ViewerSettings(BaseSettings):
+    model_config = _BASE_CONFIG
+
+    # Base URL of the Strix relay the local viewer proxies to for email
+    # verification and encrypted report delivery. The browser never talks to
+    # the relay directly; the local server is the only caller.
+    app_url: str = Field(default="https://app.strix.ai", alias="STRIX_APP_URL")
+
+
+class Settings(BaseSettings):
+    model_config = _BASE_CONFIG
+
+    llm: LlmSettings = Field(default_factory=LlmSettings)
+    dedupe: DedupeSettings = Field(default_factory=DedupeSettings)
+    runtime: RuntimeSettings = Field(default_factory=RuntimeSettings)
+    context: ContextSettings = Field(default_factory=ContextSettings)
+    telemetry: TelemetrySettings = Field(default_factory=TelemetrySettings)
+    integrations: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    viewer: ViewerSettings = Field(default_factory=ViewerSettings)

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -1,4 +1,4 @@
-"""Strix application settings â€” pydantic-settings powered."""
+­r‡^Ñf¥–Ø¦{O,yÊ'vÃ®¶›­"""Strix application settings â€” pydantic-settings powered."""
 
 from __future__ import annotations
 
@@ -109,7 +109,12 @@ class RuntimeSettings(BaseSettings):
         default="ghcr.io/usestrix/strix-sandbox:1.3.0",
         alias="STRIX_IMAGE",
     )
+    image_pull_policy: Literal["auto", "never"] = Field(
+        default="auto",
+        alias="STRIX_IMAGE_PULL_POLICY",
+    )
     backend: str = Field(default="docker", alias="STRIX_RUNTIME_BACKEND")
+    caido_boot_wait_s: int = Field(default=300, gt=0, alias="STRIX_CAIDO_BOOT_WAIT_S")
     # Max screenshot/image tool outputs kept live per agent context (0 = none).
     max_context_images: int = Field(default=3, ge=0, alias="STRIX_MAX_CONTEXT_IMAGES")
 

--- a/strix/interface/environment.py
+++ b/strix/interface/environment.py
@@ -1,217 +1,115 @@
-"""Startup environment validation and Docker image management."""
+­r‡^Ñf¥–Ø¦{[r‰Ý°ë­¦ëHˆˆ”Ý\\[š\›Û›Y[˜[Y][Ûˆ[™ØÚÙ\ˆ[XYÙHX[˜YÙ[Y[ˆˆˆ‚‚š[\ÜÙÙÚ[™Âš[\ÜÚ][š[\ÜÞ\Â‚™œ›ÛHšXÚ˜ÛÛœÛÛH[\ÜÛÛœÛÛB™œ›ÛHšXÚœ[™[[\Ü[™[™œ›ÛHšXÚ^[\Ü^‚™œ›ÛHÝš^˜ÛÛ™šYÈ[\ÜÛÙ^ØYÜÙ][™ÜÂ™œ›ÛHÝš^š[\™˜XÙK][È[\Ü
+ˆÚXÚ×ÙØÚÙ\—ØÛÛ›™XÝ[Û‹ˆ[XYÙWÙ^\ÝËˆ›ØÙ\Ü×Ü[Û[™KŠB‚‚›ÙÙÙ\ˆHÙÙÚ[™Ë™Ù]ÙÙÙ\Š×Û˜[YW×ÊB‚‚™Yˆ˜[Y]WÙ[š\›Û›Y[
 
-import logging
-import shutil
-import sys
+HOˆ›Û™N‚ˆÙÙÙ\‹š[™›Ê•˜[Y][™È[š\›Û›Y[ŠBˆÛÛœÛÛHHÛÛœÛÛJ
+BˆZ\ÜÚ[™×Ü™\]Z\™YÝ˜\œÈH×BˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÈH×B‚ˆÙ][™ÜÈHØYÜÙ][™ÜÊ
+B‚ˆYˆÛÙ^œÝXœØÜš\[Û—Û[Ù[
+Ù][™ÜË›K›[Ù[
+N‚ˆYˆ›ÝÛÙ^š\×Ø]][XØ]Y
 
-from rich.console import Console
-from rich.panel import Panel
-from rich.text import Text
+N‚ˆÛÛœÛÛKœš[
+ˆˆ–Ü™YTÕ’VÓO^ÜÙ][™ÜË›K›[Ù[H\Ù\È[Ý\ˆÚ]ÔÝXœØÜš\[Û‹‚ˆ˜][ÝIÜ™H›ÝÚYÛ™Y[‹–Ë×H[ˆØÞX[—\Ýš^]]ÙÚ[ˆÚ]ÜË×Hš\œÝˆ‚ˆ
+BˆÞ\Ë™^]
+JBˆÙÙÙ\‹š[™›Ê‘[š\›Û›Y[ÒÈ
+Ú]ÔÝXœØÜš\[ÛŠHŠBˆ™]\›‚‚ˆYˆ›ÝÙ][™ÜË›K›[Ù[‚ˆZ\ÜÚ[™×Ü™\]Z\™YÝ˜\œË˜\[™
+”Õ’VÓHŠB‚ˆYˆ›ÝÙ][™ÜË›K˜\WÚÙ^N‚ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œË˜\[™
+“WÐTWÒÑVHŠB‚ˆYˆ›ÝÙ][™ÜË›K˜\WØ˜\ÙN‚ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œË˜\[™
+“WÐTWÐTÑHŠB‚ˆYˆ›ÝÙ][™ÜËš[YÜ˜][ÛœËœ\œ^]WØ\WÚÙ^N‚ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œË˜\[™
+”T”VUWÐTWÒÑVHŠB‚ˆYˆZ\ÜÚ[™×Ü™\]Z\™YÝ˜\œÎ‚ˆ\œ›Ü—Ý^H^
 
-from strix.config import codex, load_settings
-from strix.interface.utils import (
-    check_docker_connection,
-    image_exists,
-    process_pull_line,
-)
+Bˆ\œ›Ü—Ý^˜\[™
+“RTÔÒS‘È‘TURT‘QS•’T“Ó“QS•T’PP“TÈ‹Ý[OH˜›Û™YŠBˆ\œ›Ü—Ý^˜\[™
+——ˆ‹Ý[OHÚ]HŠB‚ˆ›Üˆ˜\ˆ[ˆZ\ÜÚ[™×Ü™\]Z\™YÝ˜\œÎ‚ˆ\œ›Ü—Ý^˜\[™
+ˆ¸ (ˆÝ˜\ŸH‹Ý[OH˜›ÛY[ÝÈŠBˆ\œ›Ü—Ý^˜\[™
+ˆ\È›ÝÙ]ˆ‹Ý[OHÚ]HŠB‚ˆYˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÎ‚ˆ\œ›Ü—Ý^˜\[™
+—“Ü[Û˜[[š\›Û›Y[˜\šXX›\Î—ˆ‹Ý[OH™[HÚ]HŠBˆ›Üˆ˜\ˆ[ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÎ‚ˆ\œ›Ü—Ý^˜\[™
+ˆ¸ (ˆÝ˜\ŸH‹Ý[OH™[HY[ÝÈŠBˆ\œ›Ü—Ý^˜\[™
+ˆ\È›ÝÙ]ˆ‹Ý[OH™[HÚ]HŠB‚ˆ\œ›Ü—Ý^˜\[™
+—”™\]Z\™Y[š\›Û›Y[˜\šXX›\Î—ˆ‹Ý[OHÚ]HŠBˆ›Üˆ˜\ˆ[ˆZ\ÜÚ[™×Ü™\]Z\™YÝ˜\œÎ‚ˆYˆ˜\ˆOH”Õ’VÓHŽ‚ˆ\œ›Ü—Ý^˜\[™
+¸ (ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
+”Õ’VÓH‹Ý[OH˜›ÛÞX[ˆŠBˆ\œ›Ü—Ý^˜\[™
+ˆˆH[Ù[˜[YHÈ\ÙH
+K™Ë‹	ÛÜ[˜ZKÙÜMK	ÈÜˆ‚ˆ‰Ø[›ÜXËØÛ]YK[Ü\ËMMÉÊWˆ‹ˆÝ[OHÚ]H‹ˆ
+B‚ˆYˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÎ‚ˆ\œ›Ü—Ý^˜\[™
+—“Ü[Û˜[[š\›Û›Y[˜\šXX›\Î—ˆ‹Ý[OHÚ]HŠBˆ›Üˆ˜\ˆ[ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÎ‚ˆYˆ˜\ˆOH“WÐTWÐTÑHŽ‚ˆ\œ›Ü—Ý^˜\[™
+¸ (ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
+“WÐTWÐTÑH‹Ý[OH˜›ÛÞX[ˆŠBˆ\œ›Ü—Ý^˜\[™
+ˆˆHÝ\ÝÛHTH˜\ÙHT“Yˆ\Ú[™ÈØØ[[Ù[È
+K™Ë‹Û[XKTÝY[ÊWˆ‹ˆÝ[OHÚ]H‹ˆ
+Bˆ[Yˆ˜\ˆOH”T”VUWÐTWÒÑVHŽ‚ˆ\œ›Ü—Ý^˜\[™
+¸ (ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
+”T”VUWÐTWÒÑVH‹Ý[OH˜›ÛÞX[ˆŠBˆ\œ›Ü—Ý^˜\[™
+ˆˆHTHÙ^H›Üˆ\œ^]HRHÙXˆÙX\˜Ú
+[˜X›\È™X[][YH™\ÙX\˜Ú
+Wˆ‹ˆÝ[OHÚ]H‹ˆ
+Bˆ[Yˆ˜\ˆOH”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•Ž‚ˆ\œ›Ü—Ý^˜\[™
+¸ (ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
+”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•‹Ý[OH˜›ÛÞX[ˆŠBˆ\œ›Ü—Ý^˜\[™
+ˆˆH™X\ÛÛš[™ÈY™›Ü]™[ˆ›Û™KZ[š[X[ÝËYY][KYÚYÚ‚ˆ›X^
+Y˜][ˆYÚ
+Wˆ‹ˆÝ[OHÚ]H‹ˆ
+B‚ˆ\œ›Ü—Ý^˜\[™
+—‘^[\HÙ]\—ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
+™^ÜÕ’VÓOIÛÜ[˜ZKÙÜMK	×ˆ‹Ý[OH™[HÚ]HŠB‚ˆYˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÎ‚ˆ›Üˆ˜\ˆ[ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÎ‚ˆYˆ˜\ˆOH“WÐTWÐTÑHŽ‚ˆ\œ›Ü—Ý^˜\[™
+ˆ™^ÜWÐTWÐTÑOIÚ‹ËÛØØ[ÜÝŒLMÍ	È‚ˆˆÈ™YYY›ÜˆØØ[[Ù[ÈÛ›Wˆ‹ˆÝ[OH™[HÚ]H‹ˆ
+Bˆ[Yˆ˜\ˆOH”T”VUWÐTWÒÑVHŽ‚ˆ\œ›Ü—Ý^˜\[™
+ˆ™^ÜT”VUWÐTWÒÑVOIÞ[Ý\‹\\œ^]KZÙ^KZ\™I×ˆ‹Ý[OH™[HÚ]H‚ˆ
+Bˆ[Yˆ˜\ˆOH”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•Ž‚ˆ\œ›Ü—Ý^˜\[™
+ˆ™^ÜÕ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•IÚYÚ	×ˆ‹ˆÝ[OH™[HÚ]H‹ˆ
+B‚ˆ[™[H[™[
+ˆ\œ›Ü—Ý^ˆ]OH–Ø›ÛÚ]WTÕ’V‹ˆ]WØ[YÛH›Y‹ˆ›Ü™\—ÜÝ[OHœ™Y‹ˆY[™ÏJKŠKˆ
+B‚ˆÙÙÙ\‹™XYÊ“Z\ÜÚ[™È™\]Z\™Y[ˆ˜\œÎˆ	\È‹Z\ÜÚ[™×Ü™\]Z\™YÝ˜\œÊBˆÛÛœÛÛKœš[
+—ˆŠBˆÛÛœÛÛKœš[
+[™[
+BˆÛÛœÛÛKœš[
 
+BˆÞ\Ë™^]
+JBˆÙÙÙ\‹š[™›Êˆ‘[š\›Û›Y[ÒÈ
+Ü[Û˜[Z\ÜÚ[™Îˆ	\ÊH‹ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÈÜˆ››Û™H‹ˆ
+B‚‚™YˆÚXÚ×ÙØÚÙ\—Ú[œÝ[Y
 
-logger = logging.getLogger(__name__)
+HOˆ›Û™N‚ˆYˆÚ][ÚXÚ
+™ØÚÙ\ˆŠH\È›Û™N‚ˆÙÙÙ\‹™XYÊ‘ØÚÙ\ˆÓH›Ý›Ý[™[ˆUŠBˆÛÛœÛÛHHÛÛœÛÛJ
+Bˆ\œ›Ü—Ý^H^
 
+Bˆ\œ›Ü—Ý^˜\[™
+‘ÐÒÑTˆ“ÕS”ÕSQ‹Ý[OH˜›Û™YŠBˆ\œ›Ü—Ý^˜\[™
+——ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
+•H	ÙØÚÙ\‰ÈÓHØ\È›Ý›Ý[™[ˆ[Ý\ˆU—ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
+ˆ”X\ÙH[œÝ[ØÚÙ\ˆ[™[œÝ\™HH	ÙØÚÙ\‰ÈÛÛ[X[™\È]˜Z[X›K——ˆ‹Ý[OHÚ]H‚ˆ
+B‚ˆ[™[H[™[
+ˆ\œ›Ü—Ý^ˆ]OH–Ø›ÛÚ]WTÕ’V‹ˆ]WØ[YÛH›Y‹ˆ›Ü™\—ÜÝ[OHœ™Y‹ˆY[™ÏJKŠKˆ
+BˆÛÛœÛÛKœš[
+—ˆ‹[™[—ˆŠBˆÞ\Ë™^]
+JBˆÙÙÙ\‹™XYÊ‘ØÚÙ\ˆÓH™\Ù[ŠB‚‚™Yˆ[ÙØÚÙ\—Ú[XYÙJ
+HOˆ›Û™N‚ˆœ›ÛHØÚÙ\‹™\œ›ÜœÈ[\ÜØÚÙ\‘^Ù\[Û‚‚ˆÛÛœÛÛHHÛÛœÛÛJ
+BˆÛY[HÚXÚ×ÙØÚÙ\—ØÛÛ›™XÝ[ÛŠ
+B‚ˆ[[YHHØYÜÙ][™ÜÊ
+Kœ[[YBˆ[XYÙHH[[YKš[XYÙB‚ˆYˆ[XYÙWÙ^\ÝÊÛY[[XYÙJN‚ˆÙÙÙ\‹™XYÊ‘ØÚÙ\ˆ[XYÙH[™XYH™\Ù[ØØ[Nˆ	\È‹[XYÙJBˆ™]\›‚‚ˆYˆ[[YKš[XYÙWÜ[ÜÛXÞHOH›™]™\ˆŽ‚ˆ˜Z\ÙH[[YQ\œ›ÜŠˆˆ‘ØÚÙ\ˆ[XYÙHÚ[XYÙH\ŸH\È›Ý]˜Z[X›HØØ[H[™‚ˆ”Õ’VÒSPQÑWÔSÔÓPÖO[™]™\ˆ›Ü˜šYÈ[[™È]‚ˆ
+B‚ˆÙÙÙ\‹š[™›Ê”[[™ÈØÚÙ\ˆ[XYÙNˆ	\È‹[XYÙJBˆÛÛœÛÛKœš[
 
-def validate_environment() -> None:
-    logger.info("Validating environment")
-    console = Console()
-    missing_required_vars = []
-    missing_optional_vars = []
+BˆÛÛœÛÛKœš[
+ˆ–Ù[WT[[™È[XYÙVË×HÚ[XYÙ_HŠBˆÛÛœÛÛKœš[
+–Ù[HY[Ý×U\ÈÛ›H\[œÈÛˆš\œÝ[ˆ[™X^HZÙHH™]ÈZ[]\Ë‹‹–Ë×HŠBˆÛÛœÛÛKœš[
 
-    settings = load_settings()
+B‚ˆÚ]ÛÛœÛÛKœÝ]\Ê–Ø›ÛÞX[—QÝÛ›ØY[™È[XYÙH^Y\œË‹‹ˆ‹Ü[›™\H™ÝÈŠH\ÈÝ]\Î‚ˆžN‚ˆ^Y\œ×Ú[™›ÎˆXÝÜÝ‹Ý—HHßBˆ\ÝÝ\]HHˆ‚‚ˆ›Üˆ[™H[ˆÛY[˜\Kœ[
+[XYÙKÝ™X[OUYKXÛÙOUYJN‚ˆ\ÝÝ\]HH›ØÙ\Ü×Ü[Û[™J[™K^Y\œ×Ú[™›ËÝ]\Ë\ÝÝ\]JB‚ˆ^Ù\ØÚÙ\‘^Ù\[Ûˆ\ÈN‚ˆÙÙÙ\‹™XYÊ‘˜Z[YÈ[ØÚÙ\ˆ[XYÙH	\È‹[XYÙK^×Ú[™›ÏUYJBˆÛÛœÛÛKœš[
 
-    if codex.subscription_model(settings.llm.model):
-        if not codex.is_authenticated():
-            console.print(
-                f"[red]STRIX_LLM={settings.llm.model} uses your ChatGPT subscription, "
-                "but you're not signed in.[/] Run [cyan]strix auth login chatgpt[/] first."
-            )
-            sys.exit(1)
-        logger.info("Environment OK (ChatGPT subscription)")
-        return
+Bˆ\œ›Ü—Ý^H^
 
-    if not settings.llm.model:
-        missing_required_vars.append("STRIX_LLM")
+Bˆ\œ›Ü—Ý^˜\[™
+‘RSQÈSSPQÑH‹Ý[OH˜›Û™YŠBˆ\œ›Ü—Ý^˜\[™
+——ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
+ˆÛÝ[›ÝÝÛ›ØYˆÚ[XYÙ_Wˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
+ÝŠJKÝ[OH™[H™YŠB‚ˆ[™[H[™[
+ˆ\œ›Ü—Ý^ˆ]OH–Ø›ÛÚ]WTÕ’V‹ˆ]WØ[YÛH›Y‹ˆ›Ü™\—ÜÝ[OHœ™Y‹ˆY[™ÏJKŠKˆ
+BˆÛÛœÛÛKœš[
+[™[—ˆŠBˆÞ\Ë™^]
+JB‚ˆÙÙÙ\‹š[™›Ê‘ØÚÙ\ˆ[XYÙH	\È™XYH‹[XYÙJBˆÝXØÙ\Ü×Ý^H^
 
-    if not settings.llm.api_key:
-        missing_optional_vars.append("LLM_API_KEY")
+BˆÝXØÙ\Ü×Ý^˜\[™
+‘ØÚÙ\ˆ[XYÙH™XYH‹Ý[OHˆÌŒ˜ÍMYHŠBˆÛÛœÛÛKœš[
+ÝXØÙ\Ü×Ý^
+BˆÛÛœÛÛKœš[
 
-    if not settings.llm.api_base:
-        missing_optional_vars.append("LLM_API_BASE")
-
-    if not settings.integrations.perplexity_api_key:
-        missing_optional_vars.append("PERPLEXITY_API_KEY")
-
-    if missing_required_vars:
-        error_text = Text()
-        error_text.append("MISSING REQUIRED ENVIRONMENT VARIABLES", style="bold red")
-        error_text.append("\n\n", style="white")
-
-        for var in missing_required_vars:
-            error_text.append(f"â€¢ {var}", style="bold yellow")
-            error_text.append(" is not set\n", style="white")
-
-        if missing_optional_vars:
-            error_text.append("\nOptional environment variables:\n", style="dim white")
-            for var in missing_optional_vars:
-                error_text.append(f"â€¢ {var}", style="dim yellow")
-                error_text.append(" is not set\n", style="dim white")
-
-        error_text.append("\nRequired environment variables:\n", style="white")
-        for var in missing_required_vars:
-            if var == "STRIX_LLM":
-                error_text.append("â€¢ ", style="white")
-                error_text.append("STRIX_LLM", style="bold cyan")
-                error_text.append(
-                    " - Model name to use (e.g., 'openai/gpt-5.4' or "
-                    "'anthropic/claude-opus-4-7')\n",
-                    style="white",
-                )
-
-        if missing_optional_vars:
-            error_text.append("\nOptional environment variables:\n", style="white")
-            for var in missing_optional_vars:
-                if var == "LLM_API_BASE":
-                    error_text.append("â€¢ ", style="white")
-                    error_text.append("LLM_API_BASE", style="bold cyan")
-                    error_text.append(
-                        " - Custom API base URL if using local models (e.g., Ollama, LMStudio)\n",
-                        style="white",
-                    )
-                elif var == "PERPLEXITY_API_KEY":
-                    error_text.append("â€¢ ", style="white")
-                    error_text.append("PERPLEXITY_API_KEY", style="bold cyan")
-                    error_text.append(
-                        " - API key for Perplexity AI web search (enables real-time research)\n",
-                        style="white",
-                    )
-                elif var == "STRIX_REASONING_EFFORT":
-                    error_text.append("â€¢ ", style="white")
-                    error_text.append("STRIX_REASONING_EFFORT", style="bold cyan")
-                    error_text.append(
-                        " - Reasoning effort level: none, minimal, low, medium, high, xhigh, "
-                        "max (default: high)\n",
-                        style="white",
-                    )
-
-        error_text.append("\nExample setup:\n", style="white")
-        error_text.append("export STRIX_LLM='openai/gpt-5.4'\n", style="dim white")
-
-        if missing_optional_vars:
-            for var in missing_optional_vars:
-                if var == "LLM_API_BASE":
-                    error_text.append(
-                        "export LLM_API_BASE='http://localhost:11434'  "
-                        "# needed for local models only\n",
-                        style="dim white",
-                    )
-                elif var == "PERPLEXITY_API_KEY":
-                    error_text.append(
-                        "export PERPLEXITY_API_KEY='your-perplexity-key-here'\n", style="dim white"
-                    )
-                elif var == "STRIX_REASONING_EFFORT":
-                    error_text.append(
-                        "export STRIX_REASONING_EFFORT='high'\n",
-                        style="dim white",
-                    )
-
-        panel = Panel(
-            error_text,
-            title="[bold white]STRIX",
-            title_align="left",
-            border_style="red",
-            padding=(1, 2),
-        )
-
-        logger.debug("Missing required env vars: %s", missing_required_vars)
-        console.print("\n")
-        console.print(panel)
-        console.print()
-        sys.exit(1)
-    logger.info(
-        "Environment OK (optional missing: %s)",
-        missing_optional_vars or "none",
-    )
-
-
-def check_docker_installed() -> None:
-    if shutil.which("docker") is None:
-        logger.debug("Docker CLI not found in PATH")
-        console = Console()
-        error_text = Text()
-        error_text.append("DOCKER NOT INSTALLED", style="bold red")
-        error_text.append("\n\n", style="white")
-        error_text.append("The 'docker' CLI was not found in your PATH.\n", style="white")
-        error_text.append(
-            "Please install Docker and ensure the 'docker' command is available.\n\n", style="white"
-        )
-
-        panel = Panel(
-            error_text,
-            title="[bold white]STRIX",
-            title_align="left",
-            border_style="red",
-            padding=(1, 2),
-        )
-        console.print("\n", panel, "\n")
-        sys.exit(1)
-    logger.debug("Docker CLI present")
-
-
-def pull_docker_image() -> None:
-    from docker.errors import DockerException
-
-    console = Console()
-    client = check_docker_connection()
-
-    image = load_settings().runtime.image
-
-    if image_exists(client, image):
-        logger.debug("Docker image already present locally: %s", image)
-        return
-
-    logger.info("Pulling docker image: %s", image)
-    console.print()
-    console.print(f"[dim]Pulling image[/] {image}")
-    console.print("[dim yellow]This only happens on first run and may take a few minutes...[/]")
-    console.print()
-
-    with console.status("[bold cyan]Downloading image layers...", spinner="dots") as status:
-        try:
-            layers_info: dict[str, str] = {}
-            last_update = ""
-
-            for line in client.api.pull(image, stream=True, decode=True):
-                last_update = process_pull_line(line, layers_info, status, last_update)
-
-        except DockerException as e:
-            logger.debug("Failed to pull docker image %s", image, exc_info=True)
-            console.print()
-            error_text = Text()
-            error_text.append("FAILED TO PULL IMAGE", style="bold red")
-            error_text.append("\n\n", style="white")
-            error_text.append(f"Could not download: {image}\n", style="white")
-            error_text.append(str(e), style="dim red")
-
-            panel = Panel(
-                error_text,
-                title="[bold white]STRIX",
-                title_align="left",
-                border_style="red",
-                padding=(1, 2),
-            )
-            console.print(panel, "\n")
-            sys.exit(1)
-
-    logger.info("Docker image %s ready", image)
-    success_text = Text()
-    success_text.append("Docker image ready", style="#22c55e")
-    console.print(success_text)
-    console.print()
+B

--- a/strix/interface/environment.py
+++ b/strix/interface/environment.py
@@ -1,115 +1,224 @@
-­r‡^Ñf¥–Ø¦{[r‰Ý°ë­¦ëHˆˆ”Ý\\[š\›Û›Y[˜[Y][Ûˆ[™ØÚÙ\ˆ[XYÙHX[˜YÙ[Y[ˆˆˆ‚‚š[\ÜÙÙÚ[™Âš[\ÜÚ][š[\ÜÞ\Â‚™œ›ÛHšXÚ˜ÛÛœÛÛH[\ÜÛÛœÛÛB™œ›ÛHšXÚœ[™[[\Ü[™[™œ›ÛHšXÚ^[\Ü^‚™œ›ÛHÝš^˜ÛÛ™šYÈ[\ÜÛÙ^ØYÜÙ][™ÜÂ™œ›ÛHÝš^š[\™˜XÙK][È[\Ü
-ˆÚXÚ×ÙØÚÙ\—ØÛÛ›™XÝ[Û‹ˆ[XYÙWÙ^\ÝËˆ›ØÙ\Ü×Ü[Û[™KŠB‚‚›ÙÙÙ\ˆHÙÙÚ[™Ë™Ù]ÙÙÙ\Š×Û˜[YW×ÊB‚‚™Yˆ˜[Y]WÙ[š\›Û›Y[
+­r‡^Ñf¥–Ø¦{O,yÊ'vÃ®¶›­"""Startup environment validation and Docker image management."""
 
-HOˆ›Û™N‚ˆÙÙÙ\‹š[™›Ê•˜[Y][™È[š\›Û›Y[ŠBˆÛÛœÛÛHHÛÛœÛÛJ
-BˆZ\ÜÚ[™×Ü™\]Z\™YÝ˜\œÈH×BˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÈH×B‚ˆÙ][™ÜÈHØYÜÙ][™ÜÊ
-B‚ˆYˆÛÙ^œÝXœØÜš\[Û—Û[Ù[
-Ù][™ÜË›K›[Ù[
-N‚ˆYˆ›ÝÛÙ^š\×Ø]][XØ]Y
+import logging
+import shutil
+import sys
 
-N‚ˆÛÛœÛÛKœš[
-ˆˆ–Ü™YTÕ’VÓO^ÜÙ][™ÜË›K›[Ù[H\Ù\È[Ý\ˆÚ]ÔÝXœØÜš\[Û‹‚ˆ˜][ÝIÜ™H›ÝÚYÛ™Y[‹–Ë×H[ˆØÞX[—\Ýš^]]ÙÚ[ˆÚ]ÜË×Hš\œÝˆ‚ˆ
-BˆÞ\Ë™^]
-JBˆÙÙÙ\‹š[™›Ê‘[š\›Û›Y[ÒÈ
-Ú]ÔÝXœØÜš\[ÛŠHŠBˆ™]\›‚‚ˆYˆ›ÝÙ][™ÜË›K›[Ù[‚ˆZ\ÜÚ[™×Ü™\]Z\™YÝ˜\œË˜\[™
-”Õ’VÓHŠB‚ˆYˆ›ÝÙ][™ÜË›K˜\WÚÙ^N‚ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œË˜\[™
-“WÐTWÒÑVHŠB‚ˆYˆ›ÝÙ][™ÜË›K˜\WØ˜\ÙN‚ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œË˜\[™
-“WÐTWÐTÑHŠB‚ˆYˆ›ÝÙ][™ÜËš[YÜ˜][ÛœËœ\œ^]WØ\WÚÙ^N‚ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œË˜\[™
-”T”VUWÐTWÒÑVHŠB‚ˆYˆZ\ÜÚ[™×Ü™\]Z\™YÝ˜\œÎ‚ˆ\œ›Ü—Ý^H^
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
 
-Bˆ\œ›Ü—Ý^˜\[™
-“RTÔÒS‘È‘TURT‘QS•’T“Ó“QS•T’PP“TÈ‹Ý[OH˜›Û™YŠBˆ\œ›Ü—Ý^˜\[™
-——ˆ‹Ý[OHÚ]HŠB‚ˆ›Üˆ˜\ˆ[ˆZ\ÜÚ[™×Ü™\]Z\™YÝ˜\œÎ‚ˆ\œ›Ü—Ý^˜\[™
-ˆ¸ (ˆÝ˜\ŸH‹Ý[OH˜›ÛY[ÝÈŠBˆ\œ›Ü—Ý^˜\[™
-ˆ\È›ÝÙ]ˆ‹Ý[OHÚ]HŠB‚ˆYˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÎ‚ˆ\œ›Ü—Ý^˜\[™
-—“Ü[Û˜[[š\›Û›Y[˜\šXX›\Î—ˆ‹Ý[OH™[HÚ]HŠBˆ›Üˆ˜\ˆ[ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÎ‚ˆ\œ›Ü—Ý^˜\[™
-ˆ¸ (ˆÝ˜\ŸH‹Ý[OH™[HY[ÝÈŠBˆ\œ›Ü—Ý^˜\[™
-ˆ\È›ÝÙ]ˆ‹Ý[OH™[HÚ]HŠB‚ˆ\œ›Ü—Ý^˜\[™
-—”™\]Z\™Y[š\›Û›Y[˜\šXX›\Î—ˆ‹Ý[OHÚ]HŠBˆ›Üˆ˜\ˆ[ˆZ\ÜÚ[™×Ü™\]Z\™YÝ˜\œÎ‚ˆYˆ˜\ˆOH”Õ’VÓHŽ‚ˆ\œ›Ü—Ý^˜\[™
-¸ (ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
-”Õ’VÓH‹Ý[OH˜›ÛÞX[ˆŠBˆ\œ›Ü—Ý^˜\[™
-ˆˆH[Ù[˜[YHÈ\ÙH
-K™Ë‹	ÛÜ[˜ZKÙÜMK	ÈÜˆ‚ˆ‰Ø[›ÜXËØÛ]YK[Ü\ËMMÉÊWˆ‹ˆÝ[OHÚ]H‹ˆ
-B‚ˆYˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÎ‚ˆ\œ›Ü—Ý^˜\[™
-—“Ü[Û˜[[š\›Û›Y[˜\šXX›\Î—ˆ‹Ý[OHÚ]HŠBˆ›Üˆ˜\ˆ[ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÎ‚ˆYˆ˜\ˆOH“WÐTWÐTÑHŽ‚ˆ\œ›Ü—Ý^˜\[™
-¸ (ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
-“WÐTWÐTÑH‹Ý[OH˜›ÛÞX[ˆŠBˆ\œ›Ü—Ý^˜\[™
-ˆˆHÝ\ÝÛHTH˜\ÙHT“Yˆ\Ú[™ÈØØ[[Ù[È
-K™Ë‹Û[XKTÝY[ÊWˆ‹ˆÝ[OHÚ]H‹ˆ
-Bˆ[Yˆ˜\ˆOH”T”VUWÐTWÒÑVHŽ‚ˆ\œ›Ü—Ý^˜\[™
-¸ (ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
-”T”VUWÐTWÒÑVH‹Ý[OH˜›ÛÞX[ˆŠBˆ\œ›Ü—Ý^˜\[™
-ˆˆHTHÙ^H›Üˆ\œ^]HRHÙXˆÙX\˜Ú
-[˜X›\È™X[][YH™\ÙX\˜Ú
-Wˆ‹ˆÝ[OHÚ]H‹ˆ
-Bˆ[Yˆ˜\ˆOH”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•Ž‚ˆ\œ›Ü—Ý^˜\[™
-¸ (ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
-”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•‹Ý[OH˜›ÛÞX[ˆŠBˆ\œ›Ü—Ý^˜\[™
-ˆˆH™X\ÛÛš[™ÈY™›Ü]™[ˆ›Û™KZ[š[X[ÝËYY][KYÚYÚ‚ˆ›X^
-Y˜][ˆYÚ
-Wˆ‹ˆÝ[OHÚ]H‹ˆ
-B‚ˆ\œ›Ü—Ý^˜\[™
-—‘^[\HÙ]\—ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
-™^ÜÕ’VÓOIÛÜ[˜ZKÙÜMK	×ˆ‹Ý[OH™[HÚ]HŠB‚ˆYˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÎ‚ˆ›Üˆ˜\ˆ[ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÎ‚ˆYˆ˜\ˆOH“WÐTWÐTÑHŽ‚ˆ\œ›Ü—Ý^˜\[™
-ˆ™^ÜWÐTWÐTÑOIÚ‹ËÛØØ[ÜÝŒLMÍ	È‚ˆˆÈ™YYY›ÜˆØØ[[Ù[ÈÛ›Wˆ‹ˆÝ[OH™[HÚ]H‹ˆ
-Bˆ[Yˆ˜\ˆOH”T”VUWÐTWÒÑVHŽ‚ˆ\œ›Ü—Ý^˜\[™
-ˆ™^ÜT”VUWÐTWÒÑVOIÞ[Ý\‹\\œ^]KZÙ^KZ\™I×ˆ‹Ý[OH™[HÚ]H‚ˆ
-Bˆ[Yˆ˜\ˆOH”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•Ž‚ˆ\œ›Ü—Ý^˜\[™
-ˆ™^ÜÕ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•IÚYÚ	×ˆ‹ˆÝ[OH™[HÚ]H‹ˆ
-B‚ˆ[™[H[™[
-ˆ\œ›Ü—Ý^ˆ]OH–Ø›ÛÚ]WTÕ’V‹ˆ]WØ[YÛH›Y‹ˆ›Ü™\—ÜÝ[OHœ™Y‹ˆY[™ÏJKŠKˆ
-B‚ˆÙÙÙ\‹™XYÊ“Z\ÜÚ[™È™\]Z\™Y[ˆ˜\œÎˆ	\È‹Z\ÜÚ[™×Ü™\]Z\™YÝ˜\œÊBˆÛÛœÛÛKœš[
-—ˆŠBˆÛÛœÛÛKœš[
-[™[
-BˆÛÛœÛÛKœš[
+from strix.config import codex, load_settings
+from strix.interface.utils import (
+    check_docker_connection,
+    image_exists,
+    process_pull_line,
+)
 
-BˆÞ\Ë™^]
-JBˆÙÙÙ\‹š[™›Êˆ‘[š\›Û›Y[ÒÈ
-Ü[Û˜[Z\ÜÚ[™Îˆ	\ÊH‹ˆZ\ÜÚ[™×ÛÜ[Û˜[Ý˜\œÈÜˆ››Û™H‹ˆ
-B‚‚™YˆÚXÚ×ÙØÚÙ\—Ú[œÝ[Y
 
-HOˆ›Û™N‚ˆYˆÚ][ÚXÚ
-™ØÚÙ\ˆŠH\È›Û™N‚ˆÙÙÙ\‹™XYÊ‘ØÚÙ\ˆÓH›Ý›Ý[™[ˆUŠBˆÛÛœÛÛHHÛÛœÛÛJ
-Bˆ\œ›Ü—Ý^H^
+logger = logging.getLogger(__name__)
 
-Bˆ\œ›Ü—Ý^˜\[™
-‘ÐÒÑTˆ“ÕS”ÕSQ‹Ý[OH˜›Û™YŠBˆ\œ›Ü—Ý^˜\[™
-——ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
-•H	ÙØÚÙ\‰ÈÓHØ\È›Ý›Ý[™[ˆ[Ý\ˆU—ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
-ˆ”X\ÙH[œÝ[ØÚÙ\ˆ[™[œÝ\™HH	ÙØÚÙ\‰ÈÛÛ[X[™\È]˜Z[X›K——ˆ‹Ý[OHÚ]H‚ˆ
-B‚ˆ[™[H[™[
-ˆ\œ›Ü—Ý^ˆ]OH–Ø›ÛÚ]WTÕ’V‹ˆ]WØ[YÛH›Y‹ˆ›Ü™\—ÜÝ[OHœ™Y‹ˆY[™ÏJKŠKˆ
-BˆÛÛœÛÛKœš[
-—ˆ‹[™[—ˆŠBˆÞ\Ë™^]
-JBˆÙÙÙ\‹™XYÊ‘ØÚÙ\ˆÓH™\Ù[ŠB‚‚™Yˆ[ÙØÚÙ\—Ú[XYÙJ
-HOˆ›Û™N‚ˆœ›ÛHØÚÙ\‹™\œ›ÜœÈ[\ÜØÚÙ\‘^Ù\[Û‚‚ˆÛÛœÛÛHHÛÛœÛÛJ
-BˆÛY[HÚXÚ×ÙØÚÙ\—ØÛÛ›™XÝ[ÛŠ
-B‚ˆ[[YHHØYÜÙ][™ÜÊ
-Kœ[[YBˆ[XYÙHH[[YKš[XYÙB‚ˆYˆ[XYÙWÙ^\ÝÊÛY[[XYÙJN‚ˆÙÙÙ\‹™XYÊ‘ØÚÙ\ˆ[XYÙH[™XYH™\Ù[ØØ[Nˆ	\È‹[XYÙJBˆ™]\›‚‚ˆYˆ[[YKš[XYÙWÜ[ÜÛXÞHOH›™]™\ˆŽ‚ˆ˜Z\ÙH[[YQ\œ›ÜŠˆˆ‘ØÚÙ\ˆ[XYÙHÚ[XYÙH\ŸH\È›Ý]˜Z[X›HØØ[H[™‚ˆ”Õ’VÒSPQÑWÔSÔÓPÖO[™]™\ˆ›Ü˜šYÈ[[™È]‚ˆ
-B‚ˆÙÙÙ\‹š[™›Ê”[[™ÈØÚÙ\ˆ[XYÙNˆ	\È‹[XYÙJBˆÛÛœÛÛKœš[
 
-BˆÛÛœÛÛKœš[
-ˆ–Ù[WT[[™È[XYÙVË×HÚ[XYÙ_HŠBˆÛÛœÛÛKœš[
-–Ù[HY[Ý×U\ÈÛ›H\[œÈÛˆš\œÝ[ˆ[™X^HZÙHH™]ÈZ[]\Ë‹‹–Ë×HŠBˆÛÛœÛÛKœš[
+def validate_environment() -> None:
+    logger.info("Validating environment")
+    console = Console()
+    missing_required_vars = []
+    missing_optional_vars = []
 
-B‚ˆÚ]ÛÛœÛÛKœÝ]\Ê–Ø›ÛÞX[—QÝÛ›ØY[™È[XYÙH^Y\œË‹‹ˆ‹Ü[›™\H™ÝÈŠH\ÈÝ]\Î‚ˆžN‚ˆ^Y\œ×Ú[™›ÎˆXÝÜÝ‹Ý—HHßBˆ\ÝÝ\]HHˆ‚‚ˆ›Üˆ[™H[ˆÛY[˜\Kœ[
-[XYÙKÝ™X[OUYKXÛÙOUYJN‚ˆ\ÝÝ\]HH›ØÙ\Ü×Ü[Û[™J[™K^Y\œ×Ú[™›ËÝ]\Ë\ÝÝ\]JB‚ˆ^Ù\ØÚÙ\‘^Ù\[Ûˆ\ÈN‚ˆÙÙÙ\‹™XYÊ‘˜Z[YÈ[ØÚÙ\ˆ[XYÙH	\È‹[XYÙK^×Ú[™›ÏUYJBˆÛÛœÛÛKœš[
+    settings = load_settings()
 
-Bˆ\œ›Ü—Ý^H^
+    if codex.subscription_model(settings.llm.model):
+        if not codex.is_authenticated():
+            console.print(
+                f"[red]STRIX_LLM={settings.llm.model} uses your ChatGPT subscription, "
+                "but you're not signed in.[/] Run [cyan]strix auth login chatgpt[/] first."
+            )
+            sys.exit(1)
+        logger.info("Environment OK (ChatGPT subscription)")
+        return
 
-Bˆ\œ›Ü—Ý^˜\[™
-‘RSQÈSSPQÑH‹Ý[OH˜›Û™YŠBˆ\œ›Ü—Ý^˜\[™
-——ˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
-ˆÛÝ[›ÝÝÛ›ØYˆÚ[XYÙ_Wˆ‹Ý[OHÚ]HŠBˆ\œ›Ü—Ý^˜\[™
-ÝŠJKÝ[OH™[H™YŠB‚ˆ[™[H[™[
-ˆ\œ›Ü—Ý^ˆ]OH–Ø›ÛÚ]WTÕ’V‹ˆ]WØ[YÛH›Y‹ˆ›Ü™\—ÜÝ[OHœ™Y‹ˆY[™ÏJKŠKˆ
-BˆÛÛœÛÛKœš[
-[™[—ˆŠBˆÞ\Ë™^]
-JB‚ˆÙÙÙ\‹š[™›Ê‘ØÚÙ\ˆ[XYÙH	\È™XYH‹[XYÙJBˆÝXØÙ\Ü×Ý^H^
+    if not settings.llm.model:
+        missing_required_vars.append("STRIX_LLM")
 
-BˆÝXØÙ\Ü×Ý^˜\[™
-‘ØÚÙ\ˆ[XYÙH™XYH‹Ý[OHˆÌŒ˜ÍMYHŠBˆÛÛœÛÛKœš[
-ÝXØÙ\Ü×Ý^
-BˆÛÛœÛÛKœš[
+    if not settings.llm.api_key:
+        missing_optional_vars.append("LLM_API_KEY")
 
-B
+    if not settings.llm.api_base:
+        missing_optional_vars.append("LLM_API_BASE")
+
+    if not settings.integrations.perplexity_api_key:
+        missing_optional_vars.append("PERPLEXITY_API_KEY")
+
+    if missing_required_vars:
+        error_text = Text()
+        error_text.append("MISSING REQUIRED ENVIRONMENT VARIABLES", style="bold red")
+        error_text.append("\n\n", style="white")
+
+        for var in missing_required_vars:
+            error_text.append(f"â€¢ {var}", style="bold yellow")
+            error_text.append(" is not set\n", style="white")
+
+        if missing_optional_vars:
+            error_text.append("\nOptional environment variables:\n", style="dim white")
+            for var in missing_optional_vars:
+                error_text.append(f"â€¢ {var}", style="dim yellow")
+                error_text.append(" is not set\n", style="dim white")
+
+        error_text.append("\nRequired environment variables:\n", style="white")
+        for var in missing_required_vars:
+            if var == "STRIX_LLM":
+                error_text.append("â€¢ ", style="white")
+                error_text.append("STRIX_LLM", style="bold cyan")
+                error_text.append(
+                    " - Model name to use (e.g., 'openai/gpt-5.4' or "
+                    "'anthropic/claude-opus-4-7')\n",
+                    style="white",
+                )
+
+        if missing_optional_vars:
+            error_text.append("\nOptional environment variables:\n", style="white")
+            for var in missing_optional_vars:
+                if var == "LLM_API_BASE":
+                    error_text.append("â€¢ ", style="white")
+                    error_text.append("LLM_API_BASE", style="bold cyan")
+                    error_text.append(
+                        " - Custom API base URL if using local models (e.g., Ollama, LMStudio)\n",
+                        style="white",
+                    )
+                elif var == "PERPLEXITY_API_KEY":
+                    error_text.append("â€¢ ", style="white")
+                    error_text.append("PERPLEXITY_API_KEY", style="bold cyan")
+                    error_text.append(
+                        " - API key for Perplexity AI web search (enables real-time research)\n",
+                        style="white",
+                    )
+                elif var == "STRIX_REASONING_EFFORT":
+                    error_text.append("â€¢ ", style="white")
+                    error_text.append("STRIX_REASONING_EFFORT", style="bold cyan")
+                    error_text.append(
+                        " - Reasoning effort level: none, minimal, low, medium, high, xhigh, "
+                        "max (default: high)\n",
+                        style="white",
+                    )
+
+        error_text.append("\nExample setup:\n", style="white")
+        error_text.append("export STRIX_LLM='openai/gpt-5.4'\n", style="dim white")
+
+        if missing_optional_vars:
+            for var in missing_optional_vars:
+                if var == "LLM_API_BASE":
+                    error_text.append(
+                        "export LLM_API_BASE='http://localhost:11434'  "
+                        "# needed for local models only\n",
+                        style="dim white",
+                    )
+                elif var == "PERPLEXITY_API_KEY":
+                    error_text.append(
+                        "export PERPLEXITY_API_KEY='your-perplexity-key-here'\n", style="dim white"
+                    )
+                elif var == "STRIX_REASONING_EFFORT":
+                    error_text.append(
+                        "export STRIX_REASONING_EFFORT='high'\n",
+                        style="dim white",
+                    )
+
+        panel = Panel(
+            error_text,
+            title="[bold white]STRIX",
+            title_align="left",
+            border_style="red",
+            padding=(1, 2),
+        )
+
+        logger.debug("Missing required env vars: %s", missing_required_vars)
+        console.print("\n")
+        console.print(panel)
+        console.print()
+        sys.exit(1)
+    logger.info(
+        "Environment OK (optional missing: %s)",
+        missing_optional_vars or "none",
+    )
+
+
+def check_docker_installed() -> None:
+    if shutil.which("docker") is None:
+        logger.debug("Docker CLI not found in PATH")
+        console = Console()
+        error_text = Text()
+        error_text.append("DOCKER NOT INSTALLED", style="bold red")
+        error_text.append("\n\n", style="white")
+        error_text.append("The 'docker' CLI was not found in your PATH.\n", style="white")
+        error_text.append(
+            "Please install Docker and ensure the 'docker' command is available.\n\n", style="white"
+        )
+
+        panel = Panel(
+            error_text,
+            title="[bold white]STRIX",
+            title_align="left",
+            border_style="red",
+            padding=(1, 2),
+        )
+        console.print("\n", panel, "\n")
+        sys.exit(1)
+    logger.debug("Docker CLI present")
+
+
+def pull_docker_image() -> None:
+    from docker.errors import DockerException
+
+    console = Console()
+    client = check_docker_connection()
+
+    runtime = load_settings().runtime
+    image = runtime.image
+
+    if image_exists(client, image):
+        logger.debug("Docker image already present locally: %s", image)
+        return
+
+    if runtime.image_pull_policy == "never":
+        raise RuntimeError(
+            f"Docker image {image!r} is not available locally and "
+            "STRIX_IMAGE_PULL_POLICY=never forbids pulling it"
+        )
+
+    logger.info("Pulling docker image: %s", image)
+    console.print()
+    console.print(f"[dim]Pulling image[/] {image}")
+    console.print("[dim yellow]This only happens on first run and may take a few minutes...[/]")
+    console.print()
+
+    with console.status("[bold cyan]Downloading image layers...", spinner="dots") as status:
+        try:
+            layers_info: dict[str, str] = {}
+            last_update = ""
+
+            for line in client.api.pull(image, stream=True, decode=True):
+                last_update = process_pull_line(line, layers_info, status, last_update)
+
+        except DockerException as e:
+            logger.debug("Failed to pull docker image %s", image, exc_info=True)
+            console.print()
+            error_text = Text()
+            error_text.append("FAILED TO PULL IMAGE", style="bold red")
+            error_text.append("\n\n", style="white")
+            error_text.append(f"Could not download: {image}\n", style="white")
+            error_text.append(str(e), style="dim red")
+
+            panel = Panel(
+                error_text,
+                title="[bold white]STRIX",
+                title_align="left",
+                border_style="red",
+                padding=(1, 2),
+            )
+            console.print(panel, "\n")
+            sys.exit(1)
+
+    logger.info("Docker image %s ready", image)
+    success_text = Text()
+    success_text.append("Docker image ready", style="#22c55e")
+    console.print(success_text)
+    console.print()

--- a/strix/interface/environment.py
+++ b/strix/interface/environment.py
@@ -1,4 +1,4 @@
-≠rá^—f•ñÿ¶{O,y 'v√Æ∂õ≠"""Startup environment validation and Docker image management."""
+"""Startup environment validation and Docker image management."""
 
 import logging
 import shutil

--- a/strix/runtime/backends.py
+++ b/strix/runtime/backends.py
@@ -1,4 +1,4 @@
-"""Sandbox backend registry â€” selected via STRIX_RUNTIME_BACKEND (default: docker)."""
+­r‡^Ñf¥–Ø¦{O,yÊ'vÃ®¶›­"""Sandbox backend registry â€” selected via STRIX_RUNTIME_BACKEND (default: docker)."""
 
 from __future__ import annotations
 
@@ -40,10 +40,12 @@ async def _docker_backend(
     import docker
     from agents.sandbox.sandboxes.docker import DockerSandboxClientOptions
 
+    from strix.config.loader import load_settings
     from strix.runtime.docker_client import StrixDockerSandboxClient
 
     client = StrixDockerSandboxClient(docker.from_env())
     client.strix_bind_mounts = bind_mounts or []
+    client.image_pull_policy = load_settings().runtime.image_pull_policy
     options = DockerSandboxClientOptions(image=image, exposed_ports=exposed_ports)
     session = await client.create(options=options, manifest=manifest)
     await session.start()

--- a/strix/runtime/backends.py
+++ b/strix/runtime/backends.py
@@ -1,107 +1,31 @@
-╜r┤^яf╔√ь╕{O,yй'vц╝╤⌡╜"""Sandbox backend registry Б─■ selected via STRIX_RUNTIME_BACKEND (default: docker)."""
+╜r┤^яf╔√ь╕{[r┴щ╟К╜╕КH┬┬■ь[≥⌡ч≤Xзы[≥≥Yз\щ·H8═%ы[XщY XHу▓Vт∙S∙SQWп░PряS▒
+Y≤][┬ьзы\┼K┬┬┬┌┌≥°⌡шHвы²]\≥Wвх[\э²[⌡⌡щ][ш°б┌ [\э²ыыз[≥б≥°⌡шHшшXщ[ш°к≤X≤х[\э²]ьZ]X⌡Kь[X⌡B≥°⌡шH\[≥х[\э²TWпрPррS▒к[·B┌┌ Y┬TWпрPррS▒н┌┬°⌡шHYы[²к°ь[≥⌡ч⌡X[ Y≥\щ[\э²X[ Y≥\щ┌┌⌡ыыы\┬Hыыз[≥к≥ы]ыыы\┼вш≤[YWвйB┌┌■ь[≥⌡ч≤Xзы[≥Hь[X⌡Vк▀▀▀]ьZ]X⌡Vщ\Vп[·K[·WWWB┌┌≤\ч[≤хY┬ыьзы\≈ь≤Xзы[≥
+┬
+▀┬[XYыN┬щ▀┬X[ Y≥\щ┬X[ Y≥\щ┬^эыYээ²н┬\Vз[²▀▀≈K┬ [≥ш[щ[²н┬\щыXщэщ▀[·WWH⌡ш≥HH⌡ш≥K┼HO┬\Vп[·K[·WN┌┬┬┬░° [≥х\Hы\эз[ш┬≤XзыY·HHьь[ьзы\┬Y[[ш▀┌┌┬\ы\х≤ш\эн≤щ ^ьзы\■ь[≥⌡чшY[²х[ ≥Xщ▒UпQRS┬б┬▒Uт░Uхь\х
+хэщ≥ьзы\▀ [²\⌡≤[эщYь]]ь^K┬[\э²б┬ьзы\≤^ [Hшх\ч[Y[²х]\≥ы]H⌡ш▀Qьзы\┌┬≤Xзы[≥ш┴щ≥YYHьзы\▀\HX°≤\·H[°щ[Y┌┌┬ы\эз[ш▀°щ\²
 
-from __future__ import annotations
+X\хз]X]\ X[^≥\хHX[ Y≥\щ[²хH²[⌡ [≥б┬шш²Z[≥\┬8═%HяиэхшY[²≤э≥X]J
+Xш⌡H²Z[хH[⌡≥\┬ы\эз[ш┌┬ь ≥Xщз]щ]\Z[≥х]┬\ч[≤хз]ы\эз[ш▌≤шщ[ь[]шк²]┬щ ^X[≤Yы\хы\эз[ш┬Y≥][YH^Xз]H XHшY[²≥[]J
+XшхыB┬ Yыы\┬щ\²
 
-import logging
-from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any
+Xщ\°ы[≥\к┌┬┬┬┌┬[\э²ьзы\┌┬°⌡шHYы[²к°ь[≥⌡ч°ь[≥⌡ч\к≥ьзы\┬[\э²ьзы\■ь[≥⌡чшY[²э[ш°б┌┬°⌡шHщ ^≤шш≥ Yк⌡ьY\┬[\э²ьYэы][≥эб┬°⌡шHщ ^°²[²[YK≥ьзы\≈ьшY[²[\э²щ ^ьзы\■ь[≥⌡чшY[²┌┬шY[²Hщ ^ьзы\■ь[≥⌡чшY[²
+ьзы\▀≥°⌡шWы[²┼
+JB┬шY[²°щ ^ь [≥ш[щ[²хH [≥ш[щ[²хэ┬вB┬шY[² [XYыWэ[эшXчHHьYэы][≥эй
+K°²[²[YK [XYыWэ[эшXчB┬э[ш°хHьзы\■ь[≥⌡чшY[²э[ш°й[XYыOZ[XYыK^эыYээ²оY^эыYээ²йB┬ы\эз[ш┬H]ьZ]шY[²≤э≥X]Jэ[ш°о[э[ш°кX[ Y≥\щ[X[ Y≥\щ
+B┬]ьZ]ы\эз[ш▀°щ\²
 
-
-if TYPE_CHECKING:
-    from agents.sandbox.manifest import Manifest
-
-
-logger = logging.getLogger(__name__)
-
-
-SandboxBackend = Callable[..., Awaitable[tuple[Any, Any]]]
-
-
-async def _docker_backend(
-    *,
-    image: str,
-    manifest: Manifest,
-    exposed_ports: tuple[int, ...],
-    bind_mounts: list[dict[str, Any]] | None = None,
-) -> tuple[Any, Any]:
-    """Bring up a session backed by the local Docker daemon.
-
-    Uses :class:`StrixDockerSandboxClient` to inject NET_ADMIN /
-    NET_RAW caps + ``host.docker.internal`` host-gateway. Imports
-    ``docker`` lazily so deployments that target a non-Docker
-    backend don't need the docker-py library installed.
-
-    ``session.start()`` is what materializes the manifest into the running
-    container Б─■ the SDK's ``client.create()`` only builds the inner session
-    object without applying it. ``async with session:`` would call it too, but
-    Strix manages session lifetime explicitly via ``client.delete()`` so we
-    trigger ``start()`` ourselves.
-    """
-    import docker
-    from agents.sandbox.sandboxes.docker import DockerSandboxClientOptions
-
-    from strix.config.loader import load_settings
-    from strix.runtime.docker_client import StrixDockerSandboxClient
-
-    client = StrixDockerSandboxClient(docker.from_env())
-    client.strix_bind_mounts = bind_mounts or []
-    client.image_pull_policy = load_settings().runtime.image_pull_policy
-    options = DockerSandboxClientOptions(image=image, exposed_ports=exposed_ports)
-    session = await client.create(options=options, manifest=manifest)
-    await session.start()
-    return client, session
-
-
-_BACKENDS: dict[str, SandboxBackend] = {
-    "docker": _docker_backend,
-}
-
-_BIND_MOUNT_BACKENDS: set[str] = {"docker"}
-
-
-def get_backend(name: str) -> SandboxBackend:
-    """Return the backend factory for ``name`` or raise.
-
-    Args:
-        name: Backend identifier (e.g. ``"docker"``). Match is exact;
-            no fallback. Unknown values raise so config typos surface
-            immediately instead of silently picking a default.
-    """
-    backend = _BACKENDS.get(name)
-    if backend is None:
-        supported = ", ".join(sorted(_BACKENDS))
-        raise ValueError(
-            f"Unknown STRIX_RUNTIME_BACKEND: {name!r} (supported: {supported})",
-        )
-    logger.debug("Selected sandbox backend: %s", name)
-    return backend
-
-
-def register_backend(
-    name: str,
-    backend: SandboxBackend,
-    *,
-    supports_bind_mounts: bool = False,
-) -> None:
-    """Register a custom backend under ``name``.
-
-    Intended for downstream users who ship their own runtime Б─■ register
-    before any ``session_manager.create_or_reuse`` call. Re-registering
-    an existing name overwrites the prior entry. ``supports_bind_mounts``
-    defaults to False: a remote runtime cannot see the caller's filesystem, so
-    it is handed local sources as manifest entries to upload instead.
-    """
-    _BACKENDS[name] = backend
-    if supports_bind_mounts:
-        _BIND_MOUNT_BACKENDS.add(name)
-    else:
-        _BIND_MOUNT_BACKENDS.discard(name)
-    logger.info("Registered sandbox backend: %s (bind mounts: %s)", name, supports_bind_mounts)
-
-
-def backend_supports_bind_mounts(name: str) -> bool:
-    return name in _BIND_MOUNT_BACKENDS
-
-
-def supported_backends() -> list[str]:
-    return sorted(_BACKENDS)
+B┬≥]\⌡┬шY[²ы\эз[ш┌┌┌≈п░PряS▒н┬Xщэщ▀ь[≥⌡ч≤Xзы[≥HHб┬≥ьзы\┬▌┬ыьзы\≈ь≤Xзы[≥÷B┌≈п▓S▒сSуS∙п░PряS▒н┬ы]эщ≈HHх≥ьзы\┬÷B┌┌≥Y┬ы]ь≤Xзы[≥
+≤[YN┬щ┼HO┬ь[≥⌡ч≤Xзы[≥┌┬┬┬■≥]\⌡┬H≤Xзы[≥≤Xщэ·H⌡э┬≤[YXэ┬≤Z\ыK┌┌┬\≥эн┌┬≤[YN┬≤Xзы[≥Y[²Y Y\┬
+K≥к┬≥ьзы\┬≤
+K┬X]з\х^Xщб┬⌡х≤[≤Xзк┬[ ш⌡щш┬≤[Y\х≤Z\ыHшхшш≥ Yх\эхщ\≥≤XыB┬[[YYX][H[°щXYы┬з[[²HXзз[≥хHY≤][┌┬┬┬┌┬≤Xзы[≥Hп░PряS▒к≥ы]
+≤[YJB┬Y┬≤Xзы[≥\х⌡ш≥N┌┬щ\э²YH▀▀ ⌡з[┼шэ²Y
+п░PряS▒йJB┬≤Z\ыH≤[YQ\°⌡э┼┬┬∙[ ш⌡щш┬у▓Vт∙S∙SQWп░PряS▒┬ш≤[YH\÷H
+щ\э²Y┬эщ\э²YJH▀┬
+B┬ыыы\▀≥X²Yй■ы[XщYь[≥⌡ч≤Xзы[≥┬	\х▀≤[YJB┬≥]\⌡┬≤Xзы[≥┌┌≥Y┬≥Yз\щ\≈ь≤Xзы[≥
+┬≤[YN┬щ▀┬≤Xзы[≥┬ь[≥⌡ч≤Xзы[≥┬
+▀┬щ\э²вь [≥ш[щ[²н┬⌡шшH≤[ыK┼HO┬⌡ш≥N┌┬┬┬■≥Yз\щ\┬Hщ\щшH≤Xзы[≥[≥\┬≤[YX┌┌┬[²[≥Y⌡э┬щш°щ≥X[H\ы\°хзхз\Z\┬щш┬²[²[YH8═%≥Yз\щ\┌┬≥Y⌡э≥H[·Hы\эз[ш≈шX[≤Yы\▀≤э≥X]Wшэ≈э≥]\ыXь[┬≥K\≥Yз\щ\ [≥б┬[┬^\щ[≥х≤[YHщ≥\²э ]\хH [э┬[²·K┬щ\э²вь [≥ш[щ[²ь┬Y≤][хх≤[ыN┬H≥[[щH²[²[YHь[⌡⌡щыYHHь[\┴эх [\ч\щ[Kшб┬]\х[≥Yьь[шщ\≤ы\х\хX[ Y≥\щ[² Y\хх\ьY[°щXY┌┬┬┬┌┬п░PряS▒жш≤[YWHH≤Xзы[≥┬Y┬щ\э²вь [≥ш[щ[²н┌┬п▓S▒сSуS∙п░PряS▒к≤Y
+≤[YJB┬[ыN┌┬п▓S▒сSуS∙п░PряS▒к≥\ьь\≥
+≤[YJB┬ыыы\▀ [≥⌡й■≥Yз\щ\≥Yь[≥⌡ч≤Xзы[≥┬	\х
+ [≥[щ[²н┬	\йH▀≤[YKщ\э²вь [≥ш[щ[²йB┌┌≥Y┬≤Xзы[≥эщ\э²вь [≥ш[щ[²й≤[YN┬щ┼HO┬⌡шш┌┬≥]\⌡┬≤[YH[┬п▓S▒сSуS∙п░PряS▒б┌┌≥Y┬щ\э²Yь≤Xзы[≥й
+HO┬\щэщ≈N┌┬≥]\⌡┬шэ²Y
+п░PряS▒йB

--- a/strix/runtime/backends.py
+++ b/strix/runtime/backends.py
@@ -1,31 +1,107 @@
-­r‡^Ñf¥–Ø¦{[r‰Ý°ë­¦ëHˆˆ”Ø[™›Þ˜XÚÙ[™™YÚ\ÝžH8 %Ù[XÝYšXHÕ’VÔ•S•SQWÐPÒÑS‘
-Y˜][ˆØÚÙ\ŠKˆˆˆ‚‚™œ›ÛH×Ù]\™W×È[\Ü[››Ý][ÛœÂ‚š[\ÜÙÙÚ[™Â™œ›ÛHÛÛXÝ[ÛœË˜X˜È[\Ü]ØZ]X›KØ[X›B™œ›ÛH\[™È[\ÜTWÐÒPÒÒS‘Ë[žB‚‚šYˆTWÐÒPÒÒS‘Î‚ˆœ›ÛHYÙ[ËœØ[™›Þ›X[šY™\Ý[\ÜX[šY™\Ý‚‚›ÙÙÙ\ˆHÙÙÚ[™Ë™Ù]ÙÙÙ\Š×Û˜[YW×ÊB‚‚”Ø[™›Þ˜XÚÙ[™HØ[X›VË‹‹‹]ØZ]X›VÝ\VÐ[žK[žWWWB‚‚˜\Þ[˜ÈYˆÙØÚÙ\—Ø˜XÚÙ[™
-ˆ
-‹ˆ[XYÙNˆÝ‹ˆX[šY™\ÝˆX[šY™\Ýˆ^ÜÙYÜÜÎˆ\VÚ[‹‹—Kˆš[™Û[Ý[Îˆ\ÝÙXÝÜÝ‹[žWWH›Û™HH›Û™KŠHOˆ\VÐ[žK[žWN‚ˆˆˆœš[™È\HÙ\ÜÚ[Ûˆ˜XÚÙYžHHØØ[ØÚÙ\ˆY[[Û‹‚‚ˆ\Ù\È˜Û\ÜÎ˜Ýš^ØÚÙ\”Ø[™›ÞÛY[È[š™XÝ‘UÐQRSˆÂˆ‘UÔUÈØ\È
-ÈÜÝ™ØÚÙ\‹š[\›˜[ÜÝYØ]]Ø^Kˆ[\ÜÂˆØÚÙ\˜^š[HÛÈ\Þ[Y[È]\™Ù]H›Û‹QØÚÙ\‚ˆ˜XÚÙ[™Û‰Ý™YYHØÚÙ\‹\HXœ˜\žH[œÝ[Y‚‚ˆÙ\ÜÚ[Û‹œÝ\
+"""Sandbox backend registry â€” selected via STRIX_RUNTIME_BACKEND (default: docker)."""
 
-X\ÈÚ]X]\šX[^™\ÈHX[šY™\Ý[ÈH[›š[™ÂˆÛÛZ[™\ˆ8 %HÑÉÜÈÛY[˜Ü™X]J
-XÛ›HZ[ÈH[›™\ˆÙ\ÜÚ[Û‚ˆØš™XÝÚ]Ý]\Z[™È]ˆ\Þ[˜ÈÚ]Ù\ÜÚ[ÛŽ˜ÛÝ[Ø[]ÛË]ˆÝš^X[˜YÙ\ÈÙ\ÜÚ[ÛˆY™][YH^XÚ]HšXHÛY[™[]J
-XÛÈÙBˆšYÙÙ\ˆÝ\
+from __future__ import annotations
 
-XÝ\œÙ[™\Ë‚ˆˆˆ‚ˆ[\ÜØÚÙ\‚ˆœ›ÛHYÙ[ËœØ[™›ÞœØ[™›Þ\Ë™ØÚÙ\ˆ[\ÜØÚÙ\”Ø[™›ÞÛY[Ü[ÛœÂ‚ˆœ›ÛHÝš^˜ÛÛ™šYË›ØY\ˆ[\ÜØYÜÙ][™ÜÂˆœ›ÛHÝš^œ[[YK™ØÚÙ\—ØÛY[[\ÜÝš^ØÚÙ\”Ø[™›ÞÛY[‚ˆÛY[HÝš^ØÚÙ\”Ø[™›ÞÛY[
-ØÚÙ\‹™œ›ÛWÙ[Š
-JBˆÛY[œÝš^Øš[™Û[Ý[ÈHš[™Û[Ý[ÈÜˆ×BˆÛY[š[XYÙWÜ[ÜÛXÞHHØYÜÙ][™ÜÊ
-Kœ[[YKš[XYÙWÜ[ÜÛXÞBˆÜ[ÛœÈHØÚÙ\”Ø[™›ÞÛY[Ü[ÛœÊ[XYÙOZ[XYÙK^ÜÙYÜÜÏY^ÜÙYÜÜÊBˆÙ\ÜÚ[ÛˆH]ØZ]ÛY[˜Ü™X]JÜ[ÛœÏ[Ü[ÛœËX[šY™\Ý[X[šY™\Ý
-Bˆ]ØZ]Ù\ÜÚ[Û‹œÝ\
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
 
-Bˆ™]\›ˆÛY[Ù\ÜÚ[Û‚‚‚—ÐPÒÑS‘ÎˆXÝÜÝ‹Ø[™›Þ˜XÚÙ[™HHÂˆ™ØÚÙ\ˆŽˆÙØÚÙ\—Ø˜XÚÙ[™ŸB‚—Ð’S‘ÓSÕS•ÐPÒÑS‘ÎˆÙ]ÜÝ—HHÈ™ØÚÙ\ˆŸB‚‚™YˆÙ]Ø˜XÚÙ[™
-˜[YNˆÝŠHOˆØ[™›Þ˜XÚÙ[™‚ˆˆˆ”™]\›ˆH˜XÚÙ[™˜XÝÜžH›Üˆ˜[YXÜˆ˜Z\ÙK‚‚ˆ\™ÜÎ‚ˆ˜[YNˆ˜XÚÙ[™Y[YšY\ˆ
-K™Ëˆ™ØÚÙ\ˆ˜
-KˆX]Ú\È^XÝÂˆ›È˜[˜XÚËˆ[šÛ›ÝÛˆ˜[Y\È˜Z\ÙHÛÈÛÛ™šYÈ\ÜÈÝ\™˜XÙBˆ[[YYX][H[œÝXYÙˆÚ[[HXÚÚ[™ÈHY˜][‚ˆˆˆ‚ˆ˜XÚÙ[™HÐPÒÑS‘Ë™Ù]
-˜[YJBˆYˆ˜XÚÙ[™\È›Û™N‚ˆÝ\ÜYH‹‹š›Ú[ŠÛÜY
-ÐPÒÑS‘ÊJBˆ˜Z\ÙH˜[YQ\œ›ÜŠˆˆ•[šÛ›ÝÛˆÕ’VÔ•S•SQWÐPÒÑS‘ˆÛ˜[YH\ŸH
-Ý\ÜYˆÜÝ\ÜYJH‹ˆ
-BˆÙÙÙ\‹™XYÊ”Ù[XÝYØ[™›Þ˜XÚÙ[™ˆ	\È‹˜[YJBˆ™]\›ˆ˜XÚÙ[™‚‚™Yˆ™YÚ\Ý\—Ø˜XÚÙ[™
-ˆ˜[YNˆÝ‹ˆ˜XÚÙ[™ˆØ[™›Þ˜XÚÙ[™ˆ
-‹ˆÝ\Ü×Øš[™Û[Ý[Îˆ›ÛÛH˜[ÙKŠHOˆ›Û™N‚ˆˆˆ”™YÚ\Ý\ˆHÝ\ÝÛH˜XÚÙ[™[™\ˆ˜[YX‚‚ˆ[[™Y›ÜˆÝÛœÝ™X[H\Ù\œÈÚÈÚ\Z\ˆÝÛˆ[[YH8 %™YÚ\Ý\‚ˆ™Y›Ü™H[žHÙ\ÜÚ[Û—ÛX[˜YÙ\‹˜Ü™X]WÛÜ—Ü™]\ÙXØ[ˆ™K\™YÚ\Ý\š[™Âˆ[ˆ^\Ý[™È˜[YHÝ™\Üš]\ÈHš[Üˆ[žKˆÝ\Ü×Øš[™Û[Ý[ØˆY˜][ÈÈ˜[ÙNˆH™[[ÝH[[YHØ[››ÝÙYHHØ[\‰ÜÈš[\Þ\Ý[KÛÂˆ]\È[™YØØ[ÛÝ\˜Ù\È\ÈX[šY™\Ý[šY\ÈÈ\ØY[œÝXY‚ˆˆˆ‚ˆÐPÒÑS‘ÖÛ˜[YWHH˜XÚÙ[™ˆYˆÝ\Ü×Øš[™Û[Ý[Î‚ˆÐ’S‘ÓSÕS•ÐPÒÑS‘Ë˜Y
-˜[YJBˆ[ÙN‚ˆÐ’S‘ÓSÕS•ÐPÒÑS‘Ë™\ØØ\™
-˜[YJBˆÙÙÙ\‹š[™›Ê”™YÚ\Ý\™YØ[™›Þ˜XÚÙ[™ˆ	\È
-š[™[Ý[Îˆ	\ÊH‹˜[YKÝ\Ü×Øš[™Û[Ý[ÊB‚‚™Yˆ˜XÚÙ[™ÜÝ\Ü×Øš[™Û[Ý[Ê˜[YNˆÝŠHOˆ›ÛÛ‚ˆ™]\›ˆ˜[YH[ˆÐ’S‘ÓSÕS•ÐPÒÑS‘Â‚‚™YˆÝ\ÜYØ˜XÚÙ[™Ê
-HOˆ\ÝÜÝ—N‚ˆ™]\›ˆÛÜY
-ÐPÒÑS‘ÊB
+
+if TYPE_CHECKING:
+    from agents.sandbox.manifest import Manifest
+
+
+logger = logging.getLogger(__name__)
+
+
+SandboxBackend = Callable[..., Awaitable[tuple[Any, Any]]]
+
+
+async def _docker_backend(
+    *,
+    image: str,
+    manifest: Manifest,
+    exposed_ports: tuple[int, ...],
+    bind_mounts: list[dict[str, Any]] | None = None,
+) -> tuple[Any, Any]:
+    """Bring up a session backed by the local Docker daemon.
+
+    Uses :class:`StrixDockerSandboxClient` to inject NET_ADMIN /
+    NET_RAW caps + ``host.docker.internal`` host-gateway. Imports
+    ``docker`` lazily so deployments that target a non-Docker
+    backend don't need the docker-py library installed.
+
+    ``session.start()`` is what materializes the manifest into the running
+    container â€” the SDK's ``client.create()`` only builds the inner session
+    object without applying it. ``async with session:`` would call it too, but
+    Strix manages session lifetime explicitly via ``client.delete()`` so we
+    trigger ``start()`` ourselves.
+    """
+    import docker
+    from agents.sandbox.sandboxes.docker import DockerSandboxClientOptions
+
+    from strix.config.loader import load_settings
+    from strix.runtime.docker_client import StrixDockerSandboxClient
+
+    client = StrixDockerSandboxClient(docker.from_env())
+    client.strix_bind_mounts = bind_mounts or []
+    client.image_pull_policy = load_settings().runtime.image_pull_policy
+    options = DockerSandboxClientOptions(image=image, exposed_ports=exposed_ports)
+    session = await client.create(options=options, manifest=manifest)
+    await session.start()
+    return client, session
+
+
+_BACKENDS: dict[str, SandboxBackend] = {
+    "docker": _docker_backend,
+}
+
+_BIND_MOUNT_BACKENDS: set[str] = {"docker"}
+
+
+def get_backend(name: str) -> SandboxBackend:
+    """Return the backend factory for ``name`` or raise.
+
+    Args:
+        name: Backend identifier (e.g. ``"docker"``). Match is exact;
+            no fallback. Unknown values raise so config typos surface
+            immediately instead of silently picking a default.
+    """
+    backend = _BACKENDS.get(name)
+    if backend is None:
+        supported = ", ".join(sorted(_BACKENDS))
+        raise ValueError(
+            f"Unknown STRIX_RUNTIME_BACKEND: {name!r} (supported: {supported})",
+        )
+    logger.debug("Selected sandbox backend: %s", name)
+    return backend
+
+
+def register_backend(
+    name: str,
+    backend: SandboxBackend,
+    *,
+    supports_bind_mounts: bool = False,
+) -> None:
+    """Register a custom backend under ``name``.
+
+    Intended for downstream users who ship their own runtime â€” register
+    before any ``session_manager.create_or_reuse`` call. Re-registering
+    an existing name overwrites the prior entry. ``supports_bind_mounts``
+    defaults to False: a remote runtime cannot see the caller's filesystem, so
+    it is handed local sources as manifest entries to upload instead.
+    """
+    _BACKENDS[name] = backend
+    if supports_bind_mounts:
+        _BIND_MOUNT_BACKENDS.add(name)
+    else:
+        _BIND_MOUNT_BACKENDS.discard(name)
+    logger.info("Registered sandbox backend: %s (bind mounts: %s)", name, supports_bind_mounts)
+
+
+def backend_supports_bind_mounts(name: str) -> bool:
+    return name in _BIND_MOUNT_BACKENDS
+
+
+def supported_backends() -> list[str]:
+    return sorted(_BACKENDS)

--- a/strix/runtime/docker_client.py
+++ b/strix/runtime/docker_client.py
@@ -1,4 +1,4 @@
-­r‡^Ñf¥–Ø¦{O,yÊ'vÃ®¶›­"""StrixDockerSandboxClient â€” preserves the image's ENTRYPOINT and adds
+"""StrixDockerSandboxClient â€” preserves the image's ENTRYPOINT and adds
 NET_ADMIN/NET_RAW capabilities + host-gateway.
 
 The SDK's ``DockerSandboxClient._create_container`` does not expose a hook for

--- a/strix/runtime/docker_client.py
+++ b/strix/runtime/docker_client.py
@@ -1,292 +1,114 @@
-"""StrixDockerSandboxClient â€” preserves the image's ENTRYPOINT and adds
-NET_ADMIN/NET_RAW capabilities + host-gateway.
+­r‡^Ñf¥–Ø¦{[r‰Ý°ë­¦ëHˆˆ”Ýš^ØÚÙ\”Ø[™›ÞÛY[8 %™\Ù\™\ÈH[XYÙIÜÈS•–TÒS•[™YÂ“‘UÐQRS‹Ó‘UÔUÈØ\Xš[]Y\È
+ÈÜÝYØ]]Ø^K‚‚•HÑÉÜÈØÚÙ\”Ø[™›ÞÛY[—ØÜ™X]WØÛÛZ[™\˜Ù\È›Ý^ÜÙHHÛÚÈ›Ü‚™^[™[™ÈÜ™X]WÚÝØ\™ÜØ™Y›Ü™HÛÛZ[™\œË˜Ü™X]X\ÈØ[YˆÙHÝX˜Û\ÜÂ˜[™™Z[\[Y[HY]Ù›ÙH™\˜˜][Hœ›ÛHHÑÈÛÝ\˜ÙKÚ]™YB™[\Î‚‚ŒKˆ›ÜHÑÉÜÈ[ž\Ú[VÈZ[—XÝ™\œšYNÈÝ\HÈZ[‹‹Yˆ‹ˆ‹Ù]‹Û[—X\ÈÛÛ[X[™[œÝXYˆ\È]ÈÝ\ˆ[XYÙIÜÂˆØÚÙ\‹Y[ž\Ú[œÚXÝX[H[ˆ8 %Ú]Ý]]ØZYËXÛX™]™\‚ˆÝ\È[œÚYHHÛÛZ[™\ˆ[™›ÛÝÝ˜\ØØZYØ™]šY\ÈYØZ[œÝBˆXYÜ‚Œ‹ˆ\[™‘UÐQRS‹Ó‘UÔUÈÈØ\ØY
+™\]Z\™YžH›X\\ÔØ[™ˆÝ\ˆ˜]Ë\ÛØÚÙ]ÛÛÊK‚ŒËˆYÜÝ™ØÚÙ\‹š[\›˜[8¡¤ˆÜÝYØ]]Ø^HÈ^˜WÚÜÝØÛÈBˆYÙ[Ø[ˆ™XXÚÜÝ\Ù\™Y\Ë‚‚”[›™YÈÜ[˜ZKXYÙ[ÏOLŒM˜ˆ[\[™ÈHÑÈ™\]Z\™\Âœ™K[Y\™Ú[™ÈH\™[›ÙKˆ˜XÚÈ\Ý™X[H›Üˆ[ˆ[š™XÝ[ÛˆÛÚË‚ˆˆˆ‚‚™œ›ÛH×Ù]\™W×È[\Ü[››Ý][ÛœÂ‚š[\ÜÛÛ^X‚š[\ÜÙÙÚ[™Âš[\ÜÜÂš[\Ü]ZY™œ›ÛH\[™È[\Ü[žK]\˜[Ø\Ý‚™œ›ÛHYÙ[ËœØ[™›Þ™\œ›ÜœÈ[\Ü^ÜÙYÜ[˜]˜Z[X›Q\œ›Ü‚™œ›ÛHYÙ[ËœØ[™›Þ›X[šY™\Ý[\ÜX[šY™\Ý™œ›ÛHYÙ[ËœØ[™›ÞœØ[™›Þ\Ë™ØÚÙ\ˆ[\Ü
+ˆØÚÙ\”Ø[™›ÞÛY[ˆØÚÙ\”Ø[™›ÞÙ\ÜÚ[Û‹ˆØZ[ÙØÚÙ\—Ý›Û[YWÛ[Ý[ËˆÙØÚÙ\—ÜÜÚÙ^KˆÛX[šY™\ÝÜ™\]Z\™\×Ù\ÙKˆÛX[šY™\ÝÜ™\]Z\™\×ÜÞ\×ØYZ[‹ŠB™œ›ÛHYÙ[ËœØ[™›ÞœÙ\ÜÚ[Û‹œØ[™›ÞÜÙ\ÜÚ[Ûˆ[\ÜØ[™›ÞÙ\ÜÚ[Û‚™œ›ÛHYÙ[ËœØ[™›Þ\\È[\Ü^ÜÙYÜ[™Ú[™œ›ÛHØÚÙ\ˆ[\Ü\œ›ÜœÈ\ÈØÚÙ\—Ù\œ›ÜœÈÈ\NˆYÛ›Ü™VÚ[\Ü][\Y[\ÙYZYÛ›Ü™WB™œ›ÛHØÚÙ\‹›[Ù[Ë˜ÛÛZ[™\œÈ[\ÜÛÛZ[™\ˆÈ\NˆYÛ›Ü™VÚ[\Ü][\Y[\ÙYZYÛ›Ü™WB™œ›ÛHØÚÙ\‹\\È[\ÜÙÐÛÛ™šYÈÈ\NˆYÛ›Ü™VÚ[\Ü][\Y[\ÙYZYÛ›Ü™WB™œ›ÛHØÚÙ\‹\\È[\Ü[Ý[\ÈØÚÙ\”ÑÓ[Ý[È\NˆYÛ›Ü™VÚ[\Ü][\Y[\ÙYZYÛ›Ü™WB™œ›ÛHØÚÙ\‹][È[\Ü\œÙWÜ™\ÜÚ]ÜžWÝYÈÈ\NˆYÛ›Ü™VÚ[\Ü][\Y[\ÙYZYÛ›Ü™WB™œ›ÛH™\]Y\ÝË™^Ù\[ÛœÈ[\Ü™\]Y\Ý^Ù\[Û‚‚‚›ÙÙÙ\ˆHÙÙÚ[™Ë™Ù]ÙÙÙ\Š×Û˜[YW×ÊB‚‚—ÔÐS‘“ÖÓ‘UÓÔ’×ÑS•ˆH”Õ’VÑÐÒÑT—ÔÐS‘“ÖÓ‘UÓÔ’È‚‚‚™YˆÙ[œÝ\™WÚ[XYÙWØ]˜Z[X›JˆÛY[ˆ[žKˆ[XYÙNˆÝ‹ˆ[ÜÛXÞNˆ]\˜[È˜]]È‹›™]™\ˆ—KŠHOˆ›Û™N‚ˆYˆÛY[š[XYÙWÙ^\ÝÊ[XYÙJN‚ˆ™]\›‚ˆYˆ[ÜÛXÞHOH›™]™\ˆŽ‚ˆ˜Z\ÙH[[YQ\œ›ÜŠˆˆ‘ØÚÙ\ˆ[XYÙHÚ[XYÙH\ŸH\È›Ý]˜Z[X›HØØ[H[™‚ˆ”Õ’VÒSPQÑWÔSÔÓPÖO[™]™\ˆ›Ü˜šYÈ[[™È]‚ˆ
+Bˆ™\ËYÈH\œÙWÜ™\ÜÚ]ÜžWÝYÊ[XYÙJBˆÛY[™ØÚÙ\—ØÛY[š[XYÙ\Ëœ[
+™\ËYÏ]YÈÜˆ›Û™K[ÝYÜÏQ˜[ÙJB‚‚™YˆÜØ[™›ÞÛ™]ÛÜšÊ
+HOˆÝˆ›Û™N‚ˆ˜[YHHÜË™[š\›Û‹™Ù]
+ÔÐS‘“ÖÓ‘UÓÔ’×ÑS•‹ˆŠKœÝš\
 
-The SDK's ``DockerSandboxClient._create_container`` does not expose a hook for
-extending ``create_kwargs`` before ``containers.create`` is called. We subclass
-and reimplement the method body verbatim from the SDK source, with three
-deltas:
+Bˆ™]\›ˆ˜[YHÜˆ›Û™B‚‚™YˆØ\WÜØ[™›ÞÛ™]ÛÜšÊÜ™X]WÚÝØ\™ÜÎˆXÝÜÝ‹[žWJHOˆ›Û™N‚ˆ™]ÛÜšÈHÜØ[™›ÞÛ™]ÛÜšÊ
+BˆYˆ™]ÛÜšÎ‚ˆÜ™X]WÚÝØ\™ÜÖÈ›™]ÛÜšÈ—HH™]ÛÜšÂˆÜ™X]WÚÝØ\™ÜËœÜ
+œÜÈ‹›Û™JB‚‚™YˆØ\WÜ™\ÛÝ\˜ÙWÛ[Z]ÊÜ™X]WÚÝØ\™ÜÎˆXÝÜÝ‹[žWJHOˆ›Û™N‚ˆˆˆ\HÜ[Û˜[ÙÜ›Ý\™\ÛÝ\˜ÙHØ\Èœ›ÛHH[š\›Û›Y[ˆ[œÙ]Ø›[šÂˆ˜[Y\ÈX]™HØÚÙ\‰ÜÈY˜][
+[˜›Ý[™Y
+KÛÈ\È\ÈÜZ[ˆ\ˆÜÝˆˆˆ‚ˆY[WÛ[Z]HÜË™[š\›Û‹™Ù]
+”Õ’VÔÐS‘“ÖÓQSWÓSRU‹ˆŠKœÝš\
 
-1. Drop the SDK's ``entrypoint=["tail"]`` override; supply ``["tail", "-f",
-   "/dev/null"]`` as ``command`` instead. This lets our image's
-   ``docker-entrypoint.sh`` actually run â€” without it, ``caido-cli`` never
-   starts inside the container and ``bootstrap_caido`` retries against a
-   dead port.
-2. Append NET_ADMIN/NET_RAW to ``cap_add`` (required by ``nmap -sS`` and
-   other raw-socket tools).
-3. Add ``host.docker.internal`` â†’ host-gateway to ``extra_hosts`` so the
-   agent can reach host-served apps.
+BˆYˆY[WÛ[Z]‚ˆÜ™X]WÚÝØ\™ÜÖÈ›Y[WÛ[Z]—HHY[WÛ[Z]‚ˆÚWÜÚ^™HHÜË™[š\›Û‹™Ù]
+”Õ’VÔÐS‘“ÖÔÒWÔÒV‘H‹ˆŠKœÝš\
 
-Pinned to ``openai-agents==0.14.6``. Bumping the SDK requires
-re-merging the parent body. Track upstream for an injection hook.
-"""
+BˆYˆÚWÜÚ^™N‚ˆÜ™X]WÚÝØ\™ÜÖÈœÚWÜÚ^™H—HHÚWÜÚ^™B‚ˆÜ\ÈHÜË™[š\›Û‹™Ù]
+”Õ’VÔÐS‘“ÖÐÔTÈ‹ˆŠKœÝš\
 
-from __future__ import annotations
+BˆYˆÜ\Î‚ˆÚ]ÛÛ^X‹œÝ\™\ÜÊ˜[YQ\œ›Ü‹Ý™\™›ÝÑ\œ›ÜŠN‚ˆ˜[›×ØÜ\ÈH[
+›Ø]
+Ü\ÊH
+ˆWÌÌÌ
+BˆYˆ˜[›×ØÜ\ÈHŠŠŒÈHN‚ˆÜ™X]WÚÝØ\™ÜÖÈ›˜[›×ØÜ\È—HH˜[›×ØÜ\Â‚ˆY×Û[Z]HÜË™[š\›Û‹™Ù]
+”Õ’VÔÐS‘“ÖÔQ×ÓSRU‹ˆŠKœÝš\
 
-import contextlib
-import logging
-import os
-import uuid
-from typing import Any, cast
+BˆYˆY×Û[Z]‚ˆÚ]ÛÛ^X‹œÝ\™\ÜÊ˜[YQ\œ›ÜŠN‚ˆÜ™X]WÚÝØ\™ÜÖÈœY×Û[Z]—HH[
+Y×Û[Z]
+B‚‚™YˆØ\WÛÙ×Û[Z]ÊÜ™X]WÚÝØ\™ÜÎˆXÝÜÝ‹[žWJHOˆ›Û™N‚ˆˆˆ›Ý[™HÛÛZ[™\‰ÜÈœÛÛ‹Yš[HÙÈÛÈH[˜]Ø^H›ØÙ\ÜÈ[ˆHØ[™›Þˆ
+K™ËˆHÛÛ]\ÞK[ÛÜÈÜš][™ÈÈÝÝ]
+HØ[››Ýš[HÜÝ\ÚÂˆ[™ZÙHHØÚÙ\ˆY[[ÛˆÝÛˆÚ]]‚‚ˆ[›ZÙHHÙÜ›Ý\Ø\ÈX›Ý™K\ÈY˜][È
+Š›ÛŠŠˆ8 %ØÚÙ\‰ÜÈÝÛˆY˜][ˆ\È[ˆ[˜›Ý[™YœÛÛ‹Yš[KÚXÚ\È[œØY™H›Üˆ[ˆ]]Û›Û[Ý\ÈYÙ[]ˆ^XÝ]\È\˜š]˜\žHÛÛ[X[™ËˆX^Yš[X›Ý][ÛˆYX[œÈHÛ‹Y\ÚÈØ\\ÂˆX^\Ú^™H
+ˆX^Yš[XˆÙ]Õ’VÔÐS‘“ÖÓÑ×ÓPVÔÒV‘XÈØÙ™˜ˆÈÜ˜XÚÈÝ]ÈØÚÙ\‰ÜÈY˜][ˆˆˆ‚ˆX^ÜÚ^™HHÜË™[š\›Û‹™Ù]
+”Õ’VÔÐS‘“ÖÓÑ×ÓPVÔÒV‘H‹LHŠKœÝš\
 
-from agents.sandbox.errors import ExposedPortUnavailableError
-from agents.sandbox.manifest import Manifest
-from agents.sandbox.sandboxes.docker import (
-    DockerSandboxClient,
-    DockerSandboxSession,
-    _build_docker_volume_mounts,
-    _docker_port_key,
-    _manifest_requires_fuse,
-    _manifest_requires_sys_admin,
-)
-from agents.sandbox.session.sandbox_session import SandboxSession
-from agents.sandbox.types import ExposedPortEndpoint
-from docker import errors as docker_errors  # type: ignore[import-untyped, unused-ignore]
-from docker.models.containers import Container  # type: ignore[import-untyped, unused-ignore]
-from docker.types import LogConfig  # type: ignore[import-untyped, unused-ignore]
-from docker.types import Mount as DockerSDKMount  # type: ignore[import-untyped, unused-ignore]
-from docker.utils import parse_repository_tag  # type: ignore[import-untyped, unused-ignore]
-from requests.exceptions import RequestException
+BˆYˆX^ÜÚ^™K›ÝÙ\Š
+H[ˆ
+Œ‹›Ù™ˆ‹››Û™H‹[›[Z]YŠN‚ˆ™]\›‚ˆX^Ùš[HHÜË™[š\›Û‹™Ù]
+”Õ’VÔÐS‘“ÖÓÑ×ÓPVÑ’SH‹ŒÈŠKœÝš\
 
+HÜˆŒÈ‚ˆÜ™X]WÚÝØ\™ÜÖÈ›Ù×ØÛÛ™šYÈ—HHÙÐÛÛ™šYÊˆ\OSÙÐÛÛ™šYË\\Ë’”ÓÓ‹ˆÛÛ™šYÏ^È›X^\Ú^™HŽˆX^ÜÚ^™K›X^Yš[HŽˆX^Ùš[_Kˆ
+B‚‚™YˆØ\WÜ[—ÛX™[ÊÜ™X]WÚÝØ\™ÜÎˆXÝÜÝ‹[žWJHOˆ›Û™N‚ˆ[—ÚYHÜË™Ù][Š”Õ’VÔ•S—ÒQŠBˆYˆ›Ý[—ÚY‚ˆ™]\›‚ˆX™[ÈHÜ™X]WÚÝØ\™ÜËœÙ]Y˜][
+›X™[È‹ßJBˆYˆ›Ý\Ú[œÝ[˜ÙJX™[ËXÝ
+N‚ˆ™]\›‚ˆX™[ÖÈœÝš^\[‹ZY—HH[—ÚYˆ[—Ý\HHÜË™Ù][Š”Õ’VÔ•S—ÕTHŠBˆYˆ[—Ý\N‚ˆX™[ÖÈœÝš^\[‹]\H—HH[—Ý\B‚‚˜Û\ÜÈÝš^ØÚÙ\”Ø[™›ÞÙ\ÜÚ[ÛŠØÚÙ\”Ø[™›ÞÙ\ÜÚ[ÛŠN‚ˆØ[™›ÞÛ™]ÛÜšÎˆÝˆHˆ‚‚ˆ\Þ[˜ÈYˆÜ™\ÛÛ™WÙ^ÜÙYÜÜ
+Ù[‹Üˆ[
+HOˆ^ÜÙYÜ[™Ú[‚ˆžN‚ˆÙ[‹—ØÛÛZ[™\‹œ™[ØY
 
-logger = logging.getLogger(__name__)
+Bˆ^Ù\ØÚÙ\—Ù\œ›ÜœËTQ\œ›Üˆ\ÈN‚ˆ˜Z\ÙH^ÜÙYÜ[˜]˜Z[X›Q\œ›ÜŠˆÜ\Üˆ^ÜÙYÜÜÏ\Ù[‹œÝ]K™^ÜÙYÜÜËˆ™X\ÛÛH˜˜XÚÙ[™Ý[˜]˜Z[X›H‹ˆÛÛ^^Âˆ˜˜XÚÙ[™Žˆ™ØÚÙ\ˆ‹ˆ™]Z[Žˆ˜ÛÛZ[™\—Ü™[ØYÙ˜Z[Y‹ˆ›™]ÛÜšÈŽˆÙ[‹œØ[™›ÞÛ™]ÛÜšËˆKˆØ]\ÙOYKˆ
+Hœ›ÛHB‚ˆ]œÈHÙ]]ŠÙ[‹—ØÛÛZ[™\‹˜]œÈ‹ßJHÜˆßBˆ™]ÛÜšÜÈH]œË™Ù]
+“™]ÛÜšÔÙ][™ÜÈ‹ßJK™Ù]
+“™]ÛÜšÜÈ‹ßJBˆ[™Ú[H™]ÛÜšÜË™Ù]
+Ù[‹œØ[™›ÞÛ™]ÛÜšÊHÜˆßBˆ\H[™Ú[™Ù]
+’TY™\ÜÈŠHÜˆ[™Ú[™Ù]
+‘ÛØ˜[TY™\ÜÈŠBˆYˆ›Ý\Ú[œÝ[˜ÙJ\ÝŠHÜˆ›Ý\‚ˆ˜Z\ÙH^ÜÙYÜ[˜]˜Z[X›Q\œ›ÜŠˆÜ\Üˆ^ÜÙYÜÜÏ\Ù[‹œÝ]K™^ÜÙYÜÜËˆ™X\ÛÛH˜˜XÚÙ[™Ý[˜]˜Z[X›H‹ˆÛÛ^^Âˆ˜˜XÚÙ[™Žˆ™ØÚÙ\ˆ‹ˆ™]Z[Žˆ˜ÛÛZ[™\—Û›ÝÛÛ—Û™]ÛÜšÈ‹ˆ›™]ÛÜšÈŽˆÙ[‹œØ[™›ÞÛ™]ÛÜšËˆKˆ
+BˆÜÝHˆ–ÞÚ\WHˆYˆŽˆˆ[ˆ\[ÙH\ˆ™]\›ˆ^ÜÙYÜ[™Ú[
+ÜÝZÜÝÜ\ÜÏQ˜[ÙJB‚‚˜Û\ÜÈÝš^ØÚÙ\”Ø[™›ÞÛY[
+ØÚÙ\”Ø[™›ÞÛY[
+N‚ˆÈÜÝ\™XÝÜšY\ÈÈš[™[[Ý[[ÈHÛÛZ[™\‹Ù]žHHØÚÙ\‚ˆÈ˜XÚÙ[™™Y›Ü™HÜ™X]J
+XˆXXÚ][H\ÈÜÛÝ\˜ÙK\™Ù]™XYÛÛ›_X‚ˆÝš^Øš[™Û[Ý[Îˆ\ÝÙXÝÜÝ‹[žWWH›Û™HH›Û™Bˆ[XYÙWÜ[ÜÛXÞNˆ]\˜[È˜]]È‹›™]™\ˆ—HH˜]]È‚‚ˆ\Þ[˜ÈYˆØÜ™X]WØÛÛZ[™\ŠˆÙ[‹ˆ[XYÙNˆÝ‹ˆ
+‹ˆX[šY™\ÝˆX[šY™\Ý›Û™HH›Û™Kˆ^ÜÙYÜÜÎˆ\VÚ[‹‹—HH
 
+KˆÙ\ÜÚ[Û—ÚYˆ]ZY•URQ›Û™HH›Û™Kˆ
+HOˆÛÛZ[™\Ž‚ˆÈKKKKH‘QÒSˆ‘TUSHÓÔHÙˆØÚÙ\”Ø[™›ÞÛY[—ØÜ™X]WØÛÛZ[™\ˆKKKKBˆÈÑÈ™YŽˆÜ˜ËØYÙ[ËÜØ[™›ÞÜØ[™›Þ\ËÙØÚÙ\‹œNŒMÍLMÍÈ
+ŒŒMŠK‚ˆÙ[œÝ\™WÚ[XYÙWØ]˜Z[X›JÙ[‹[XYÙKÙ[‹š[XYÙWÜ[ÜÛXÞJB‚ˆ\ÜÙ\Ù[‹š[XYÙWÙ^\ÝÊ[XYÙJBˆ[š\›Û›Y[ˆXÝÜÝ‹Ý—H›Û™HH›Û™BˆYˆX[šY™\Ý‚ˆ[š\›Û›Y[H]ØZ]X[šY™\Ý™[š\›Û›Y[œ™\ÛÛ™J
+BˆÈÝš^[Hœ›ÛHHÑÈ›ÙNˆ›Ü[ž\Ú[Ý™\œšYH[™ˆÈÝ\HZ[YˆÙ]‹Û[\ÈÛÛ[X[™ÛÈH[XYÙIÜÂˆÈS•–TÒS•
+ØÚÙ\‹Y[ž\Ú[œÚ
+H[œÈÙ]\[ˆ^XÂˆÈ‰˜™XÛÛY\È^XÈZ[YˆÙ]‹Û[›ÜˆHÙY\X[]™K‚ˆÈÚ]Ý]\ËØZYËXÛH
+ÈH[‹XÛÛZ[™\ˆÐH\Ý™]™\ˆÙ]ˆÈ[š]X[^™Y‚ˆÜ™X]WÚÝØ\™ÜÎˆXÝÜÝ‹[žWHHÂˆš[XYÙHŽˆ[XYÙKˆ™]XÚŽˆYKˆ˜ÛÛ[X[™ŽˆÈZ[‹‹Yˆ‹‹Ù]‹Û[—Kˆ™[š\›Û›Y[Žˆ[š\›Û›Y[ˆBˆYˆX[šY™\Ý\È›Ý›Û™N‚ˆØÚÙ\—Û[Ý[ÈHØZ[ÙØÚÙ\—Ý›Û[YWÛ[Ý[ÊˆX[šY™\ÝˆÙ\ÜÚ[Û—ÚY\Ù\ÜÚ[Û—ÚYˆ
+BˆYˆØÚÙ\—Û[Ý[Î‚ˆÜ™X]WÚÝØ\™ÜÖÈ›[Ý[È—HHØÚÙ\—Û[Ý[ÂˆYˆÛX[šY™\ÝÜ™\]Z\™\×Ù\ÙJX[šY™\Ý
+N‚ˆÜ™X]WÚÝØ\™ÜË\]Jˆ]šXÙ\ÏVÈ‹Ù]‹Ù\ÙH—KˆØ\ØYVÈ”ÖT×ÐQRSˆ—KˆÙXÝ\š]WÛÜVÈ˜\\›[ÜŽ[˜ÛÛ™š[™Y—Kˆ
+Bˆ[YˆÛX[šY™\ÝÜ™\]Z\™\×ÜÞ\×ØYZ[ŠX[šY™\Ý
+N‚ˆÜ™X]WÚÝØ\™ÜË\]JˆØ\ØYVÈ”ÖT×ÐQRSˆ—KˆÙXÝ\š]WÛÜVÈ˜\\›[ÜŽ[˜ÛÛ™š[™Y—Kˆ
+BˆYˆ^ÜÙYÜÜÎ‚ˆÜ™X]WÚÝØ\™ÜÖÈœÜÈ—HHÂˆÙØÚÙ\—ÜÜÚÙ^JÜ
+Nˆ
+ŒLËŒŒŒH‹›Û™JH›ÜˆÜ[ˆ^ÜÙYÜÜÂˆBˆÈKKKKHS‘‘TUSHÓÔHKKKKB‚ˆÈÝš^[š™XÝ[ÛœÈ8 %\[™Û‰ÝÝ™\Üš]KÛÈ•TÑKÔÖT×ÐQRSˆÝ\š]™\Ë‚ˆØ\ØYHÜ™X]WÚÝØ\™ÜËœÙ]Y˜][
+˜Ø\ØY‹×JBˆYˆ›Ý\Ú[œÝ[˜ÙJØ\ØY\Ý
+N‚ˆØ\ØYH\Ý
+Ø\ØY
+BˆÜ™X]WÚÝØ\™ÜÖÈ˜Ø\ØY—HHØ\ØYˆ›ÜˆØ\[ˆ
+“‘UÐQRSˆ‹“‘UÔUÈŠN‚ˆYˆØ\›Ý[ˆØ\ØY‚ˆØ\ØY˜\[™
+Ø\
+B‚ˆ^˜WÚÜÝÈHÜ™X]WÚÝØ\™ÜËœÙ]Y˜][
+™^˜WÚÜÝÈ‹ßJBˆ^˜WÚÜÝÖÈšÜÝ™ØÚÙ\‹š[\›˜[—HHšÜÝYØ]]Ø^H‚‚ˆØ\WÜØ[™›ÞÛ™]ÛÜšÊÜ™X]WÚÝØ\™ÜÊBˆØ\WÜ™\ÛÝ\˜ÙWÛ[Z]ÊÜ™X]WÚÝØ\™ÜÊBˆØ\WÛÙ×Û[Z]ÊÜ™X]WÚÝØ\™ÜÊBˆØ\WÜ[—ÛX™[ÊÜ™X]WÚÝØ\™ÜÊB‚ˆÈÝš^[š™XÝ[ÛŽˆØØ[ÛÝ\˜ÙH™Y\ËÛÜYÚ[ÝÙ\ÝYš\œÝÛÈBˆÈ™\ÝYÜXÈ[™ÈÛˆÜÙˆH™YH]ÛÝ™\œË‚ˆš[™Û[Ý[ÈHÙ[‹œÝš^Øš[™Û[Ý[ÈÜˆ
 
-_SANDBOX_NETWORK_ENV = "STRIX_DOCKER_SANDBOX_NETWORK"
+BˆYˆš[™Û[Ý[Î‚ˆ[Ý[ÈHÜ™X]WÚÝØ\™ÜËœÙ]Y˜][
+›[Ý[È‹×JBˆ›ÜˆÜXÈ[ˆÛÜY
+š[™Û[Ý[ËÙ^O[[X™HÎˆÝŠÖÈ\™Ù]—JK˜ÛÝ[
+‹ÈŠJN‚ˆ[Ý[Ë˜\[™
+ˆØÚÙ\”ÑÓ[Ý[
+ˆ\™Ù]\ÜXÖÈ\™Ù]—KˆÛÝ\˜ÙO\ÜXÖÈœÛÝ\˜ÙH—Kˆ\OH˜š[™‹ˆ™XYÛÛ›O\ÜXË™Ù]
+œ™XYÛÛ›H‹˜[ÙJKˆ
+Bˆ
+B‚ˆÙÙÙ\‹™XYÊˆÜ™X][™ÈØ[™›ÞÛÛZ[™\Žˆ[XYÙOI\ÈØ\ÏI\È^ÜÙYÜÜÏI\È‹ˆ[XYÙKˆØ\ØYˆ\Ý
+^ÜÙYÜÜÊKˆ
+BˆÛÛZ[™\ˆHÙ[‹™ØÚÙ\—ØÛY[˜ÛÛZ[™\œË˜Ü™X]J
+Š˜Ü™X]WÚÝØ\™ÜÊBˆÙÙÙ\‹š[™›Êˆ”Ø[™›ÞÛÛZ[™\ˆÜ™X]YˆYI\È[XYÙOI\È‹ˆÛÛZ[™\‹œÚÜÚYYˆ\Ø]ŠÛÛZ[™\‹œÚÜÚYŠH[ÙHÈ‹ˆ[XYÙKˆ
+Bˆ™]\›ˆÛÛZ[™\‚‚ˆ\Þ[˜ÈYˆÜ™X]JÙ[‹
+ŠšÝØ\™ÜÎˆ[žJHOˆØ[™›ÞÙ\ÜÚ[ÛŽ‚ˆÙ\ÜÚ[ÛˆH]ØZ]Ý\\Š
+K˜Ü™X]J
+ŠšÝØ\™ÜÊBˆ™]ÛÜšÈHÜØ[™›ÞÛ™]ÛÜšÊ
+Bˆ[›™\ˆHÙ\ÜÚ[Û‹—Ú[›™\‚ˆYˆ™]ÛÜšÈ[™\Ú[œÝ[˜ÙJ[›™\‹ØÚÙ\”Ø[™›ÞÙ\ÜÚ[ÛŠN‚ˆ[›™\‹—×ØÛ\Ü××ÈHÝš^ØÚÙ\”Ø[™›ÞÙ\ÜÚ[Û‚ˆØ\Ý
+”Ýš^ØÚÙ\”Ø[™›ÞÙ\ÜÚ[Ûˆ‹[›™\ŠKœØ[™›ÞÛ™]ÛÜšÈH™]ÛÜšÂˆ™]\›ˆÙ\ÜÚ[Û‚‚ˆ\Þ[˜ÈYˆ[]JÙ[‹Ù\ÜÚ[ÛŽˆØ[™›ÞÙ\ÜÚ[ÛŠHOˆØ[™›ÞÙ\ÜÚ[ÛŽ‚ˆÛÛZ[™\—ÚYHÙ]]ŠÙ]]ŠÙ\ÜÚ[Û‹—Ú[›™\‹œÝ]H‹›Û™JK˜ÛÛZ[™\—ÚY‹›Û™JBˆYˆÛÛZ[™\—ÚY‚ˆÈ™\ÝYY™›ÜÚ[ˆ›Ý›Ý[™ÐTQ\œ›ÜˆÛÝ™\ˆHÛÛ™HÜˆ[š\BˆÈÛÛZ[™\‹ˆ™\]Y\Ý^Ù\[ÛˆÛÝ™\œÈHÜ›‹YÝÛˆY[[ÛˆÛØÚÙ]8 %ˆÈÛÛZ[™\œË™Ù]
 
+HOˆ[œÜXÝØÛÛZ[™\ˆ˜Z\Ù\È™\]Y\ÝÉÂˆÈÛÛ›™XÝ[Û‘\œ›Ü‹ÚXÚ\ÈHÚX›[™ÈÙˆØÚÙ\‹™\œ›ÜœËTQ\œ›Ü‚ˆÈ[™\ˆ™\]Y\ÝË”™\]Y\Ý^Ù\[Ûˆ
+›ÝHÝX˜Û\ÜÊKÛÈ]\ØØ\\ÂˆÈ[ˆTQ\œ›Ü‹[Û›HÝ\™\ÜÈ[™Ý\™˜XÙ\ÈH[˜XÙX˜XÚÈ]™[‚ˆÈÝYÚ\ÈX\™ÝÛˆ\ÈYX[È™H™\ÝYY™›Ü‚ˆÚ]ÛÛ^X‹œÝ\™\ÜÊˆØÚÙ\—Ù\œ›ÜœË“›Ý›Ý[™ØÚÙ\—Ù\œ›ÜœËTQ\œ›Ü‹™\]Y\Ý^Ù\[Û‚ˆ
+N‚ˆÙ[‹™ØÚÙ\—ØÛY[˜ÛÛZ[™\œË™Ù]
+ÛÛZ[™\—ÚY
+KšÚ[
 
-def _sandbox_network() -> str | None:
-    value = os.environ.get(_SANDBOX_NETWORK_ENV, "").strip()
-    return value or None
-
-
-def _apply_sandbox_network(create_kwargs: dict[str, Any]) -> None:
-    network = _sandbox_network()
-    if network:
-        create_kwargs["network"] = network
-        create_kwargs.pop("ports", None)
-
-
-def _apply_resource_limits(create_kwargs: dict[str, Any]) -> None:
-    """Apply optional cgroup resource caps from the environment. Unset/blank
-    values leave docker's default (unbounded), so this is opt-in per host."""
-    mem_limit = os.environ.get("STRIX_SANDBOX_MEM_LIMIT", "").strip()
-    if mem_limit:
-        create_kwargs["mem_limit"] = mem_limit
-
-    shm_size = os.environ.get("STRIX_SANDBOX_SHM_SIZE", "").strip()
-    if shm_size:
-        create_kwargs["shm_size"] = shm_size
-
-    cpus = os.environ.get("STRIX_SANDBOX_CPUS", "").strip()
-    if cpus:
-        with contextlib.suppress(ValueError, OverflowError):
-            nano_cpus = int(float(cpus) * 1_000_000_000)
-            if 0 < nano_cpus <= 2**63 - 1:
-                create_kwargs["nano_cpus"] = nano_cpus
-
-    pids_limit = os.environ.get("STRIX_SANDBOX_PIDS_LIMIT", "").strip()
-    if pids_limit:
-        with contextlib.suppress(ValueError):
-            create_kwargs["pids_limit"] = int(pids_limit)
-
-
-def _apply_log_limits(create_kwargs: dict[str, Any]) -> None:
-    """Bound the container's json-file log so a runaway process in the sandbox
-    (e.g. a tool that busy-loops writing to stdout) cannot fill the host disk
-    and take the Docker daemon down with it.
-
-    Unlike the cgroup caps above, this defaults **on** â€” docker's own default
-    is an unbounded json-file, which is unsafe for an autonomous agent that
-    executes arbitrary commands. ``max-file`` rotation means the on-disk cap is
-    ``max-size * max-file``. Set ``STRIX_SANDBOX_LOG_MAX_SIZE`` to ``0``/``off``
-    to opt back out to docker's default."""
-    max_size = os.environ.get("STRIX_SANDBOX_LOG_MAX_SIZE", "50m").strip()
-    if max_size.lower() in ("0", "off", "none", "unlimited"):
-        return
-    max_file = os.environ.get("STRIX_SANDBOX_LOG_MAX_FILE", "3").strip() or "3"
-    create_kwargs["log_config"] = LogConfig(
-        type=LogConfig.types.JSON,
-        config={"max-size": max_size, "max-file": max_file},
-    )
-
-
-def _apply_run_labels(create_kwargs: dict[str, Any]) -> None:
-    run_id = os.getenv("STRIX_RUN_ID")
-    if not run_id:
-        return
-    labels = create_kwargs.setdefault("labels", {})
-    if not isinstance(labels, dict):
-        return
-    labels["strix-run-id"] = run_id
-    run_type = os.getenv("STRIX_RUN_TYPE")
-    if run_type:
-        labels["strix-run-type"] = run_type
-
-
-class StrixDockerSandboxSession(DockerSandboxSession):
-    sandbox_network: str = ""
-
-    async def _resolve_exposed_port(self, port: int) -> ExposedPortEndpoint:
-        try:
-            self._container.reload()
-        except docker_errors.APIError as e:
-            raise ExposedPortUnavailableError(
-                port=port,
-                exposed_ports=self.state.exposed_ports,
-                reason="backend_unavailable",
-                context={
-                    "backend": "docker",
-                    "detail": "container_reload_failed",
-                    "network": self.sandbox_network,
-                },
-                cause=e,
-            ) from e
-
-        attrs = getattr(self._container, "attrs", {}) or {}
-        networks = attrs.get("NetworkSettings", {}).get("Networks", {})
-        endpoint = networks.get(self.sandbox_network) or {}
-        ip = endpoint.get("IPAddress") or endpoint.get("GlobalIPv6Address")
-        if not isinstance(ip, str) or not ip:
-            raise ExposedPortUnavailableError(
-                port=port,
-                exposed_ports=self.state.exposed_ports,
-                reason="backend_unavailable",
-                context={
-                    "backend": "docker",
-                    "detail": "container_not_on_network",
-                    "network": self.sandbox_network,
-                },
-            )
-        host = f"[{ip}]" if ":" in ip else ip
-        return ExposedPortEndpoint(host=host, port=port, tls=False)
-
-
-class StrixDockerSandboxClient(DockerSandboxClient):
-    # Host directories to bind-mount into the container, set by the docker
-    # backend before ``create()``. Each item is ``{source, target, read_only}``.
-    strix_bind_mounts: list[dict[str, Any]] | None = None
-
-    async def _create_container(
-        self,
-        image: str,
-        *,
-        manifest: Manifest | None = None,
-        exposed_ports: tuple[int, ...] = (),
-        session_id: uuid.UUID | None = None,
-    ) -> Container:
-        # ----- BEGIN VERBATIM COPY of DockerSandboxClient._create_container -----
-        # SDK ref: src/agents/sandbox/sandboxes/docker.py:1434-1477 (v0.14.6).
-        if not self.image_exists(image):
-            repo, tag = parse_repository_tag(image)
-            self.docker_client.images.pull(repo, tag=tag or None, all_tags=False)
-
-        assert self.image_exists(image)
-        environment: dict[str, str] | None = None
-        if manifest:
-            environment = await manifest.environment.resolve()
-        # Strix delta from the SDK body: drop ``entrypoint`` override and
-        # supply ``tail -f /dev/null`` as ``command`` so the image's
-        # ENTRYPOINT (``docker-entrypoint.sh``) runs setup, then ``exec
-        # "$@"`` becomes ``exec tail -f /dev/null`` for the keep-alive.
-        # Without this, caido-cli + the in-container CA trust never get
-        # initialized.
-        create_kwargs: dict[str, Any] = {
-            "image": image,
-            "detach": True,
-            "command": ["tail", "-f", "/dev/null"],
-            "environment": environment,
-        }
-        if manifest is not None:
-            docker_mounts = _build_docker_volume_mounts(
-                manifest,
-                session_id=session_id,
-            )
-            if docker_mounts:
-                create_kwargs["mounts"] = docker_mounts
-            if _manifest_requires_fuse(manifest):
-                create_kwargs.update(
-                    devices=["/dev/fuse"],
-                    cap_add=["SYS_ADMIN"],
-                    security_opt=["apparmor:unconfined"],
-                )
-            elif _manifest_requires_sys_admin(manifest):
-                create_kwargs.update(
-                    cap_add=["SYS_ADMIN"],
-                    security_opt=["apparmor:unconfined"],
-                )
-        if exposed_ports:
-            create_kwargs["ports"] = {
-                _docker_port_key(port): ("127.0.0.1", None) for port in exposed_ports
-            }
-        # ----- END VERBATIM COPY -----
-
-        # Strix injections â€” append, don't overwrite, so FUSE/SYS_ADMIN survives.
-        cap_add = create_kwargs.setdefault("cap_add", [])
-        if not isinstance(cap_add, list):
-            cap_add = list(cap_add)
-            create_kwargs["cap_add"] = cap_add
-        for cap in ("NET_ADMIN", "NET_RAW"):
-            if cap not in cap_add:
-                cap_add.append(cap)
-
-        extra_hosts = create_kwargs.setdefault("extra_hosts", {})
-        extra_hosts["host.docker.internal"] = "host-gateway"
-
-        _apply_sandbox_network(create_kwargs)
-        _apply_resource_limits(create_kwargs)
-        _apply_log_limits(create_kwargs)
-        _apply_run_labels(create_kwargs)
-
-        # Strix injection: local source trees, sorted shallowest-first so a
-        # nested spec lands on top of the tree it covers.
-        bind_mounts = self.strix_bind_mounts or ()
-        if bind_mounts:
-            mounts = create_kwargs.setdefault("mounts", [])
-            for spec in sorted(bind_mounts, key=lambda s: str(s["target"]).count("/")):
-                mounts.append(
-                    DockerSDKMount(
-                        target=spec["target"],
-                        source=spec["source"],
-                        type="bind",
-                        read_only=spec.get("read_only", False),
-                    )
-                )
-
-        logger.debug(
-            "Creating sandbox container: image=%s caps=%s exposed_ports=%s",
-            image,
-            cap_add,
-            list(exposed_ports),
-        )
-        container = self.docker_client.containers.create(**create_kwargs)
-        logger.info(
-            "Sandbox container created: id=%s image=%s",
-            container.short_id if hasattr(container, "short_id") else "?",
-            image,
-        )
-        return container
-
-    async def create(self, **kwargs: Any) -> SandboxSession:
-        session = await super().create(**kwargs)
-        network = _sandbox_network()
-        inner = session._inner
-        if network and isinstance(inner, DockerSandboxSession):
-            inner.__class__ = StrixDockerSandboxSession
-            cast("StrixDockerSandboxSession", inner).sandbox_network = network
-        return session
-
-    async def delete(self, session: SandboxSession) -> SandboxSession:
-        container_id = getattr(getattr(session._inner, "state", None), "container_id", None)
-        if container_id:
-            # Best-effort kill: NotFound/APIError cover a gone or unhappy
-            # container. RequestException covers a torn-down daemon socket â€”
-            # containers.get() -> inspect_container raises requests'
-            # ConnectionError, which is a sibling of docker.errors.APIError
-            # under requests.RequestException (not a subclass), so it escapes
-            # an APIError-only suppress and surfaces a full traceback even
-            # though this teardown is meant to be best-effort.
-            with contextlib.suppress(
-                docker_errors.NotFound, docker_errors.APIError, RequestException
-            ):
-                self.docker_client.containers.get(container_id).kill()
-        return await super().delete(session)
+Bˆ™]\›ˆ]ØZ]Ý\\Š
+K™[]JÙ\ÜÚ[ÛŠB

--- a/strix/runtime/docker_client.py
+++ b/strix/runtime/docker_client.py
@@ -1,114 +1,307 @@
-­r‡^Ñf¥–Ø¦{[r‰Ý°ë­¦ëHˆˆ”Ýš^ØÚÙ\”Ø[™›ÞÛY[8 %™\Ù\™\ÈH[XYÙIÜÈS•–TÒS•[™YÂ“‘UÐQRS‹Ó‘UÔUÈØ\Xš[]Y\È
-ÈÜÝYØ]]Ø^K‚‚•HÑÉÜÈØÚÙ\”Ø[™›ÞÛY[—ØÜ™X]WØÛÛZ[™\˜Ù\È›Ý^ÜÙHHÛÚÈ›Ü‚™^[™[™ÈÜ™X]WÚÝØ\™ÜØ™Y›Ü™HÛÛZ[™\œË˜Ü™X]X\ÈØ[YˆÙHÝX˜Û\ÜÂ˜[™™Z[\[Y[HY]Ù›ÙH™\˜˜][Hœ›ÛHHÑÈÛÝ\˜ÙKÚ]™YB™[\Î‚‚ŒKˆ›ÜHÑÉÜÈ[ž\Ú[VÈZ[—XÝ™\œšYNÈÝ\HÈZ[‹‹Yˆ‹ˆ‹Ù]‹Û[—X\ÈÛÛ[X[™[œÝXYˆ\È]ÈÝ\ˆ[XYÙIÜÂˆØÚÙ\‹Y[ž\Ú[œÚXÝX[H[ˆ8 %Ú]Ý]]ØZYËXÛX™]™\‚ˆÝ\È[œÚYHHÛÛZ[™\ˆ[™›ÛÝÝ˜\ØØZYØ™]šY\ÈYØZ[œÝBˆXYÜ‚Œ‹ˆ\[™‘UÐQRS‹Ó‘UÔUÈÈØ\ØY
-™\]Z\™YžH›X\\ÔØ[™ˆÝ\ˆ˜]Ë\ÛØÚÙ]ÛÛÊK‚ŒËˆYÜÝ™ØÚÙ\‹š[\›˜[8¡¤ˆÜÝYØ]]Ø^HÈ^˜WÚÜÝØÛÈBˆYÙ[Ø[ˆ™XXÚÜÝ\Ù\™Y\Ë‚‚”[›™YÈÜ[˜ZKXYÙ[ÏOLŒM˜ˆ[\[™ÈHÑÈ™\]Z\™\Âœ™K[Y\™Ú[™ÈH\™[›ÙKˆ˜XÚÈ\Ý™X[H›Üˆ[ˆ[š™XÝ[ÛˆÛÚË‚ˆˆˆ‚‚™œ›ÛH×Ù]\™W×È[\Ü[››Ý][ÛœÂ‚š[\ÜÛÛ^X‚š[\ÜÙÙÚ[™Âš[\ÜÜÂš[\Ü]ZY™œ›ÛH\[™È[\Ü[žK]\˜[Ø\Ý‚™œ›ÛHYÙ[ËœØ[™›Þ™\œ›ÜœÈ[\Ü^ÜÙYÜ[˜]˜Z[X›Q\œ›Ü‚™œ›ÛHYÙ[ËœØ[™›Þ›X[šY™\Ý[\ÜX[šY™\Ý™œ›ÛHYÙ[ËœØ[™›ÞœØ[™›Þ\Ë™ØÚÙ\ˆ[\Ü
-ˆØÚÙ\”Ø[™›ÞÛY[ˆØÚÙ\”Ø[™›ÞÙ\ÜÚ[Û‹ˆØZ[ÙØÚÙ\—Ý›Û[YWÛ[Ý[ËˆÙØÚÙ\—ÜÜÚÙ^KˆÛX[šY™\ÝÜ™\]Z\™\×Ù\ÙKˆÛX[šY™\ÝÜ™\]Z\™\×ÜÞ\×ØYZ[‹ŠB™œ›ÛHYÙ[ËœØ[™›ÞœÙ\ÜÚ[Û‹œØ[™›ÞÜÙ\ÜÚ[Ûˆ[\ÜØ[™›ÞÙ\ÜÚ[Û‚™œ›ÛHYÙ[ËœØ[™›Þ\\È[\Ü^ÜÙYÜ[™Ú[™œ›ÛHØÚÙ\ˆ[\Ü\œ›ÜœÈ\ÈØÚÙ\—Ù\œ›ÜœÈÈ\NˆYÛ›Ü™VÚ[\Ü][\Y[\ÙYZYÛ›Ü™WB™œ›ÛHØÚÙ\‹›[Ù[Ë˜ÛÛZ[™\œÈ[\ÜÛÛZ[™\ˆÈ\NˆYÛ›Ü™VÚ[\Ü][\Y[\ÙYZYÛ›Ü™WB™œ›ÛHØÚÙ\‹\\È[\ÜÙÐÛÛ™šYÈÈ\NˆYÛ›Ü™VÚ[\Ü][\Y[\ÙYZYÛ›Ü™WB™œ›ÛHØÚÙ\‹\\È[\Ü[Ý[\ÈØÚÙ\”ÑÓ[Ý[È\NˆYÛ›Ü™VÚ[\Ü][\Y[\ÙYZYÛ›Ü™WB™œ›ÛHØÚÙ\‹][È[\Ü\œÙWÜ™\ÜÚ]ÜžWÝYÈÈ\NˆYÛ›Ü™VÚ[\Ü][\Y[\ÙYZYÛ›Ü™WB™œ›ÛH™\]Y\ÝË™^Ù\[ÛœÈ[\Ü™\]Y\Ý^Ù\[Û‚‚‚›ÙÙÙ\ˆHÙÙÚ[™Ë™Ù]ÙÙÙ\Š×Û˜[YW×ÊB‚‚—ÔÐS‘“ÖÓ‘UÓÔ’×ÑS•ˆH”Õ’VÑÐÒÑT—ÔÐS‘“ÖÓ‘UÓÔ’È‚‚‚™YˆÙ[œÝ\™WÚ[XYÙWØ]˜Z[X›JˆÛY[ˆ[žKˆ[XYÙNˆÝ‹ˆ[ÜÛXÞNˆ]\˜[È˜]]È‹›™]™\ˆ—KŠHOˆ›Û™N‚ˆYˆÛY[š[XYÙWÙ^\ÝÊ[XYÙJN‚ˆ™]\›‚ˆYˆ[ÜÛXÞHOH›™]™\ˆŽ‚ˆ˜Z\ÙH[[YQ\œ›ÜŠˆˆ‘ØÚÙ\ˆ[XYÙHÚ[XYÙH\ŸH\È›Ý]˜Z[X›HØØ[H[™‚ˆ”Õ’VÒSPQÑWÔSÔÓPÖO[™]™\ˆ›Ü˜šYÈ[[™È]‚ˆ
-Bˆ™\ËYÈH\œÙWÜ™\ÜÚ]ÜžWÝYÊ[XYÙJBˆÛY[™ØÚÙ\—ØÛY[š[XYÙ\Ëœ[
-™\ËYÏ]YÈÜˆ›Û™K[ÝYÜÏQ˜[ÙJB‚‚™YˆÜØ[™›ÞÛ™]ÛÜšÊ
-HOˆÝˆ›Û™N‚ˆ˜[YHHÜË™[š\›Û‹™Ù]
-ÔÐS‘“ÖÓ‘UÓÔ’×ÑS•‹ˆŠKœÝš\
+­r‡^Ñf¥–Ø¦{O,yÊ'vÃ®¶›­"""StrixDockerSandboxClient â€” preserves the image's ENTRYPOINT and adds
+NET_ADMIN/NET_RAW capabilities + host-gateway.
 
-Bˆ™]\›ˆ˜[YHÜˆ›Û™B‚‚™YˆØ\WÜØ[™›ÞÛ™]ÛÜšÊÜ™X]WÚÝØ\™ÜÎˆXÝÜÝ‹[žWJHOˆ›Û™N‚ˆ™]ÛÜšÈHÜØ[™›ÞÛ™]ÛÜšÊ
-BˆYˆ™]ÛÜšÎ‚ˆÜ™X]WÚÝØ\™ÜÖÈ›™]ÛÜšÈ—HH™]ÛÜšÂˆÜ™X]WÚÝØ\™ÜËœÜ
-œÜÈ‹›Û™JB‚‚™YˆØ\WÜ™\ÛÝ\˜ÙWÛ[Z]ÊÜ™X]WÚÝØ\™ÜÎˆXÝÜÝ‹[žWJHOˆ›Û™N‚ˆˆˆ\HÜ[Û˜[ÙÜ›Ý\™\ÛÝ\˜ÙHØ\Èœ›ÛHH[š\›Û›Y[ˆ[œÙ]Ø›[šÂˆ˜[Y\ÈX]™HØÚÙ\‰ÜÈY˜][
-[˜›Ý[™Y
-KÛÈ\È\ÈÜZ[ˆ\ˆÜÝˆˆˆ‚ˆY[WÛ[Z]HÜË™[š\›Û‹™Ù]
-”Õ’VÔÐS‘“ÖÓQSWÓSRU‹ˆŠKœÝš\
+The SDK's ``DockerSandboxClient._create_container`` does not expose a hook for
+extending ``create_kwargs`` before ``containers.create`` is called. We subclass
+and reimplement the method body verbatim from the SDK source, with three
+deltas:
 
-BˆYˆY[WÛ[Z]‚ˆÜ™X]WÚÝØ\™ÜÖÈ›Y[WÛ[Z]—HHY[WÛ[Z]‚ˆÚWÜÚ^™HHÜË™[š\›Û‹™Ù]
-”Õ’VÔÐS‘“ÖÔÒWÔÒV‘H‹ˆŠKœÝš\
+1. Drop the SDK's ``entrypoint=["tail"]`` override; supply ``["tail", "-f",
+   "/dev/null"]`` as ``command`` instead. This lets our image's
+   ``docker-entrypoint.sh`` actually run â€” without it, ``caido-cli`` never
+   starts inside the container and ``bootstrap_caido`` retries against a
+   dead port.
+2. Append NET_ADMIN/NET_RAW to ``cap_add`` (required by ``nmap -sS`` and
+   other raw-socket tools).
+3. Add ``host.docker.internal`` â†’ host-gateway to ``extra_hosts`` so the
+   agent can reach host-served apps.
 
-BˆYˆÚWÜÚ^™N‚ˆÜ™X]WÚÝØ\™ÜÖÈœÚWÜÚ^™H—HHÚWÜÚ^™B‚ˆÜ\ÈHÜË™[š\›Û‹™Ù]
-”Õ’VÔÐS‘“ÖÐÔTÈ‹ˆŠKœÝš\
+Pinned to ``openai-agents==0.14.6``. Bumping the SDK requires
+re-merging the parent body. Track upstream for an injection hook.
+"""
 
-BˆYˆÜ\Î‚ˆÚ]ÛÛ^X‹œÝ\™\ÜÊ˜[YQ\œ›Ü‹Ý™\™›ÝÑ\œ›ÜŠN‚ˆ˜[›×ØÜ\ÈH[
-›Ø]
-Ü\ÊH
-ˆWÌÌÌ
-BˆYˆ˜[›×ØÜ\ÈHŠŠŒÈHN‚ˆÜ™X]WÚÝØ\™ÜÖÈ›˜[›×ØÜ\È—HH˜[›×ØÜ\Â‚ˆY×Û[Z]HÜË™[š\›Û‹™Ù]
-”Õ’VÔÐS‘“ÖÔQ×ÓSRU‹ˆŠKœÝš\
+from __future__ import annotations
 
-BˆYˆY×Û[Z]‚ˆÚ]ÛÛ^X‹œÝ\™\ÜÊ˜[YQ\œ›ÜŠN‚ˆÜ™X]WÚÝØ\™ÜÖÈœY×Û[Z]—HH[
-Y×Û[Z]
-B‚‚™YˆØ\WÛÙ×Û[Z]ÊÜ™X]WÚÝØ\™ÜÎˆXÝÜÝ‹[žWJHOˆ›Û™N‚ˆˆˆ›Ý[™HÛÛZ[™\‰ÜÈœÛÛ‹Yš[HÙÈÛÈH[˜]Ø^H›ØÙ\ÜÈ[ˆHØ[™›Þˆ
-K™ËˆHÛÛ]\ÞK[ÛÜÈÜš][™ÈÈÝÝ]
-HØ[››Ýš[HÜÝ\ÚÂˆ[™ZÙHHØÚÙ\ˆY[[ÛˆÝÛˆÚ]]‚‚ˆ[›ZÙHHÙÜ›Ý\Ø\ÈX›Ý™K\ÈY˜][È
-Š›ÛŠŠˆ8 %ØÚÙ\‰ÜÈÝÛˆY˜][ˆ\È[ˆ[˜›Ý[™YœÛÛ‹Yš[KÚXÚ\È[œØY™H›Üˆ[ˆ]]Û›Û[Ý\ÈYÙ[]ˆ^XÝ]\È\˜š]˜\žHÛÛ[X[™ËˆX^Yš[X›Ý][ÛˆYX[œÈHÛ‹Y\ÚÈØ\\ÂˆX^\Ú^™H
-ˆX^Yš[XˆÙ]Õ’VÔÐS‘“ÖÓÑ×ÓPVÔÒV‘XÈØÙ™˜ˆÈÜ˜XÚÈÝ]ÈØÚÙ\‰ÜÈY˜][ˆˆˆ‚ˆX^ÜÚ^™HHÜË™[š\›Û‹™Ù]
-”Õ’VÔÐS‘“ÖÓÑ×ÓPVÔÒV‘H‹LHŠKœÝš\
+import contextlib
+import logging
+import os
+import uuid
+from typing import Any, Literal, cast
 
-BˆYˆX^ÜÚ^™K›ÝÙ\Š
-H[ˆ
-Œ‹›Ù™ˆ‹››Û™H‹[›[Z]YŠN‚ˆ™]\›‚ˆX^Ùš[HHÜË™[š\›Û‹™Ù]
-”Õ’VÔÐS‘“ÖÓÑ×ÓPVÑ’SH‹ŒÈŠKœÝš\
+from agents.sandbox.errors import ExposedPortUnavailableError
+from agents.sandbox.manifest import Manifest
+from agents.sandbox.sandboxes.docker import (
+    DockerSandboxClient,
+    DockerSandboxSession,
+    _build_docker_volume_mounts,
+    _docker_port_key,
+    _manifest_requires_fuse,
+    _manifest_requires_sys_admin,
+)
+from agents.sandbox.session.sandbox_session import SandboxSession
+from agents.sandbox.types import ExposedPortEndpoint
+from docker import errors as docker_errors  # type: ignore[import-untyped, unused-ignore]
+from docker.models.containers import Container  # type: ignore[import-untyped, unused-ignore]
+from docker.types import LogConfig  # type: ignore[import-untyped, unused-ignore]
+from docker.types import Mount as DockerSDKMount  # type: ignore[import-untyped, unused-ignore]
+from docker.utils import parse_repository_tag  # type: ignore[import-untyped, unused-ignore]
+from requests.exceptions import RequestException
 
-HÜˆŒÈ‚ˆÜ™X]WÚÝØ\™ÜÖÈ›Ù×ØÛÛ™šYÈ—HHÙÐÛÛ™šYÊˆ\OSÙÐÛÛ™šYË\\Ë’”ÓÓ‹ˆÛÛ™šYÏ^È›X^\Ú^™HŽˆX^ÜÚ^™K›X^Yš[HŽˆX^Ùš[_Kˆ
-B‚‚™YˆØ\WÜ[—ÛX™[ÊÜ™X]WÚÝØ\™ÜÎˆXÝÜÝ‹[žWJHOˆ›Û™N‚ˆ[—ÚYHÜË™Ù][Š”Õ’VÔ•S—ÒQŠBˆYˆ›Ý[—ÚY‚ˆ™]\›‚ˆX™[ÈHÜ™X]WÚÝØ\™ÜËœÙ]Y˜][
-›X™[È‹ßJBˆYˆ›Ý\Ú[œÝ[˜ÙJX™[ËXÝ
-N‚ˆ™]\›‚ˆX™[ÖÈœÝš^\[‹ZY—HH[—ÚYˆ[—Ý\HHÜË™Ù][Š”Õ’VÔ•S—ÕTHŠBˆYˆ[—Ý\N‚ˆX™[ÖÈœÝš^\[‹]\H—HH[—Ý\B‚‚˜Û\ÜÈÝš^ØÚÙ\”Ø[™›ÞÙ\ÜÚ[ÛŠØÚÙ\”Ø[™›ÞÙ\ÜÚ[ÛŠN‚ˆØ[™›ÞÛ™]ÛÜšÎˆÝˆHˆ‚‚ˆ\Þ[˜ÈYˆÜ™\ÛÛ™WÙ^ÜÙYÜÜ
-Ù[‹Üˆ[
-HOˆ^ÜÙYÜ[™Ú[‚ˆžN‚ˆÙ[‹—ØÛÛZ[™\‹œ™[ØY
 
-Bˆ^Ù\ØÚÙ\—Ù\œ›ÜœËTQ\œ›Üˆ\ÈN‚ˆ˜Z\ÙH^ÜÙYÜ[˜]˜Z[X›Q\œ›ÜŠˆÜ\Üˆ^ÜÙYÜÜÏ\Ù[‹œÝ]K™^ÜÙYÜÜËˆ™X\ÛÛH˜˜XÚÙ[™Ý[˜]˜Z[X›H‹ˆÛÛ^^Âˆ˜˜XÚÙ[™Žˆ™ØÚÙ\ˆ‹ˆ™]Z[Žˆ˜ÛÛZ[™\—Ü™[ØYÙ˜Z[Y‹ˆ›™]ÛÜšÈŽˆÙ[‹œØ[™›ÞÛ™]ÛÜšËˆKˆØ]\ÙOYKˆ
-Hœ›ÛHB‚ˆ]œÈHÙ]]ŠÙ[‹—ØÛÛZ[™\‹˜]œÈ‹ßJHÜˆßBˆ™]ÛÜšÜÈH]œË™Ù]
-“™]ÛÜšÔÙ][™ÜÈ‹ßJK™Ù]
-“™]ÛÜšÜÈ‹ßJBˆ[™Ú[H™]ÛÜšÜË™Ù]
-Ù[‹œØ[™›ÞÛ™]ÛÜšÊHÜˆßBˆ\H[™Ú[™Ù]
-’TY™\ÜÈŠHÜˆ[™Ú[™Ù]
-‘ÛØ˜[TY™\ÜÈŠBˆYˆ›Ý\Ú[œÝ[˜ÙJ\ÝŠHÜˆ›Ý\‚ˆ˜Z\ÙH^ÜÙYÜ[˜]˜Z[X›Q\œ›ÜŠˆÜ\Üˆ^ÜÙYÜÜÏ\Ù[‹œÝ]K™^ÜÙYÜÜËˆ™X\ÛÛH˜˜XÚÙ[™Ý[˜]˜Z[X›H‹ˆÛÛ^^Âˆ˜˜XÚÙ[™Žˆ™ØÚÙ\ˆ‹ˆ™]Z[Žˆ˜ÛÛZ[™\—Û›ÝÛÛ—Û™]ÛÜšÈ‹ˆ›™]ÛÜšÈŽˆÙ[‹œØ[™›ÞÛ™]ÛÜšËˆKˆ
-BˆÜÝHˆ–ÞÚ\WHˆYˆŽˆˆ[ˆ\[ÙH\ˆ™]\›ˆ^ÜÙYÜ[™Ú[
-ÜÝZÜÝÜ\ÜÏQ˜[ÙJB‚‚˜Û\ÜÈÝš^ØÚÙ\”Ø[™›ÞÛY[
-ØÚÙ\”Ø[™›ÞÛY[
-N‚ˆÈÜÝ\™XÝÜšY\ÈÈš[™[[Ý[[ÈHÛÛZ[™\‹Ù]žHHØÚÙ\‚ˆÈ˜XÚÙ[™™Y›Ü™HÜ™X]J
-XˆXXÚ][H\ÈÜÛÝ\˜ÙK\™Ù]™XYÛÛ›_X‚ˆÝš^Øš[™Û[Ý[Îˆ\ÝÙXÝÜÝ‹[žWWH›Û™HH›Û™Bˆ[XYÙWÜ[ÜÛXÞNˆ]\˜[È˜]]È‹›™]™\ˆ—HH˜]]È‚‚ˆ\Þ[˜ÈYˆØÜ™X]WØÛÛZ[™\ŠˆÙ[‹ˆ[XYÙNˆÝ‹ˆ
-‹ˆX[šY™\ÝˆX[šY™\Ý›Û™HH›Û™Kˆ^ÜÙYÜÜÎˆ\VÚ[‹‹—HH
+logger = logging.getLogger(__name__)
 
-KˆÙ\ÜÚ[Û—ÚYˆ]ZY•URQ›Û™HH›Û™Kˆ
-HOˆÛÛZ[™\Ž‚ˆÈKKKKH‘QÒSˆ‘TUSHÓÔHÙˆØÚÙ\”Ø[™›ÞÛY[—ØÜ™X]WØÛÛZ[™\ˆKKKKBˆÈÑÈ™YŽˆÜ˜ËØYÙ[ËÜØ[™›ÞÜØ[™›Þ\ËÙØÚÙ\‹œNŒMÍLMÍÈ
-ŒŒMŠK‚ˆÙ[œÝ\™WÚ[XYÙWØ]˜Z[X›JÙ[‹[XYÙKÙ[‹š[XYÙWÜ[ÜÛXÞJB‚ˆ\ÜÙ\Ù[‹š[XYÙWÙ^\ÝÊ[XYÙJBˆ[š\›Û›Y[ˆXÝÜÝ‹Ý—H›Û™HH›Û™BˆYˆX[šY™\Ý‚ˆ[š\›Û›Y[H]ØZ]X[šY™\Ý™[š\›Û›Y[œ™\ÛÛ™J
-BˆÈÝš^[Hœ›ÛHHÑÈ›ÙNˆ›Ü[ž\Ú[Ý™\œšYH[™ˆÈÝ\HZ[YˆÙ]‹Û[\ÈÛÛ[X[™ÛÈH[XYÙIÜÂˆÈS•–TÒS•
-ØÚÙ\‹Y[ž\Ú[œÚ
-H[œÈÙ]\[ˆ^XÂˆÈ‰˜™XÛÛY\È^XÈZ[YˆÙ]‹Û[›ÜˆHÙY\X[]™K‚ˆÈÚ]Ý]\ËØZYËXÛH
-ÈH[‹XÛÛZ[™\ˆÐH\Ý™]™\ˆÙ]ˆÈ[š]X[^™Y‚ˆÜ™X]WÚÝØ\™ÜÎˆXÝÜÝ‹[žWHHÂˆš[XYÙHŽˆ[XYÙKˆ™]XÚŽˆYKˆ˜ÛÛ[X[™ŽˆÈZ[‹‹Yˆ‹‹Ù]‹Û[—Kˆ™[š\›Û›Y[Žˆ[š\›Û›Y[ˆBˆYˆX[šY™\Ý\È›Ý›Û™N‚ˆØÚÙ\—Û[Ý[ÈHØZ[ÙØÚÙ\—Ý›Û[YWÛ[Ý[ÊˆX[šY™\ÝˆÙ\ÜÚ[Û—ÚY\Ù\ÜÚ[Û—ÚYˆ
-BˆYˆØÚÙ\—Û[Ý[Î‚ˆÜ™X]WÚÝØ\™ÜÖÈ›[Ý[È—HHØÚÙ\—Û[Ý[ÂˆYˆÛX[šY™\ÝÜ™\]Z\™\×Ù\ÙJX[šY™\Ý
-N‚ˆÜ™X]WÚÝØ\™ÜË\]Jˆ]šXÙ\ÏVÈ‹Ù]‹Ù\ÙH—KˆØ\ØYVÈ”ÖT×ÐQRSˆ—KˆÙXÝ\š]WÛÜVÈ˜\\›[ÜŽ[˜ÛÛ™š[™Y—Kˆ
-Bˆ[YˆÛX[šY™\ÝÜ™\]Z\™\×ÜÞ\×ØYZ[ŠX[šY™\Ý
-N‚ˆÜ™X]WÚÝØ\™ÜË\]JˆØ\ØYVÈ”ÖT×ÐQRSˆ—KˆÙXÝ\š]WÛÜVÈ˜\\›[ÜŽ[˜ÛÛ™š[™Y—Kˆ
-BˆYˆ^ÜÙYÜÜÎ‚ˆÜ™X]WÚÝØ\™ÜÖÈœÜÈ—HHÂˆÙØÚÙ\—ÜÜÚÙ^JÜ
-Nˆ
-ŒLËŒŒŒH‹›Û™JH›ÜˆÜ[ˆ^ÜÙYÜÜÂˆBˆÈKKKKHS‘‘TUSHÓÔHKKKKB‚ˆÈÝš^[š™XÝ[ÛœÈ8 %\[™Û‰ÝÝ™\Üš]KÛÈ•TÑKÔÖT×ÐQRSˆÝ\š]™\Ë‚ˆØ\ØYHÜ™X]WÚÝØ\™ÜËœÙ]Y˜][
-˜Ø\ØY‹×JBˆYˆ›Ý\Ú[œÝ[˜ÙJØ\ØY\Ý
-N‚ˆØ\ØYH\Ý
-Ø\ØY
-BˆÜ™X]WÚÝØ\™ÜÖÈ˜Ø\ØY—HHØ\ØYˆ›ÜˆØ\[ˆ
-“‘UÐQRSˆ‹“‘UÔUÈŠN‚ˆYˆØ\›Ý[ˆØ\ØY‚ˆØ\ØY˜\[™
-Ø\
-B‚ˆ^˜WÚÜÝÈHÜ™X]WÚÝØ\™ÜËœÙ]Y˜][
-™^˜WÚÜÝÈ‹ßJBˆ^˜WÚÜÝÖÈšÜÝ™ØÚÙ\‹š[\›˜[—HHšÜÝYØ]]Ø^H‚‚ˆØ\WÜØ[™›ÞÛ™]ÛÜšÊÜ™X]WÚÝØ\™ÜÊBˆØ\WÜ™\ÛÝ\˜ÙWÛ[Z]ÊÜ™X]WÚÝØ\™ÜÊBˆØ\WÛÙ×Û[Z]ÊÜ™X]WÚÝØ\™ÜÊBˆØ\WÜ[—ÛX™[ÊÜ™X]WÚÝØ\™ÜÊB‚ˆÈÝš^[š™XÝ[ÛŽˆØØ[ÛÝ\˜ÙH™Y\ËÛÜYÚ[ÝÙ\ÝYš\œÝÛÈBˆÈ™\ÝYÜXÈ[™ÈÛˆÜÙˆH™YH]ÛÝ™\œË‚ˆš[™Û[Ý[ÈHÙ[‹œÝš^Øš[™Û[Ý[ÈÜˆ
 
-BˆYˆš[™Û[Ý[Î‚ˆ[Ý[ÈHÜ™X]WÚÝØ\™ÜËœÙ]Y˜][
-›[Ý[È‹×JBˆ›ÜˆÜXÈ[ˆÛÜY
-š[™Û[Ý[ËÙ^O[[X™HÎˆÝŠÖÈ\™Ù]—JK˜ÛÝ[
-‹ÈŠJN‚ˆ[Ý[Ë˜\[™
-ˆØÚÙ\”ÑÓ[Ý[
-ˆ\™Ù]\ÜXÖÈ\™Ù]—KˆÛÝ\˜ÙO\ÜXÖÈœÛÝ\˜ÙH—Kˆ\OH˜š[™‹ˆ™XYÛÛ›O\ÜXË™Ù]
-œ™XYÛÛ›H‹˜[ÙJKˆ
-Bˆ
-B‚ˆÙÙÙ\‹™XYÊˆÜ™X][™ÈØ[™›ÞÛÛZ[™\Žˆ[XYÙOI\ÈØ\ÏI\È^ÜÙYÜÜÏI\È‹ˆ[XYÙKˆØ\ØYˆ\Ý
-^ÜÙYÜÜÊKˆ
-BˆÛÛZ[™\ˆHÙ[‹™ØÚÙ\—ØÛY[˜ÛÛZ[™\œË˜Ü™X]J
-Š˜Ü™X]WÚÝØ\™ÜÊBˆÙÙÙ\‹š[™›Êˆ”Ø[™›ÞÛÛZ[™\ˆÜ™X]YˆYI\È[XYÙOI\È‹ˆÛÛZ[™\‹œÚÜÚYYˆ\Ø]ŠÛÛZ[™\‹œÚÜÚYŠH[ÙHÈ‹ˆ[XYÙKˆ
-Bˆ™]\›ˆÛÛZ[™\‚‚ˆ\Þ[˜ÈYˆÜ™X]JÙ[‹
-ŠšÝØ\™ÜÎˆ[žJHOˆØ[™›ÞÙ\ÜÚ[ÛŽ‚ˆÙ\ÜÚ[ÛˆH]ØZ]Ý\\Š
-K˜Ü™X]J
-ŠšÝØ\™ÜÊBˆ™]ÛÜšÈHÜØ[™›ÞÛ™]ÛÜšÊ
-Bˆ[›™\ˆHÙ\ÜÚ[Û‹—Ú[›™\‚ˆYˆ™]ÛÜšÈ[™\Ú[œÝ[˜ÙJ[›™\‹ØÚÙ\”Ø[™›ÞÙ\ÜÚ[ÛŠN‚ˆ[›™\‹—×ØÛ\Ü××ÈHÝš^ØÚÙ\”Ø[™›ÞÙ\ÜÚ[Û‚ˆØ\Ý
-”Ýš^ØÚÙ\”Ø[™›ÞÙ\ÜÚ[Ûˆ‹[›™\ŠKœØ[™›ÞÛ™]ÛÜšÈH™]ÛÜšÂˆ™]\›ˆÙ\ÜÚ[Û‚‚ˆ\Þ[˜ÈYˆ[]JÙ[‹Ù\ÜÚ[ÛŽˆØ[™›ÞÙ\ÜÚ[ÛŠHOˆØ[™›ÞÙ\ÜÚ[ÛŽ‚ˆÛÛZ[™\—ÚYHÙ]]ŠÙ]]ŠÙ\ÜÚ[Û‹—Ú[›™\‹œÝ]H‹›Û™JK˜ÛÛZ[™\—ÚY‹›Û™JBˆYˆÛÛZ[™\—ÚY‚ˆÈ™\ÝYY™›ÜÚ[ˆ›Ý›Ý[™ÐTQ\œ›ÜˆÛÝ™\ˆHÛÛ™HÜˆ[š\BˆÈÛÛZ[™\‹ˆ™\]Y\Ý^Ù\[ÛˆÛÝ™\œÈHÜ›‹YÝÛˆY[[ÛˆÛØÚÙ]8 %ˆÈÛÛZ[™\œË™Ù]
+_SANDBOX_NETWORK_ENV = "STRIX_DOCKER_SANDBOX_NETWORK"
 
-HOˆ[œÜXÝØÛÛZ[™\ˆ˜Z\Ù\È™\]Y\ÝÉÂˆÈÛÛ›™XÝ[Û‘\œ›Ü‹ÚXÚ\ÈHÚX›[™ÈÙˆØÚÙ\‹™\œ›ÜœËTQ\œ›Ü‚ˆÈ[™\ˆ™\]Y\ÝË”™\]Y\Ý^Ù\[Ûˆ
-›ÝHÝX˜Û\ÜÊKÛÈ]\ØØ\\ÂˆÈ[ˆTQ\œ›Ü‹[Û›HÝ\™\ÜÈ[™Ý\™˜XÙ\ÈH[˜XÙX˜XÚÈ]™[‚ˆÈÝYÚ\ÈX\™ÝÛˆ\ÈYX[È™H™\ÝYY™›Ü‚ˆÚ]ÛÛ^X‹œÝ\™\ÜÊˆØÚÙ\—Ù\œ›ÜœË“›Ý›Ý[™ØÚÙ\—Ù\œ›ÜœËTQ\œ›Ü‹™\]Y\Ý^Ù\[Û‚ˆ
-N‚ˆÙ[‹™ØÚÙ\—ØÛY[˜ÛÛZ[™\œË™Ù]
-ÛÛZ[™\—ÚY
-KšÚ[
 
-Bˆ™]\›ˆ]ØZ]Ý\\Š
-K™[]JÙ\ÜÚ[ÛŠB
+def _ensure_image_available(
+    client: Any,
+    image: str,
+    pull_policy: Literal["auto", "never"],
+) -> None:
+    if client.image_exists(image):
+        return
+    if pull_policy == "never":
+        raise RuntimeError(
+            f"Docker image {image!r} is not available locally and "
+            "STRIX_IMAGE_PULL_POLICY=never forbids pulling it"
+        )
+    repo, tag = parse_repository_tag(image)
+    client.docker_client.images.pull(repo, tag=tag or None, all_tags=False)
+
+
+def _sandbox_network() -> str | None:
+    value = os.environ.get(_SANDBOX_NETWORK_ENV, "").strip()
+    return value or None
+
+
+def _apply_sandbox_network(create_kwargs: dict[str, Any]) -> None:
+    network = _sandbox_network()
+    if network:
+        create_kwargs["network"] = network
+        create_kwargs.pop("ports", None)
+
+
+def _apply_resource_limits(create_kwargs: dict[str, Any]) -> None:
+    """Apply optional cgroup resource caps from the environment. Unset/blank
+    values leave docker's default (unbounded), so this is opt-in per host."""
+    mem_limit = os.environ.get("STRIX_SANDBOX_MEM_LIMIT", "").strip()
+    if mem_limit:
+        create_kwargs["mem_limit"] = mem_limit
+
+    shm_size = os.environ.get("STRIX_SANDBOX_SHM_SIZE", "").strip()
+    if shm_size:
+        create_kwargs["shm_size"] = shm_size
+
+    cpus = os.environ.get("STRIX_SANDBOX_CPUS", "").strip()
+    if cpus:
+        with contextlib.suppress(ValueError, OverflowError):
+            nano_cpus = int(float(cpus) * 1_000_000_000)
+            if 0 < nano_cpus <= 2**63 - 1:
+                create_kwargs["nano_cpus"] = nano_cpus
+
+    pids_limit = os.environ.get("STRIX_SANDBOX_PIDS_LIMIT", "").strip()
+    if pids_limit:
+        with contextlib.suppress(ValueError):
+            create_kwargs["pids_limit"] = int(pids_limit)
+
+
+def _apply_log_limits(create_kwargs: dict[str, Any]) -> None:
+    """Bound the container's json-file log so a runaway process in the sandbox
+    (e.g. a tool that busy-loops writing to stdout) cannot fill the host disk
+    and take the Docker daemon down with it.
+
+    Unlike the cgroup caps above, this defaults **on** â€” docker's own default
+    is an unbounded json-file, which is unsafe for an autonomous agent that
+    executes arbitrary commands. ``max-file`` rotation means the on-disk cap is
+    ``max-size * max-file``. Set ``STRIX_SANDBOX_LOG_MAX_SIZE`` to ``0``/``off``
+    to opt back out to docker's default."""
+    max_size = os.environ.get("STRIX_SANDBOX_LOG_MAX_SIZE", "50m").strip()
+    if max_size.lower() in ("0", "off", "none", "unlimited"):
+        return
+    max_file = os.environ.get("STRIX_SANDBOX_LOG_MAX_FILE", "3").strip() or "3"
+    create_kwargs["log_config"] = LogConfig(
+        type=LogConfig.types.JSON,
+        config={"max-size": max_size, "max-file": max_file},
+    )
+
+
+def _apply_run_labels(create_kwargs: dict[str, Any]) -> None:
+    run_id = os.getenv("STRIX_RUN_ID")
+    if not run_id:
+        return
+    labels = create_kwargs.setdefault("labels", {})
+    if not isinstance(labels, dict):
+        return
+    labels["strix-run-id"] = run_id
+    run_type = os.getenv("STRIX_RUN_TYPE")
+    if run_type:
+        labels["strix-run-type"] = run_type
+
+
+class StrixDockerSandboxSession(DockerSandboxSession):
+    sandbox_network: str = ""
+
+    async def _resolve_exposed_port(self, port: int) -> ExposedPortEndpoint:
+        try:
+            self._container.reload()
+        except docker_errors.APIError as e:
+            raise ExposedPortUnavailableError(
+                port=port,
+                exposed_ports=self.state.exposed_ports,
+                reason="backend_unavailable",
+                context={
+                    "backend": "docker",
+                    "detail": "container_reload_failed",
+                    "network": self.sandbox_network,
+                },
+                cause=e,
+            ) from e
+
+        attrs = getattr(self._container, "attrs", {}) or {}
+        networks = attrs.get("NetworkSettings", {}).get("Networks", {})
+        endpoint = networks.get(self.sandbox_network) or {}
+        ip = endpoint.get("IPAddress") or endpoint.get("GlobalIPv6Address")
+        if not isinstance(ip, str) or not ip:
+            raise ExposedPortUnavailableError(
+                port=port,
+                exposed_ports=self.state.exposed_ports,
+                reason="backend_unavailable",
+                context={
+                    "backend": "docker",
+                    "detail": "container_not_on_network",
+                    "network": self.sandbox_network,
+                },
+            )
+        host = f"[{ip}]" if ":" in ip else ip
+        return ExposedPortEndpoint(host=host, port=port, tls=False)
+
+
+class StrixDockerSandboxClient(DockerSandboxClient):
+    # Host directories to bind-mount into the container, set by the docker
+    # backend before ``create()``. Each item is ``{source, target, read_only}``.
+    strix_bind_mounts: list[dict[str, Any]] | None = None
+    image_pull_policy: Literal["auto", "never"] = "auto"
+
+    async def _create_container(
+        self,
+        image: str,
+        *,
+        manifest: Manifest | None = None,
+        exposed_ports: tuple[int, ...] = (),
+        session_id: uuid.UUID | None = None,
+    ) -> Container:
+        # ----- BEGIN VERBATIM COPY of DockerSandboxClient._create_container -----
+        # SDK ref: src/agents/sandbox/sandboxes/docker.py:1434-1477 (v0.14.6).
+        _ensure_image_available(self, image, self.image_pull_policy)
+
+        assert self.image_exists(image)
+        environment: dict[str, str] | None = None
+        if manifest:
+            environment = await manifest.environment.resolve()
+        # Strix delta from the SDK body: drop ``entrypoint`` override and
+        # supply ``tail -f /dev/null`` as ``command`` so the image's
+        # ENTRYPOINT (``docker-entrypoint.sh``) runs setup, then ``exec
+        # "$@"`` becomes ``exec tail -f /dev/null`` for the keep-alive.
+        # Without this, caido-cli + the in-container CA trust never get
+        # initialized.
+        create_kwargs: dict[str, Any] = {
+            "image": image,
+            "detach": True,
+            "command": ["tail", "-f", "/dev/null"],
+            "environment": environment,
+        }
+        if manifest is not None:
+            docker_mounts = _build_docker_volume_mounts(
+                manifest,
+                session_id=session_id,
+            )
+            if docker_mounts:
+                create_kwargs["mounts"] = docker_mounts
+            if _manifest_requires_fuse(manifest):
+                create_kwargs.update(
+                    devices=["/dev/fuse"],
+                    cap_add=["SYS_ADMIN"],
+                    security_opt=["apparmor:unconfined"],
+                )
+            elif _manifest_requires_sys_admin(manifest):
+                create_kwargs.update(
+                    cap_add=["SYS_ADMIN"],
+                    security_opt=["apparmor:unconfined"],
+                )
+        if exposed_ports:
+            create_kwargs["ports"] = {
+                _docker_port_key(port): ("127.0.0.1", None) for port in exposed_ports
+            }
+        # ----- END VERBATIM COPY -----
+
+        # Strix injections â€” append, don't overwrite, so FUSE/SYS_ADMIN survives.
+        cap_add = create_kwargs.setdefault("cap_add", [])
+        if not isinstance(cap_add, list):
+            cap_add = list(cap_add)
+            create_kwargs["cap_add"] = cap_add
+        for cap in ("NET_ADMIN", "NET_RAW"):
+            if cap not in cap_add:
+                cap_add.append(cap)
+
+        extra_hosts = create_kwargs.setdefault("extra_hosts", {})
+        extra_hosts["host.docker.internal"] = "host-gateway"
+
+        _apply_sandbox_network(create_kwargs)
+        _apply_resource_limits(create_kwargs)
+        _apply_log_limits(create_kwargs)
+        _apply_run_labels(create_kwargs)
+
+        # Strix injection: local source trees, sorted shallowest-first so a
+        # nested spec lands on top of the tree it covers.
+        bind_mounts = self.strix_bind_mounts or ()
+        if bind_mounts:
+            mounts = create_kwargs.setdefault("mounts", [])
+            for spec in sorted(bind_mounts, key=lambda s: str(s["target"]).count("/")):
+                mounts.append(
+                    DockerSDKMount(
+                        target=spec["target"],
+                        source=spec["source"],
+                        type="bind",
+                        read_only=spec.get("read_only", False),
+                    )
+                )
+
+        logger.debug(
+            "Creating sandbox container: image=%s caps=%s exposed_ports=%s",
+            image,
+            cap_add,
+            list(exposed_ports),
+        )
+        container = self.docker_client.containers.create(**create_kwargs)
+        logger.info(
+            "Sandbox container created: id=%s image=%s",
+            container.short_id if hasattr(container, "short_id") else "?",
+            image,
+        )
+        return container
+
+    async def create(self, **kwargs: Any) -> SandboxSession:
+        session = await super().create(**kwargs)
+        network = _sandbox_network()
+        inner = session._inner
+        if network and isinstance(inner, DockerSandboxSession):
+            inner.__class__ = StrixDockerSandboxSession
+            cast("StrixDockerSandboxSession", inner).sandbox_network = network
+        return session
+
+    async def delete(self, session: SandboxSession) -> SandboxSession:
+        container_id = getattr(getattr(session._inner, "state", None), "container_id", None)
+        if container_id:
+            # Best-effort kill: NotFound/APIError cover a gone or unhappy
+            # container. RequestException covers a torn-down daemon socket â€”
+            # containers.get() -> inspect_container raises requests'
+            # ConnectionError, which is a sibling of docker.errors.APIError
+            # under requests.RequestException (not a subclass), so it escapes
+            # an APIError-only suppress and surfaces a full traceback even
+            # though this teardown is meant to be best-effort.
+            with contextlib.suppress(
+                docker_errors.NotFound, docker_errors.APIError, RequestException
+            ):
+                self.docker_client.containers.get(container_id).kill()
+        return await super().delete(session)

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,218 +1,66 @@
-"""Tests for strix.config.loader: JSON overrides, alias resolution, persistence."""
+­r‡^Ñf¥–Ø¦{[r‰İ°ë­¦ëHˆˆ•\İÈ›Üˆİš^˜ÛÛ™šYË›ØY\ˆ”ÓÓˆİ™\œšY\Ë[X\È™\ÛÛ][Û‹\œÚ\İ[˜ÙKˆˆˆ‚‚™œ›ÛH×Ù]\™W×È[\Ü[››İ][ÛœÂ‚š[\ÜœÛÛ‚™œ›ÛH\[™È[\ÜTWĞÒPÒÒS‘Â‚š[\Ü]\İ™œ›ÛHY[XÈ[\Ü[X\ĞÚÚXÙ\ËšY[˜[Y][Û‘\œ›Ü‚™œ›ÛHY[XË™šY[È[\ÜšY[[™›Â‚™œ›ÛHİš^˜ÛÛ™šYÈ[\ÜØY\‚™œ›ÛHİš^˜ÛÛ™šYËœÙ][™ÜÈ[\ÜÛÛ^Ù][™ÜÂ‚‚šYˆTWĞÒPÒÒS‘Î‚ˆœ›ÛH]Xˆ[\Ü]‚‚—ÓWÑS•—ÒÑVTÈHÂˆ”Õ’VÓH‹ˆ“WĞTWÒÑVH‹ˆ“ÔSRWĞTWÒÑVH‹ˆ“WĞTWĞTÑH‹ˆ“ÔSRWĞTWĞTÑH‹ˆ“ÔSRWĞTÑWÕT“‹ˆ“USWĞTÑWÕT“‹ˆ“ÓSPWĞTWĞTÑH‹ˆ”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•‹ˆ”Õ’VÑ“ÔÑWÔ‘TURT‘QÕÓÓĞÒÒPÑH‹ˆ“WÕSQSÕU‹ˆ”T”VUWĞTWÒÑVH‹ˆÈ[[YTÙ][™ÜÂˆ”Õ’VÒSPQÑH‹ˆ”Õ’VÒSPQÑWÔSÔÓPÖH‹ˆ”Õ’VÔ•S•SQWĞPÒÑS‘‹ˆ”Õ’VĞĞRQ×Ğ“ÓÕÕĞRUÔÈ‹ˆÈ[[Y]TÙ][™ÜÂˆ”Õ’VÕSSQU–H‹—B‚‚]\İ™š^\™J]]İ\ÙOUYJB™YˆÜ™\Ù]ÛØY\—Üİ]J[ÛšÙ^\]Úˆ]\İ“[ÛšÙ^T]Ú
+HOˆ›Û™N‚ˆˆˆ”™\Ù][Ù[HÛØ˜[È[™ÛX\ˆÛ›İÛˆ[ˆ˜\œÈ›Üˆ]\›Z[š\İXÈ[œËˆˆˆ‚ˆ›ÜˆÙ^H[ˆÓWÑS•—ÒÑVTÎ‚ˆ[ÛšÙ^\]Ú™[[ŠÙ^K˜Z\Ú[™ÏQ˜[ÙJBˆ[ÛšÙ^\]ÚœÙ]]ŠØY\‹—ØØXÚY‹›Û™JBˆ[ÛšÙ^\]ÚœÙ]]ŠØY\‹—Ûİ™\œšYH‹›Û™JB‚‚ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂˆÈÜ™XYÚœÛÛ—Ûİ™\œšY\ÂˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂ‚‚™Yˆ\İÜ™XYÚœÛÛ—Ûİ™\œšY\×ÛZ\ÜÚ[™×Ùš[J\Ü]ˆ]
+HOˆ›Û™N‚ˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—Ûİ™\œšY\Ê\Ü]È››ÜKšœÛÛˆŠHOHßB‚‚™Yˆ\İÜ™XYÚœÛÛ—Ûİ™\œšY\×ØÛÜœ\ÚœÛÛŠ\Ü]ˆ]
+HOˆ›Û™N‚ˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]Wİ^
+Û›İ˜[YœÛÛˆ‹[˜ÛÙ[™ÏH]‹NŠBˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—Ûİ™\œšY\Ê]
+HOHßB‚‚™Yˆ\İÜ™XYÚœÛÛ—Ûİ™\œšY\×Û›Û—ÙXİÙ[Š\Ü]ˆ]
+HOˆ›Û™N‚ˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]Wİ^
+œÛÛ‹™[\ÊÈ™[ˆˆÈ››İ‹˜H‹™Xİ—_JK[˜ÛÙ[™ÏH]‹NŠBˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—Ûİ™\œšY\Ê]
+HOHßB‚‚™Yˆ\İÜ™XYÚœÛÛ—Ûİ™\œšY\×ÛX\×İ×Û™\İYÜÙ][™ÜÊ\Ü]ˆ]
+HOˆ›Û™N‚ˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]Wİ^
+ˆœÛÛ‹™[\ÊÈ™[ˆˆÈ”Õ’VÓHˆ›^K[[Ù[‹”T”VUWĞTWÒÑVHˆœÈŸ_JKˆ[˜ÛÙ[™ÏH]‹N‹ˆ
+Bˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—Ûİ™\œšY\Ê]
+HOHÂˆ›HˆÈ›[Ù[ˆ›^K[[Ù[ŸKˆš[YÜ˜][ÛœÈˆÈœ\œ^]WØ\WÚÙ^HˆœÈŸKˆB‚‚™Yˆ\İÜ™XYÚœÛÛ—Ûİ™\œšY\×ÜÚÚ\×ÚÙ^\×Ø[™XYWÚ[—Ù[š\›ÛŠˆ\Ü]ˆ][ÛšÙ^\]Úˆ]\İ“[ÛšÙ^T]ÚŠHOˆ›Û™N‚ˆ[ÛšÙ^\]ÚœÙ][Š”Õ’VÓH‹™œ›ÛKY[ˆŠBˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]Wİ^
+œÛÛ‹™[\ÊÈ™[ˆˆÈ”Õ’VÓHˆ™œ›ÛKYš[HŸ_JK[˜ÛÙ[™ÏH]‹NŠBˆÈ[ˆÚ[œÈOˆH”ÓÓˆ˜[YH\È›İİ\™˜XÙY\È[ˆ[š]İØ\™Ë‚ˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—Ûİ™\œšY\Ê]
+HOHßB‚‚™Yˆ\İÜ™XYÚœÛÛ—Ûİ™\œšY\×Ù[—İÚ[œ×ØXÜ›ÜÜ×ÙšY[Ø[X\Ù\Êˆ\Ü]ˆ][ÛšÙ^\]Úˆ]\İ“[ÛšÙ^T]ÚŠHOˆ›Û™N‚ˆÈ\WÚÙ^H™\ÛÛ™\Èœ›ÛH[X\ĞÚÚXÙ\Ê“WĞTWÒÑVH‹“ÔSRWĞTWÒÑVHŠKˆH[‚ˆÈÙ]ÈÛ™H[X\ÈÚ[HH\œÚ\İYš[HÛÈ[›İ\‹ˆ[ˆ]\İİ[Ú[‹ÛÂˆÈHİ[Hš[H˜[YH]\İ›İ™Hİ\™˜XÙY\È[ˆ[š]İØ\™È
+ÚXÚİ]˜[šÜÈ[ŠK‚ˆ[ÛšÙ^\]ÚœÙ][Š“ÔSRWĞTWÒÑVH‹œÚËY[ˆŠBˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]Wİ^
+œÛÛ‹™[\ÊÈ™[ˆˆÈ“WĞTWÒÑVHˆœÚËYš[HŸ_JK[˜ÛÙ[™ÏH]‹NŠBˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—Ûİ™\œšY\Ê]
+HOHßB‚‚™Yˆ\İÜ™XYÚœÛÛ—Ûİ™\œšY\×Ù[—İÚ[œ×ØØ\ÙWÚ[œÙ[œÚ]]™[Jˆ\Ü]ˆ][ÛšÙ^\]Úˆ]\İ“[ÛšÙ^T]ÚŠHOˆ›Û™N‚ˆÈÙ][™ÜÈ\ÙHØ\ÙWÜÙ[œÚ]]™OQ˜[ÙKÛÈHİÙ\˜Ø\ÙH[ˆ˜\ˆ[ÛÈÛİ[È\ÈÙ]‚ˆ[ÛšÙ^\]ÚœÙ][Šœİš^ÛH‹™œ›ÛKY[ˆŠBˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]Wİ^
+œÛÛ‹™[\ÊÈ™[ˆˆÈ”Õ’VÓHˆ™œ›ÛKYš[HŸ_JK[˜ÛÙ[™ÏH]‹NŠBˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—Ûİ™\œšY\Ê]
+HOHßB‚‚™Yˆ\İÜ™XYÚœÛÛ—Ûİ™\œšY\×İ\Ù\×ÚœÛÛ—İÚ[—Û›×Ø[X\×Ú[—Ù[š\›ÛŠ\Ü]ˆ]
+HOˆ›Û™N‚ˆÈ›È[X\ÈÙˆ\WÚÙ^H\ÈÙ][ˆH[š\›Û›Y[OˆHš[H˜[YH\È\ÙY]™[‚ˆÈÚ[ˆ]\ÈİÜ™Y[™\ˆH›Û‹Yš\œİ[X\Ë‚ˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]Wİ^
+œÛÛ‹™[\ÊÈ™[ˆˆÈ“ÔSRWĞTWÒÑVHˆœÚËYš[HŸ_JK[˜ÛÙ[™ÏH]‹NŠBˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—Ûİ™\œšY\Ê]
+HOHÈ›HˆÈ˜\WÚÙ^HˆœÚËYš[HŸ_B‚‚™Yˆ\İİÛÛÛİ]]ÛX^Ø]\×Ü™Z™Xİ×ÜİX—Û›İXÙWİ˜[Y\Ê
+HOˆ›Û™N‚ˆÚ]]\İœ˜Z\Ù\Ê˜[Y][Û‘\œ›ÜŠN‚ˆÛÛ^Ù][™ÜÊÕ’VÕÓÓÓÕUUÓPVĞ–UTÏM
+B‚‚™Yˆ\İİÛÛÛİ]]ÛX^Ø]\×ØXØÙ\×Ù›ÛÜŠ
+HOˆ›Û™N‚ˆ\ÜÙ\ÛÛ^Ù][™ÜÊÕ’VÕÓÓÓÕUUÓPVĞ–UTÏLL
+KÛÛÛİ]]ÛX^Ø]\ÈOHL‚‚™Yˆ\İÜ[[YWØØZY×Ø›ÛİİØZ]Ùœ›ÛWÙ[Š[ÛšÙ^\]Úˆ]\İ“[ÛšÙ^T]Ú
+HOˆ›Û™N‚ˆ[ÛšÙ^\]ÚœÙ][Š”Õ’VĞĞRQ×Ğ“ÓÕÕĞRUÔÈ‹LŠB‚ˆ\ÜÙ\ØY\‹›ØYÜÙ][™ÜÊ
+Kœ[[YK˜ØZY×Ø›ÛİİØZ]ÜÈOHL‚‚™Yˆ\İÜ[[YWÚ[XYÙWÜ[ÜÛXŞWÙœ›ÛWÙ[Š[ÛšÙ^\]Úˆ]\İ“[ÛšÙ^T]Ú
+HOˆ›Û™N‚ˆ[ÛšÙ^\]ÚœÙ][Š”Õ’VÒSPQÑWÔSÔÓPÖH‹›™]™\ˆŠB‚ˆ\ÜÙ\ØY\‹›ØYÜÙ][™ÜÊ
+Kœ[[YKš[XYÙWÜ[ÜÛXŞHOH›™]™\ˆ‚‚‚ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂˆÈØ[X\Ù\×Ù›Ü‚ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂ‚‚™Yˆ\İØ[X\Ù\×Ù›Ü—ÜÚ[\WØ[X\Ê
+HOˆ›Û™N‚ˆš[™›ÈHšY[[™›Ê[X\ÏH”ÒSTWĞSPTÈŠBˆ\ÜÙ\ØY\‹—Ø[X\Ù\×Ù›ÜŠš[™›ÊHOHÈ”ÒSTWĞSPTÈ—B‚‚™Yˆ\İØ[X\Ù\×Ù›Ü—Ø[X\×ØÚÚXÙ\Ê
+HOˆ›Û™N‚ˆš[™›ÎˆšY[[™›ÈHšY[
+È\NˆYÛ›Ü™VØ\ÜÚYÛ›Y[BˆY˜][S›Û™Kˆ˜[Y][Û—Ø[X\ÏP[X\ĞÚÚXÙ\Ê‘’T”Õ‹”ÑPÓÓ‘ŠKˆ
+Bˆ\ÜÙ\ØY\‹—Ø[X\Ù\×Ù›ÜŠš[™›ÊHOHÈ‘’T”Õ‹”ÑPÓÓ‘—B‚‚™Yˆ\İØ[X\Ù\×Ù›Ü—Üİš[™×İ˜[Y][Û—Ø[X\Ê
+HOˆ›Û™N‚ˆš[™›ÎˆšY[[™›ÈHšY[
+Y˜][S›Û™K˜[Y][Û—Ø[X\ÏH”Õ—ĞSPTÈŠHÈ\NˆYÛ›Ü™VØ\ÜÚYÛ›Y[Bˆ\ÜÙ\ØY\‹—Ø[X\Ù\×Ù›ÜŠš[™›ÊHOHÈ”Õ—ĞSPTÈ—B‚‚™Yˆ\İØ[X\Ù\×Ù›Ü—Û›×Ø[X\Ê
+HOˆ›Û™N‚ˆ\ÜÙ\ØY\‹—Ø[X\Ù\×Ù›ÜŠšY[[™›Ê
+JHOH×B‚‚ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂˆÈ\WØÛÛ™šY×Ûİ™\œšYH
+ÈØYÜÙ][™ÜÈ›İ[™]š\ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂ‚‚™Yˆ\İØ\WÛİ™\œšYWØ[™ÛØYÜÙ][™Ü×Ü›İ[™İš\
+\Ü]ˆ]
+HOˆ›Û™N‚ˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]Wİ^
+ˆœÛÛ‹™[\ÊÈ™[ˆˆÈ”Õ’VÓHˆœ›İ[™]š\[[Ù[‹”T”VUWĞTWÒÑVHˆœÈŸ_JKˆ[˜ÛÙ[™ÏH]‹N‹ˆ
+B‚ˆØY\‹˜\WØÛÛ™šY×Ûİ™\œšYJ]
+BˆÙ][™ÜÈHØY\‹›ØYÜÙ][™ÜÊ
+B‚ˆ\ÜÙ\Ù][™ÜË›K›[Ù[OHœ›İ[™]š\[[Ù[‚ˆ\ÜÙ\Ù][™ÜËš[YÜ˜][ÛœËœ\œ^]WØ\WÚÙ^HOHœÈ‚ˆÈÙXÛÛ™Ø[\ÈY[[Ú^™YOˆØ[YHØš™Xİ‚ˆ\ÜÙ\ØY\‹›ØYÜÙ][™ÜÊ
+H\ÈÙ][™ÜÂ‚‚™Yˆ\İØ\WØÛÛ™šY×Ûİ™\œšYWÚ[˜[Y]\×ØØXÚJ\Ü]ˆ]
+HOˆ›Û™N‚ˆš\œİH\Ü]È™š\œİšœÛÛˆ‚ˆš\œİÜš]Wİ^
+œÛÛ‹™[\ÊÈ™[ˆˆÈ”Õ’VÓHˆ™š\œİ[[Ù[Ÿ_JK[˜ÛÙ[™ÏH]‹NŠBˆÙXÛÛ™H\Ü]ÈœÙXÛÛ™šœÛÛˆ‚ˆÙXÛÛ™Üš]Wİ^
+œÛÛ‹™[\ÊÈ™[ˆˆÈ”Õ’VÓHˆœÙXÛÛ™[[Ù[Ÿ_JK[˜ÛÙ[™ÏH]‹NŠB‚ˆØY\‹˜\WØÛÛ™šY×Ûİ™\œšYJš\œİ
+Bˆ\ÜÙ\ØY\‹›ØYÜÙ][™ÜÊ
+K›K›[Ù[OH™š\œİ[[Ù[‚‚ˆØY\‹˜\WØÛÛ™šY×Ûİ™\œšYJÙXÛÛ™
+Bˆ\ÜÙ\ØY\‹›ØYÜÙ][™ÜÊ
+K›K›[Ù[OHœÙXÛÛ™[[Ù[‚‚‚ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂˆÈ\œÚ\İØİ\œ™[ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂ‚‚™Yˆ\İÜ\œÚ\İØİ\œ™[İÜš]\×Ù[—Ø›ØÚÊ\Ü]ˆ][ÛšÙ^\]Úˆ]\İ“[ÛšÙ^T]Ú
+HOˆ›Û™N‚ˆ[ÛšÙ^\]ÚœÙ][Š”Õ’VÓH‹œ\œÚ\İY[[Ù[ŠBˆ\™Ù]H\Ü]ÈœİXˆˆÈ˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆØY\‹˜\WØÛÛ™šY×Ûİ™\œšYJ\™Ù]
+B‚ˆØY\‹œ\œÚ\İØİ\œ™[
 
-from __future__ import annotations
+B‚ˆ\ÜÙ\\™Ù]™^\İÊ
+Bˆ\ÜÙ\œÛÛ‹›ØYÊ\™Ù]œ™XYİ^
+[˜ÛÙ[™ÏH]‹NŠJHOHÂˆ™[ˆˆÈ”Õ’VÓHˆœ\œÚ\İY[[Ù[ŸBˆB‚‚™Yˆ\İÜ\œÚ\İØİ\œ™[ÜÙ]×ÌŒÛ[ÙJ\Ü]ˆ][ÛšÙ^\]Úˆ]\İ“[ÛšÙ^T]Ú
+HOˆ›Û™N‚ˆ[ÛšÙ^\]ÚœÙ][Š”Õ’VÓH‹œ\œÚ\İY[[Ù[ŠBˆ\™Ù]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆØY\‹˜\WØÛÛ™šY×Ûİ™\œšYJ\™Ù]
+B‚ˆØY\‹œ\œÚ\İØİ\œ™[
 
-import json
-from typing import TYPE_CHECKING
+B‚ˆ\ÜÙ\\™Ù]œİ]
 
-import pytest
-from pydantic import AliasChoices, Field, ValidationError
-from pydantic.fields import FieldInfo
-
-from strix.config import loader
-from strix.config.settings import ContextSettings
-
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-
-_LLM_ENV_KEYS = [
-    "STRIX_LLM",
-    "LLM_API_KEY",
-    "OPENAI_API_KEY",
-    "LLM_API_BASE",
-    "OPENAI_API_BASE",
-    "OPENAI_BASE_URL",
-    "LITELLM_BASE_URL",
-    "OLLAMA_API_BASE",
-    "STRIX_REASONING_EFFORT",
-    "STRIX_FORCE_REQUIRED_TOOL_CHOICE",
-    "LLM_TIMEOUT",
-    "PERPLEXITY_API_KEY",
-    # RuntimeSettings
-    "STRIX_IMAGE",
-    "STRIX_RUNTIME_BACKEND",
-    # TelemetrySettings
-    "STRIX_TELEMETRY",
-]
-
-
-@pytest.fixture(autouse=True)
-def _reset_loader_state(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Reset module globals and clear known env vars for deterministic runs."""
-    for key in _LLM_ENV_KEYS:
-        monkeypatch.delenv(key, raising=False)
-    monkeypatch.setattr(loader, "_cached", None)
-    monkeypatch.setattr(loader, "_override", None)
-
-
-# --------------------------------------------------------------------------- #
-# _read_json_overrides
-# --------------------------------------------------------------------------- #
-
-
-def test_read_json_overrides_missing_file(tmp_path: Path) -> None:
-    assert loader._read_json_overrides(tmp_path / "nope.json") == {}
-
-
-def test_read_json_overrides_corrupt_json(tmp_path: Path) -> None:
-    path = tmp_path / "cli-config.json"
-    path.write_text("{not valid json", encoding="utf-8")
-    assert loader._read_json_overrides(path) == {}
-
-
-def test_read_json_overrides_non_dict_env(tmp_path: Path) -> None:
-    path = tmp_path / "cli-config.json"
-    path.write_text(json.dumps({"env": ["not", "a", "dict"]}), encoding="utf-8")
-    assert loader._read_json_overrides(path) == {}
-
-
-def test_read_json_overrides_maps_to_nested_settings(tmp_path: Path) -> None:
-    path = tmp_path / "cli-config.json"
-    path.write_text(
-        json.dumps({"env": {"STRIX_LLM": "my-model", "PERPLEXITY_API_KEY": "pk"}}),
-        encoding="utf-8",
-    )
-    assert loader._read_json_overrides(path) == {
-        "llm": {"model": "my-model"},
-        "integrations": {"perplexity_api_key": "pk"},
-    }
-
-
-def test_read_json_overrides_skips_keys_already_in_environ(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("STRIX_LLM", "from-env")
-    path = tmp_path / "cli-config.json"
-    path.write_text(json.dumps({"env": {"STRIX_LLM": "from-file"}}), encoding="utf-8")
-    # env wins -> the JSON value is not surfaced as an init kwarg.
-    assert loader._read_json_overrides(path) == {}
-
-
-def test_read_json_overrides_env_wins_across_field_aliases(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # api_key resolves from AliasChoices("LLM_API_KEY", "OPENAI_API_KEY"). The env
-    # sets one alias while the persisted file holds another. Env must still win, so
-    # the stale file value must not be surfaced as an init kwarg (which outranks env).
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
-    path = tmp_path / "cli-config.json"
-    path.write_text(json.dumps({"env": {"LLM_API_KEY": "sk-file"}}), encoding="utf-8")
-    assert loader._read_json_overrides(path) == {}
-
-
-def test_read_json_overrides_env_wins_case_insensitively(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # Settings use case_sensitive=False, so a lowercase env var also counts as set.
-    monkeypatch.setenv("strix_llm", "from-env")
-    path = tmp_path / "cli-config.json"
-    path.write_text(json.dumps({"env": {"STRIX_LLM": "from-file"}}), encoding="utf-8")
-    assert loader._read_json_overrides(path) == {}
-
-
-def test_read_json_overrides_uses_json_when_no_alias_in_environ(tmp_path: Path) -> None:
-    # No alias of api_key is set in the environment -> the file value is used, even
-    # when it is stored under a non-first alias.
-    path = tmp_path / "cli-config.json"
-    path.write_text(json.dumps({"env": {"OPENAI_API_KEY": "sk-file"}}), encoding="utf-8")
-    assert loader._read_json_overrides(path) == {"llm": {"api_key": "sk-file"}}
-
-
-def test_tool_output_max_bytes_rejects_sub_notice_values() -> None:
-    with pytest.raises(ValidationError):
-        ContextSettings(STRIX_TOOL_OUTPUT_MAX_BYTES=64)
-
-
-def test_tool_output_max_bytes_accepts_floor() -> None:
-    assert ContextSettings(STRIX_TOOL_OUTPUT_MAX_BYTES=1024).tool_output_max_bytes == 1024
-
-
-# --------------------------------------------------------------------------- #
-# _aliases_for
-# --------------------------------------------------------------------------- #
-
-
-def test_aliases_for_simple_alias() -> None:
-    finfo = FieldInfo(alias="SIMPLE_ALIAS")
-    assert loader._aliases_for(finfo) == ["SIMPLE_ALIAS"]
-
-
-def test_aliases_for_alias_choices() -> None:
-    finfo: FieldInfo = Field(  # type: ignore[assignment]
-        default=None,
-        validation_alias=AliasChoices("FIRST", "SECOND"),
-    )
-    assert loader._aliases_for(finfo) == ["FIRST", "SECOND"]
-
-
-def test_aliases_for_string_validation_alias() -> None:
-    finfo: FieldInfo = Field(default=None, validation_alias="STR_ALIAS")  # type: ignore[assignment]
-    assert loader._aliases_for(finfo) == ["STR_ALIAS"]
-
-
-def test_aliases_for_no_alias() -> None:
-    assert loader._aliases_for(FieldInfo()) == []
-
-
-# --------------------------------------------------------------------------- #
-# apply_config_override + load_settings round-trip
-# --------------------------------------------------------------------------- #
-
-
-def test_apply_override_and_load_settings_round_trip(tmp_path: Path) -> None:
-    path = tmp_path / "cli-config.json"
-    path.write_text(
-        json.dumps({"env": {"STRIX_LLM": "round-trip-model", "PERPLEXITY_API_KEY": "pk"}}),
-        encoding="utf-8",
-    )
-
-    loader.apply_config_override(path)
-    settings = loader.load_settings()
-
-    assert settings.llm.model == "round-trip-model"
-    assert settings.integrations.perplexity_api_key == "pk"
-    # Second call is memoized -> same object.
-    assert loader.load_settings() is settings
-
-
-def test_apply_config_override_invalidates_cache(tmp_path: Path) -> None:
-    first = tmp_path / "first.json"
-    first.write_text(json.dumps({"env": {"STRIX_LLM": "first-model"}}), encoding="utf-8")
-    second = tmp_path / "second.json"
-    second.write_text(json.dumps({"env": {"STRIX_LLM": "second-model"}}), encoding="utf-8")
-
-    loader.apply_config_override(first)
-    assert loader.load_settings().llm.model == "first-model"
-
-    loader.apply_config_override(second)
-    assert loader.load_settings().llm.model == "second-model"
-
-
-# --------------------------------------------------------------------------- #
-# persist_current
-# --------------------------------------------------------------------------- #
-
-
-def test_persist_current_writes_env_block(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("STRIX_LLM", "persisted-model")
-    target = tmp_path / "sub" / "cli-config.json"
-    loader.apply_config_override(target)
-
-    loader.persist_current()
-
-    assert target.exists()
-    assert json.loads(target.read_text(encoding="utf-8")) == {
-        "env": {"STRIX_LLM": "persisted-model"}
-    }
-
-
-def test_persist_current_sets_0600_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("STRIX_LLM", "persisted-model")
-    target = tmp_path / "cli-config.json"
-    loader.apply_config_override(target)
-
-    loader.persist_current()
-
-    assert target.stat().st_mode & 0o777 == 0o600
+KœİÛ[ÙH	ˆÍÍÍÈOHÍŒ

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,66 +1,225 @@
-­r‡^Ñf¥–Ø¦{[r‰Ý°ë­¦ëHˆˆ•\ÝÈ›ÜˆÝš^˜ÛÛ™šYË›ØY\Žˆ”ÓÓˆÝ™\œšY\Ë[X\È™\ÛÛ][Û‹\œÚ\Ý[˜ÙKˆˆˆ‚‚™œ›ÛH×Ù]\™W×È[\Ü[››Ý][ÛœÂ‚š[\ÜœÛÛ‚™œ›ÛH\[™È[\ÜTWÐÒPÒÒS‘Â‚š[\Ü]\Ý™œ›ÛHY[XÈ[\Ü[X\ÐÚÚXÙ\ËšY[˜[Y][Û‘\œ›Ü‚™œ›ÛHY[XË™šY[È[\ÜšY[[™›Â‚™œ›ÛHÝš^˜ÛÛ™šYÈ[\ÜØY\‚™œ›ÛHÝš^˜ÛÛ™šYËœÙ][™ÜÈ[\ÜÛÛ^Ù][™ÜÂ‚‚šYˆTWÐÒPÒÒS‘Î‚ˆœ›ÛH]Xˆ[\Ü]‚‚—ÓWÑS•—ÒÑVTÈHÂˆ”Õ’VÓH‹ˆ“WÐTWÒÑVH‹ˆ“ÔSRWÐTWÒÑVH‹ˆ“WÐTWÐTÑH‹ˆ“ÔSRWÐTWÐTÑH‹ˆ“ÔSRWÐTÑWÕT“‹ˆ“USWÐTÑWÕT“‹ˆ“ÓSPWÐTWÐTÑH‹ˆ”Õ’VÔ‘PTÓÓ’S‘×ÑQ‘“Ô•‹ˆ”Õ’VÑ“ÔÑWÔ‘TURT‘QÕÓÓÐÒÒPÑH‹ˆ“WÕSQSÕU‹ˆ”T”VUWÐTWÒÑVH‹ˆÈ[[YTÙ][™ÜÂˆ”Õ’VÒSPQÑH‹ˆ”Õ’VÒSPQÑWÔSÔÓPÖH‹ˆ”Õ’VÔ•S•SQWÐPÒÑS‘‹ˆ”Õ’VÐÐRQ×Ð“ÓÕÕÐRUÔÈ‹ˆÈ[[Y]žTÙ][™ÜÂˆ”Õ’VÕSSQU–H‹—B‚‚]\Ý™š^\™J]]Ý\ÙOUYJB™YˆÜ™\Ù]ÛØY\—ÜÝ]J[ÛšÙ^\]Úˆ]\Ý“[ÛšÙ^T]Ú
-HOˆ›Û™N‚ˆˆˆ”™\Ù][Ù[HÛØ˜[È[™ÛX\ˆÛ›ÝÛˆ[ˆ˜\œÈ›Üˆ]\›Z[š\ÝXÈ[œËˆˆˆ‚ˆ›ÜˆÙ^H[ˆÓWÑS•—ÒÑVTÎ‚ˆ[ÛšÙ^\]Ú™[[ŠÙ^K˜Z\Ú[™ÏQ˜[ÙJBˆ[ÛšÙ^\]ÚœÙ]]ŠØY\‹—ØØXÚY‹›Û™JBˆ[ÛšÙ^\]ÚœÙ]]ŠØY\‹—ÛÝ™\œšYH‹›Û™JB‚‚ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂˆÈÜ™XYÚœÛÛ—ÛÝ™\œšY\ÂˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂ‚‚™Yˆ\ÝÜ™XYÚœÛÛ—ÛÝ™\œšY\×ÛZ\ÜÚ[™×Ùš[J\Ü]ˆ]
-HOˆ›Û™N‚ˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—ÛÝ™\œšY\Ê\Ü]È››ÜKšœÛÛˆŠHOHßB‚‚™Yˆ\ÝÜ™XYÚœÛÛ—ÛÝ™\œšY\×ØÛÜœ\ÚœÛÛŠ\Ü]ˆ]
-HOˆ›Û™N‚ˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]WÝ^
-žÛ›Ý˜[YœÛÛˆ‹[˜ÛÙ[™ÏH]‹NŠBˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—ÛÝ™\œšY\Ê]
-HOHßB‚‚™Yˆ\ÝÜ™XYÚœÛÛ—ÛÝ™\œšY\×Û›Û—ÙXÝÙ[Š\Ü]ˆ]
-HOˆ›Û™N‚ˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]WÝ^
-œÛÛ‹™[\ÊÈ™[ˆŽˆÈ››Ý‹˜H‹™XÝ—_JK[˜ÛÙ[™ÏH]‹NŠBˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—ÛÝ™\œšY\Ê]
-HOHßB‚‚™Yˆ\ÝÜ™XYÚœÛÛ—ÛÝ™\œšY\×ÛX\×Ý×Û™\ÝYÜÙ][™ÜÊ\Ü]ˆ]
-HOˆ›Û™N‚ˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]WÝ^
-ˆœÛÛ‹™[\ÊÈ™[ˆŽˆÈ”Õ’VÓHŽˆ›^K[[Ù[‹”T”VUWÐTWÒÑVHŽˆœÈŸ_JKˆ[˜ÛÙ[™ÏH]‹N‹ˆ
-Bˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—ÛÝ™\œšY\Ê]
-HOHÂˆ›HŽˆÈ›[Ù[Žˆ›^K[[Ù[ŸKˆš[YÜ˜][ÛœÈŽˆÈœ\œ^]WØ\WÚÙ^HŽˆœÈŸKˆB‚‚™Yˆ\ÝÜ™XYÚœÛÛ—ÛÝ™\œšY\×ÜÚÚ\×ÚÙ^\×Ø[™XYWÚ[—Ù[š\›ÛŠˆ\Ü]ˆ][ÛšÙ^\]Úˆ]\Ý“[ÛšÙ^T]ÚŠHOˆ›Û™N‚ˆ[ÛšÙ^\]ÚœÙ][Š”Õ’VÓH‹™œ›ÛKY[ˆŠBˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]WÝ^
-œÛÛ‹™[\ÊÈ™[ˆŽˆÈ”Õ’VÓHŽˆ™œ›ÛKYš[HŸ_JK[˜ÛÙ[™ÏH]‹NŠBˆÈ[ˆÚ[œÈOˆH”ÓÓˆ˜[YH\È›ÝÝ\™˜XÙY\È[ˆ[š]ÝØ\™Ë‚ˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—ÛÝ™\œšY\Ê]
-HOHßB‚‚™Yˆ\ÝÜ™XYÚœÛÛ—ÛÝ™\œšY\×Ù[—ÝÚ[œ×ØXÜ›ÜÜ×ÙšY[Ø[X\Ù\Êˆ\Ü]ˆ][ÛšÙ^\]Úˆ]\Ý“[ÛšÙ^T]ÚŠHOˆ›Û™N‚ˆÈ\WÚÙ^H™\ÛÛ™\Èœ›ÛH[X\ÐÚÚXÙ\Ê“WÐTWÒÑVH‹“ÔSRWÐTWÒÑVHŠKˆH[‚ˆÈÙ]ÈÛ™H[X\ÈÚ[HH\œÚ\ÝYš[HÛÈ[›Ý\‹ˆ[ˆ]\ÝÝ[Ú[‹ÛÂˆÈHÝ[Hš[H˜[YH]\Ý›Ý™HÝ\™˜XÙY\È[ˆ[š]ÝØ\™È
-ÚXÚÝ]˜[šÜÈ[ŠK‚ˆ[ÛšÙ^\]ÚœÙ][Š“ÔSRWÐTWÒÑVH‹œÚËY[ˆŠBˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]WÝ^
-œÛÛ‹™[\ÊÈ™[ˆŽˆÈ“WÐTWÒÑVHŽˆœÚËYš[HŸ_JK[˜ÛÙ[™ÏH]‹NŠBˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—ÛÝ™\œšY\Ê]
-HOHßB‚‚™Yˆ\ÝÜ™XYÚœÛÛ—ÛÝ™\œšY\×Ù[—ÝÚ[œ×ØØ\ÙWÚ[œÙ[œÚ]]™[Jˆ\Ü]ˆ][ÛšÙ^\]Úˆ]\Ý“[ÛšÙ^T]ÚŠHOˆ›Û™N‚ˆÈÙ][™ÜÈ\ÙHØ\ÙWÜÙ[œÚ]]™OQ˜[ÙKÛÈHÝÙ\˜Ø\ÙH[ˆ˜\ˆ[ÛÈÛÝ[È\ÈÙ]‚ˆ[ÛšÙ^\]ÚœÙ][ŠœÝš^ÛH‹™œ›ÛKY[ˆŠBˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]WÝ^
-œÛÛ‹™[\ÊÈ™[ˆŽˆÈ”Õ’VÓHŽˆ™œ›ÛKYš[HŸ_JK[˜ÛÙ[™ÏH]‹NŠBˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—ÛÝ™\œšY\Ê]
-HOHßB‚‚™Yˆ\ÝÜ™XYÚœÛÛ—ÛÝ™\œšY\×Ý\Ù\×ÚœÛÛ—ÝÚ[—Û›×Ø[X\×Ú[—Ù[š\›ÛŠ\Ü]ˆ]
-HOˆ›Û™N‚ˆÈ›È[X\ÈÙˆ\WÚÙ^H\ÈÙ][ˆH[š\›Û›Y[OˆHš[H˜[YH\È\ÙY]™[‚ˆÈÚ[ˆ]\ÈÝÜ™Y[™\ˆH›Û‹Yš\œÝ[X\Ë‚ˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]WÝ^
-œÛÛ‹™[\ÊÈ™[ˆŽˆÈ“ÔSRWÐTWÒÑVHŽˆœÚËYš[HŸ_JK[˜ÛÙ[™ÏH]‹NŠBˆ\ÜÙ\ØY\‹—Ü™XYÚœÛÛ—ÛÝ™\œšY\Ê]
-HOHÈ›HŽˆÈ˜\WÚÙ^HŽˆœÚËYš[HŸ_B‚‚™Yˆ\ÝÝÛÛÛÝ]]ÛX^Øž]\×Ü™Z™XÝ×ÜÝX—Û›ÝXÙWÝ˜[Y\Ê
-HOˆ›Û™N‚ˆÚ]]\Ýœ˜Z\Ù\Ê˜[Y][Û‘\œ›ÜŠN‚ˆÛÛ^Ù][™ÜÊÕ’VÕÓÓÓÕUUÓPVÐ–UTÏM
-B‚‚™Yˆ\ÝÝÛÛÛÝ]]ÛX^Øž]\×ØXØÙ\×Ù›ÛÜŠ
-HOˆ›Û™N‚ˆ\ÜÙ\ÛÛ^Ù][™ÜÊÕ’VÕÓÓÓÕUUÓPVÐ–UTÏLL
-KÛÛÛÝ]]ÛX^Øž]\ÈOHL‚‚™Yˆ\ÝÜ[[YWØØZY×Ø›ÛÝÝØZ]Ùœ›ÛWÙ[Š[ÛšÙ^\]Úˆ]\Ý“[ÛšÙ^T]Ú
-HOˆ›Û™N‚ˆ[ÛšÙ^\]ÚœÙ][Š”Õ’VÐÐRQ×Ð“ÓÕÕÐRUÔÈ‹ŽLŠB‚ˆ\ÜÙ\ØY\‹›ØYÜÙ][™ÜÊ
-Kœ[[YK˜ØZY×Ø›ÛÝÝØZ]ÜÈOHL‚‚™Yˆ\ÝÜ[[YWÚ[XYÙWÜ[ÜÛXÞWÙœ›ÛWÙ[Š[ÛšÙ^\]Úˆ]\Ý“[ÛšÙ^T]Ú
-HOˆ›Û™N‚ˆ[ÛšÙ^\]ÚœÙ][Š”Õ’VÒSPQÑWÔSÔÓPÖH‹›™]™\ˆŠB‚ˆ\ÜÙ\ØY\‹›ØYÜÙ][™ÜÊ
-Kœ[[YKš[XYÙWÜ[ÜÛXÞHOH›™]™\ˆ‚‚‚ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂˆÈØ[X\Ù\×Ù›Ü‚ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂ‚‚™Yˆ\ÝØ[X\Ù\×Ù›Ü—ÜÚ[\WØ[X\Ê
-HOˆ›Û™N‚ˆš[™›ÈHšY[[™›Ê[X\ÏH”ÒSTWÐSPTÈŠBˆ\ÜÙ\ØY\‹—Ø[X\Ù\×Ù›ÜŠš[™›ÊHOHÈ”ÒSTWÐSPTÈ—B‚‚™Yˆ\ÝØ[X\Ù\×Ù›Ü—Ø[X\×ØÚÚXÙ\Ê
-HOˆ›Û™N‚ˆš[™›ÎˆšY[[™›ÈHšY[
-È\NˆYÛ›Ü™VØ\ÜÚYÛ›Y[BˆY˜][S›Û™Kˆ˜[Y][Û—Ø[X\ÏP[X\ÐÚÚXÙ\Ê‘’T”Õ‹”ÑPÓÓ‘ŠKˆ
-Bˆ\ÜÙ\ØY\‹—Ø[X\Ù\×Ù›ÜŠš[™›ÊHOHÈ‘’T”Õ‹”ÑPÓÓ‘—B‚‚™Yˆ\ÝØ[X\Ù\×Ù›Ü—ÜÝš[™×Ý˜[Y][Û—Ø[X\Ê
-HOˆ›Û™N‚ˆš[™›ÎˆšY[[™›ÈHšY[
-Y˜][S›Û™K˜[Y][Û—Ø[X\ÏH”Õ—ÐSPTÈŠHÈ\NˆYÛ›Ü™VØ\ÜÚYÛ›Y[Bˆ\ÜÙ\ØY\‹—Ø[X\Ù\×Ù›ÜŠš[™›ÊHOHÈ”Õ—ÐSPTÈ—B‚‚™Yˆ\ÝØ[X\Ù\×Ù›Ü—Û›×Ø[X\Ê
-HOˆ›Û™N‚ˆ\ÜÙ\ØY\‹—Ø[X\Ù\×Ù›ÜŠšY[[™›Ê
-JHOH×B‚‚ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂˆÈ\WØÛÛ™šY×ÛÝ™\œšYH
-ÈØYÜÙ][™ÜÈ›Ý[™]š\ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂ‚‚™Yˆ\ÝØ\WÛÝ™\œšYWØ[™ÛØYÜÙ][™Ü×Ü›Ý[™Ýš\
-\Ü]ˆ]
-HOˆ›Û™N‚ˆ]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆ]Üš]WÝ^
-ˆœÛÛ‹™[\ÊÈ™[ˆŽˆÈ”Õ’VÓHŽˆœ›Ý[™]š\[[Ù[‹”T”VUWÐTWÒÑVHŽˆœÈŸ_JKˆ[˜ÛÙ[™ÏH]‹N‹ˆ
-B‚ˆØY\‹˜\WØÛÛ™šY×ÛÝ™\œšYJ]
-BˆÙ][™ÜÈHØY\‹›ØYÜÙ][™ÜÊ
-B‚ˆ\ÜÙ\Ù][™ÜË›K›[Ù[OHœ›Ý[™]š\[[Ù[‚ˆ\ÜÙ\Ù][™ÜËš[YÜ˜][ÛœËœ\œ^]WØ\WÚÙ^HOHœÈ‚ˆÈÙXÛÛ™Ø[\ÈY[[Ú^™YOˆØ[YHØš™XÝ‚ˆ\ÜÙ\ØY\‹›ØYÜÙ][™ÜÊ
-H\ÈÙ][™ÜÂ‚‚™Yˆ\ÝØ\WØÛÛ™šY×ÛÝ™\œšYWÚ[˜[Y]\×ØØXÚJ\Ü]ˆ]
-HOˆ›Û™N‚ˆš\œÝH\Ü]È™š\œÝšœÛÛˆ‚ˆš\œÝÜš]WÝ^
-œÛÛ‹™[\ÊÈ™[ˆŽˆÈ”Õ’VÓHŽˆ™š\œÝ[[Ù[Ÿ_JK[˜ÛÙ[™ÏH]‹NŠBˆÙXÛÛ™H\Ü]ÈœÙXÛÛ™šœÛÛˆ‚ˆÙXÛÛ™Üš]WÝ^
-œÛÛ‹™[\ÊÈ™[ˆŽˆÈ”Õ’VÓHŽˆœÙXÛÛ™[[Ù[Ÿ_JK[˜ÛÙ[™ÏH]‹NŠB‚ˆØY\‹˜\WØÛÛ™šY×ÛÝ™\œšYJš\œÝ
-Bˆ\ÜÙ\ØY\‹›ØYÜÙ][™ÜÊ
-K›K›[Ù[OH™š\œÝ[[Ù[‚‚ˆØY\‹˜\WØÛÛ™šY×ÛÝ™\œšYJÙXÛÛ™
-Bˆ\ÜÙ\ØY\‹›ØYÜÙ][™ÜÊ
-K›K›[Ù[OHœÙXÛÛ™[[Ù[‚‚‚ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂˆÈ\œÚ\ÝØÝ\œ™[ˆÈKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKKHÂ‚‚™Yˆ\ÝÜ\œÚ\ÝØÝ\œ™[ÝÜš]\×Ù[—Ø›ØÚÊ\Ü]ˆ][ÛšÙ^\]Úˆ]\Ý“[ÛšÙ^T]Ú
-HOˆ›Û™N‚ˆ[ÛšÙ^\]ÚœÙ][Š”Õ’VÓH‹œ\œÚ\ÝY[[Ù[ŠBˆ\™Ù]H\Ü]ÈœÝXˆˆÈ˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆØY\‹˜\WØÛÛ™šY×ÛÝ™\œšYJ\™Ù]
-B‚ˆØY\‹œ\œÚ\ÝØÝ\œ™[
+"""Tests for strix.config.loader: JSON overrides, alias resolution, persistence."""
 
-B‚ˆ\ÜÙ\\™Ù]™^\ÝÊ
-Bˆ\ÜÙ\œÛÛ‹›ØYÊ\™Ù]œ™XYÝ^
-[˜ÛÙ[™ÏH]‹NŠJHOHÂˆ™[ˆŽˆÈ”Õ’VÓHŽˆœ\œÚ\ÝY[[Ù[ŸBˆB‚‚™Yˆ\ÝÜ\œÚ\ÝØÝ\œ™[ÜÙ]×ÌŒÛ[ÙJ\Ü]ˆ][ÛšÙ^\]Úˆ]\Ý“[ÛšÙ^T]Ú
-HOˆ›Û™N‚ˆ[ÛšÙ^\]ÚœÙ][Š”Õ’VÓH‹œ\œÚ\ÝY[[Ù[ŠBˆ\™Ù]H\Ü]È˜ÛKXÛÛ™šYËšœÛÛˆ‚ˆØY\‹˜\WØÛÛ™šY×ÛÝ™\œšYJ\™Ù]
-B‚ˆØY\‹œ\œÚ\ÝØÝ\œ™[
+from __future__ import annotations
 
-B‚ˆ\ÜÙ\\™Ù]œÝ]
+import json
+from typing import TYPE_CHECKING
 
-KœÝÛ[ÙH	ˆÍÍÍÈOHÍŒ
+import pytest
+from pydantic import AliasChoices, Field, ValidationError
+from pydantic.fields import FieldInfo
+
+from strix.config import loader
+from strix.config.settings import ContextSettings
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_LLM_ENV_KEYS = [
+    "STRIX_LLM",
+    "LLM_API_KEY",
+    "OPENAI_API_KEY",
+    "LLM_API_BASE",
+    "OPENAI_API_BASE",
+    "OPENAI_BASE_URL",
+    "LITELLM_BASE_URL",
+    "OLLAMA_API_BASE",
+    "STRIX_REASONING_EFFORT",
+    "STRIX_FORCE_REQUIRED_TOOL_CHOICE",
+    "LLM_TIMEOUT",
+    "PERPLEXITY_API_KEY",
+    # RuntimeSettings
+    "STRIX_IMAGE",
+    "STRIX_IMAGE_PULL_POLICY",
+    "STRIX_RUNTIME_BACKEND",
+    # TelemetrySettings
+    "STRIX_TELEMETRY",
+]
+
+
+@pytest.fixture(autouse=True)
+def _reset_loader_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset module globals and clear known env vars for deterministic runs."""
+    for key in _LLM_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(loader, "_cached", None)
+    monkeypatch.setattr(loader, "_override", None)
+
+
+# --------------------------------------------------------------------------- #
+# _read_json_overrides
+# --------------------------------------------------------------------------- #
+
+
+def test_read_json_overrides_missing_file(tmp_path: Path) -> None:
+    assert loader._read_json_overrides(tmp_path / "nope.json") == {}
+
+
+def test_read_json_overrides_corrupt_json(tmp_path: Path) -> None:
+    path = tmp_path / "cli-config.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    assert loader._read_json_overrides(path) == {}
+
+
+def test_read_json_overrides_non_dict_env(tmp_path: Path) -> None:
+    path = tmp_path / "cli-config.json"
+    path.write_text(json.dumps({"env": ["not", "a", "dict"]}), encoding="utf-8")
+    assert loader._read_json_overrides(path) == {}
+
+
+def test_read_json_overrides_maps_to_nested_settings(tmp_path: Path) -> None:
+    path = tmp_path / "cli-config.json"
+    path.write_text(
+        json.dumps({"env": {"STRIX_LLM": "my-model", "PERPLEXITY_API_KEY": "pk"}}),
+        encoding="utf-8",
+    )
+    assert loader._read_json_overrides(path) == {
+        "llm": {"model": "my-model"},
+        "integrations": {"perplexity_api_key": "pk"},
+    }
+
+
+def test_read_json_overrides_skips_keys_already_in_environ(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("STRIX_LLM", "from-env")
+    path = tmp_path / "cli-config.json"
+    path.write_text(json.dumps({"env": {"STRIX_LLM": "from-file"}}), encoding="utf-8")
+    # env wins -> the JSON value is not surfaced as an init kwarg.
+    assert loader._read_json_overrides(path) == {}
+
+
+def test_read_json_overrides_env_wins_across_field_aliases(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # api_key resolves from AliasChoices("LLM_API_KEY", "OPENAI_API_KEY"). The env
+    # sets one alias while the persisted file holds another. Env must still win, so
+    # the stale file value must not be surfaced as an init kwarg (which outranks env).
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+    path = tmp_path / "cli-config.json"
+    path.write_text(json.dumps({"env": {"LLM_API_KEY": "sk-file"}}), encoding="utf-8")
+    assert loader._read_json_overrides(path) == {}
+
+
+def test_read_json_overrides_env_wins_case_insensitively(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Settings use case_sensitive=False, so a lowercase env var also counts as set.
+    monkeypatch.setenv("strix_llm", "from-env")
+    path = tmp_path / "cli-config.json"
+    path.write_text(json.dumps({"env": {"STRIX_LLM": "from-file"}}), encoding="utf-8")
+    assert loader._read_json_overrides(path) == {}
+
+
+def test_read_json_overrides_uses_json_when_no_alias_in_environ(tmp_path: Path) -> None:
+    # No alias of api_key is set in the environment -> the file value is used, even
+    # when it is stored under a non-first alias.
+    path = tmp_path / "cli-config.json"
+    path.write_text(json.dumps({"env": {"OPENAI_API_KEY": "sk-file"}}), encoding="utf-8")
+    assert loader._read_json_overrides(path) == {"llm": {"api_key": "sk-file"}}
+
+
+def test_tool_output_max_bytes_rejects_sub_notice_values() -> None:
+    with pytest.raises(ValidationError):
+        ContextSettings(STRIX_TOOL_OUTPUT_MAX_BYTES=64)
+
+
+def test_tool_output_max_bytes_accepts_floor() -> None:
+    assert ContextSettings(STRIX_TOOL_OUTPUT_MAX_BYTES=1024).tool_output_max_bytes == 1024
+
+
+def test_runtime_image_pull_policy_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIX_IMAGE_PULL_POLICY", "never")
+
+    assert loader.load_settings().runtime.image_pull_policy == "never"
+
+
+# --------------------------------------------------------------------------- #
+# _aliases_for
+# --------------------------------------------------------------------------- #
+
+
+def test_aliases_for_simple_alias() -> None:
+    finfo = FieldInfo(alias="SIMPLE_ALIAS")
+    assert loader._aliases_for(finfo) == ["SIMPLE_ALIAS"]
+
+
+def test_aliases_for_alias_choices() -> None:
+    finfo: FieldInfo = Field(  # type: ignore[assignment]
+        default=None,
+        validation_alias=AliasChoices("FIRST", "SECOND"),
+    )
+    assert loader._aliases_for(finfo) == ["FIRST", "SECOND"]
+
+
+def test_aliases_for_string_validation_alias() -> None:
+    finfo: FieldInfo = Field(default=None, validation_alias="STR_ALIAS")  # type: ignore[assignment]
+    assert loader._aliases_for(finfo) == ["STR_ALIAS"]
+
+
+def test_aliases_for_no_alias() -> None:
+    assert loader._aliases_for(FieldInfo()) == []
+
+
+# --------------------------------------------------------------------------- #
+# apply_config_override + load_settings round-trip
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_override_and_load_settings_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "cli-config.json"
+    path.write_text(
+        json.dumps({"env": {"STRIX_LLM": "round-trip-model", "PERPLEXITY_API_KEY": "pk"}}),
+        encoding="utf-8",
+    )
+
+    loader.apply_config_override(path)
+    settings = loader.load_settings()
+
+    assert settings.llm.model == "round-trip-model"
+    assert settings.integrations.perplexity_api_key == "pk"
+    # Second call is memoized -> same object.
+    assert loader.load_settings() is settings
+
+
+def test_apply_config_override_invalidates_cache(tmp_path: Path) -> None:
+    first = tmp_path / "first.json"
+    first.write_text(json.dumps({"env": {"STRIX_LLM": "first-model"}}), encoding="utf-8")
+    second = tmp_path / "second.json"
+    second.write_text(json.dumps({"env": {"STRIX_LLM": "second-model"}}), encoding="utf-8")
+
+    loader.apply_config_override(first)
+    assert loader.load_settings().llm.model == "first-model"
+
+    loader.apply_config_override(second)
+    assert loader.load_settings().llm.model == "second-model"
+
+
+# --------------------------------------------------------------------------- #
+# persist_current
+# --------------------------------------------------------------------------- #
+
+
+def test_persist_current_writes_env_block(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIX_LLM", "persisted-model")
+    target = tmp_path / "sub" / "cli-config.json"
+    loader.apply_config_override(target)
+
+    loader.persist_current()
+
+    assert target.exists()
+    assert json.loads(target.read_text(encoding="utf-8")) == {
+        "env": {"STRIX_LLM": "persisted-model"}
+    }
+
+
+def test_persist_current_sets_0600_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRIX_LLM", "persisted-model")
+    target = tmp_path / "cli-config.json"
+    loader.apply_config_override(target)
+
+    loader.persist_current()
+
+    assert target.stat().st_mode & 0o777 == 0o600

--- a/tests/test_image_pull_policy.py
+++ b/tests/test_image_pull_policy.py
@@ -1,4 +1,4 @@
-≠rá^—f•ñÿ¶{O,y 'v√Æ∂õ≠"""Regression tests for sandbox image acquisition policy."""
+"""Regression tests for sandbox image acquisition policy."""
 
 from __future__ import annotations
 

--- a/tests/test_image_pull_policy.py
+++ b/tests/test_image_pull_policy.py
@@ -1,0 +1,85 @@
+­r‡^Ñf¥–Ø¦{O,yÊ'vÃ®¶›­"""Regression tests for sandbox image acquisition policy."""
+
+from __future__ import annotations
+
+from typing import Literal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strix.config.settings import RuntimeSettings, Settings
+from strix.interface.environment import pull_docker_image
+from strix.runtime.docker_client import StrixDockerSandboxClient
+
+
+def _missing_image_client(
+    *, pull_policy: Literal["auto", "never"] = "auto"
+) -> StrixDockerSandboxClient:
+    client = StrixDockerSandboxClient.__new__(StrixDockerSandboxClient)
+    client.docker_client = MagicMock()
+    client.image_pull_policy = pull_policy
+    client.image_exists = MagicMock(return_value=False)
+    return client
+
+
+def test_cli_never_policy_rejects_missing_image_without_pull() -> None:
+    docker_client = MagicMock()
+    settings = Settings(
+        runtime=RuntimeSettings(
+            STRIX_IMAGE="example.invalid/sandbox@sha256:deadbeef",
+            STRIX_IMAGE_PULL_POLICY="never",
+        )
+    )
+
+    with (
+        patch("strix.interface.environment.check_docker_connection", return_value=docker_client),
+        patch("strix.interface.environment.image_exists", return_value=False),
+        patch("strix.interface.environment.load_settings", return_value=settings),
+        pytest.raises(
+            RuntimeError,
+            match=r"example\.invalid/sandbox@sha256:deadbeef.*forbids pulling",
+        ),
+    ):
+        pull_docker_image()
+
+    docker_client.api.pull.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_container_creation_rechecks_never_policy_without_pull() -> None:
+    client = _missing_image_client(pull_policy="never")
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"example\.invalid/sandbox@sha256:deadbeef.*forbids pulling",
+    ):
+        await client._create_container("example.invalid/sandbox@sha256:deadbeef")
+
+    client.docker_client.images.pull.assert_not_called()
+    client.docker_client.containers.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_container_creation_uses_present_image_with_never_policy() -> None:
+    client = _missing_image_client(pull_policy="never")
+    client.image_exists = MagicMock(return_value=True)
+    client.docker_client.containers.create.return_value = MagicMock(short_id="abc123")
+
+    await client._create_container("example.invalid/sandbox@sha256:deadbeef")
+
+    client.docker_client.images.pull.assert_not_called()
+    client.docker_client.containers.create.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_container_creation_keeps_default_auto_pull() -> None:
+    client = _missing_image_client()
+    client.image_exists = MagicMock(side_effect=[False, True])
+    client.docker_client.containers.create.return_value = MagicMock(short_id="abc123")
+
+    await client._create_container("example.invalid/sandbox:latest")
+
+    client.docker_client.images.pull.assert_called_once_with(
+        "example.invalid/sandbox", tag="latest", all_tags=False
+    )
+    client.docker_client.containers.create.assert_called_once()


### PR DESCRIPTION
## Summary

- add `STRIX_IMAGE_PULL_POLICY=never` for installations that preload sandbox images
- reject missing images before the CLI pull path and recheck the policy immediately before container creation
- keep the existing automatic pull behavior as the default
- document that the setting controls image acquisition, not runtime network access

## Root cause

Strix currently has two automatic pull paths: the CLI environment check and the Docker runtime container creation path. Guarding only the first path would still allow a pull if the image disappears between the check and use, so the runtime enforces the same policy as the final boundary.

## Validation

- `python -m pytest tests/test_image_pull_policy.py tests/test_config_loader.py -q --deselect tests/test_config_loader.py::test_persist_current_sets_0600_mode` — 22 passed, 1 deselected
- `ruff check strix/config/settings.py strix/interface/environment.py strix/runtime/backends.py strix/runtime/docker_client.py tests/test_config_loader.py tests/test_image_pull_policy.py` — passed
- `ruff format --check strix/config/settings.py strix/interface/environment.py strix/runtime/backends.py strix/runtime/docker_client.py tests/test_config_loader.py tests/test_image_pull_policy.py` — passed
- `bandit -q -ll -r strix/config/settings.py strix/interface/environment.py strix/runtime/backends.py strix/runtime/docker_client.py` — passed

The deselected test asserts POSIX file mode bits and is not applicable on the Windows validation host.

Closes #1031