### PR TITLE
fix(llm): pass max reasoning effort to LiteLLM

### DIFF
--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -219,7 +219,7 @@ def make_model_settings(
         and model_supports_reasoning(model_name)
     ):
         model_settings = model_settings.resolve(
-            _reasoning_settings(reasoning_effort, model_settings.extra_args),
+            _reasoning_settings(reasoning_effort),
         )
     if force_required_tool_choice and _accepts_required_tool_choice(model_name):
         model_settings = model_settings.resolve(ModelSettings(tool_choice="required"))
@@ -247,18 +247,14 @@ def _request_headers(
 
 def _reasoning_settings(
     effort: ReasoningEffort,
-    extra_args: dict[str, Any] | None,
 ) -> ModelSettings:
-    """``max`` is not in the OpenAI SDK's ``Reasoning.effort`` enum, so send it as
-    a raw body field instead — also keeping it clear of LiteLLM's DeepSeek mapping,
-    which collapses every ``reasoning_effort`` level to plain thinking-enabled.
-    Providers that don't support ``max`` reject the request.
+    """``max`` is not in the OpenAI SDK's ``Reasoning.effort`` enum, so send it
+    through ``extra_args`` for the LiteLLM model to promote to its top-level
+    ``reasoning_effort`` argument. Providers that don't support ``max`` reject it.
     """
     if effort != "max":
         return ModelSettings(reasoning=Reasoning(effort=effort))
-    return ModelSettings(
-        extra_args={**(extra_args or {}), "extra_body": {"reasoning_effort": "max"}},
-    )
+    return ModelSettings(extra_args={"reasoning_effort": "max"})
 
 
 def _prompt_cache_extra_args(model_name: str) -> dict[str, Any] | None:

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -134,15 +134,15 @@ def test_prompt_cache_kept_for_non_bedrock_claude_even_if_unmapped(monkeypatch: 
         ]
 
 
-def test_max_reasoning_effort_sent_as_raw_body_field() -> None:
-    # "max" is absent from the OpenAI SDK's Reasoning enum, and LiteLLM's DeepSeek
-    # mapping collapses every effort to thinking-enabled, so it has to ride along
-    # as a raw body field to reach the provider.
+def test_max_reasoning_effort_sent_as_litellm_argument() -> None:
+    # "max" is absent from the OpenAI SDK's Reasoning enum, so it has to use the
+    # LiteLLM model's extra_args escape hatch to reach acompletion as a top-level
+    # reasoning_effort argument.
     settings = make_model_settings(
         "max", model_name="deepseek/deepseek-v4-flash", request_timeout=30
     )
     assert settings.reasoning is None
-    assert settings.extra_args == {"timeout": 30, "extra_body": {"reasoning_effort": "max"}}
+    assert settings.extra_args == {"timeout": 30, "reasoning_effort": "max"}
 
 
 def test_conversation_tail_breakpoint_moves_with_appended_transcript() -> None:

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import litellm
 import pytest
+from agents.extensions.models.litellm_model import LitellmModel
+from agents.models.interface import ModelTracing
 
 from strix.core.inputs import (
     build_root_task,
@@ -134,7 +136,10 @@ def test_prompt_cache_kept_for_non_bedrock_claude_even_if_unmapped(monkeypatch: 
         ]
 
 
-def test_max_reasoning_effort_sent_as_litellm_argument() -> None:
+@pytest.mark.asyncio
+async def test_max_reasoning_effort_sent_as_litellm_argument(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     # "max" is absent from the OpenAI SDK's Reasoning enum, so it has to use the
     # LiteLLM model's extra_args escape hatch to reach acompletion as a top-level
     # reasoning_effort argument.
@@ -143,6 +148,27 @@ def test_max_reasoning_effort_sent_as_litellm_argument() -> None:
     )
     assert settings.reasoning is None
     assert settings.extra_args == {"timeout": 30, "reasoning_effort": "max"}
+
+    captured: dict[str, Any] = {}
+
+    async def fake_acompletion(**kwargs: Any) -> litellm.types.utils.ModelResponse:
+        captured.update(kwargs)
+        return litellm.types.utils.ModelResponse()
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    model = LitellmModel(model="deepseek/deepseek-v4-flash", api_key="test")
+    await model.get_response(
+        system_instructions=None,
+        input="ping",
+        model_settings=settings,
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+    )
+
+    assert captured["reasoning_effort"] == "max"
+    assert captured["timeout"] == 30
 
 
 def test_conversation_tail_breakpoint_moves_with_appended_transcript() -> None:


### PR DESCRIPTION
## Summary

- forward `STRIX_REASONING_EFFORT=max` through OpenAI Agents' `extra_args` escape hatch so `LitellmModel` promotes it to LiteLLM's top-level `reasoning_effort` argument
- preserve existing request timeout arguments through `ModelSettings.resolve()`
- update the regression test to lock in the actual Strix -> OpenAI Agents -> LiteLLM contract

## Root cause

The `max` special case nested `reasoning_effort` under `extra_args["extra_body"]`. OpenAI Agents 0.19 only promotes `ModelSettings.extra_body["reasoning_effort"]` or `extra_args["reasoning_effort"]`, so the DeepSeek request reached `litellm.acompletion()` with its top-level `reasoning_effort` unset.

Fixes #1073.

## Validation

- `uv run pytest tests/test_inputs.py -q` - 39 passed
- `uv run ruff check strix/core/inputs.py tests/test_inputs.py` - passed
- `uv run ruff format --check strix/core/inputs.py tests/test_inputs.py` - passed
- `uv run mypy strix/core/inputs.py` - passed
- `uv run bandit -q -c pyproject.toml strix/core/inputs.py` - passed
- `uv run pyupgrade --py312-plus strix/core/inputs.py tests/test_inputs.py` - no changes
- direct boundary probe: `LitellmModel._get_reasoning_effort()` resolves `max` while the timeout remains present
- `git diff --check` - passed

`uv run pyright strix/core/inputs.py tests/test_inputs.py` still reports the repository's existing strict unknown-type baseline (56 diagnostics, all outside the changed lines). Changed-files pre-commit initialization also timed out locally while creating hook environments; the relevant checks are listed individually above.
