### PR TITLE
fix(tui): preserve cost when state is truncated

### DIFF
--- a/strix/interface/tui/backend/projection.py
+++ b/strix/interface/tui/backend/projection.py
@@ -146,7 +146,9 @@ def bounded_state_projection(state: dict[str, Any]) -> dict[str, Any]:
         }
         for message in state["messages"][-5:]
     ]
-    state["usage"] = {}
+    state["usage"] = {
+        key: state["usage"][key] for key in ("total_tokens", "cost") if key in state["usage"]
+    }
     state["error"] = terminal_projection(state["error"], max_string=512)
     state["model_warning"] = terminal_projection(state["model_warning"], max_string=256)
     state["caido_url"] = terminal_projection(state["caido_url"], max_string=256)
@@ -173,7 +175,7 @@ def bounded_state_projection(state: dict[str, Any]) -> dict[str, Any]:
         "model_warning": "",
         "caido_url": None,
         "messages": [],
-        "usage": {},
+        "usage": state["usage"],
         "subscription": state["subscription"],
         "viewer_status": state["viewer_status"],
         "viewer_url": None,

--- a/tests/test_tui_backend_server.py
+++ b/tests/test_tui_backend_server.py
@@ -243,6 +243,7 @@ def test_defensive_state_projection_preserves_usage_summary() -> None:
         ),
     )
     state = controller.snapshot()
+    state["provider"] = None
     state["future_oversized_field"] = "x" * 100_000
 
     snapshot = bounded_state_projection(state)

--- a/tests/test_tui_backend_server.py
+++ b/tests/test_tui_backend_server.py
@@ -13,7 +13,7 @@ from agents.tool import ToolOutputImage
 
 from strix.config.settings import DEFAULT_MAX_TURNS
 from strix.interface.tui.backend.controller import TuiController
-from strix.interface.tui.backend.projection import terminal_projection
+from strix.interface.tui.backend.projection import bounded_state_projection, terminal_projection
 from strix.interface.tui.backend.protocol import (
     MAX_COMMAND_BYTES,
     PROTOCOL_CAPABILITIES,
@@ -215,7 +215,11 @@ def test_unicode_heavy_setup_state_stays_within_control_frame_limit() -> None:
         "Any",
         SimpleNamespace(
             caido_url="https://例え.example/" + "道" * 10_000,
-            get_total_llm_usage=lambda: {f"model-{index}": "費" * 10_000 for index in range(20)},
+            get_total_llm_usage=lambda: {
+                "total_tokens": 720_400,
+                "cost": 20.0,
+                **{f"model-{index}": "🔒" * 10_000 for index in range(20)},
+            },
         ),
     )
     server = TuiBackendServer(controller)
@@ -226,6 +230,25 @@ def test_unicode_heavy_setup_state_stays_within_control_frame_limit() -> None:
     assert len(encoded) <= MAX_COMMAND_BYTES
     assert "🔒".encode() in encoded
     assert snapshot["projection_truncated"] is True
+    assert snapshot["usage"] == {"total_tokens": 720_400, "cost": 20.0}
+
+
+def test_defensive_state_projection_preserves_usage_summary() -> None:
+    controller = TuiController(args())
+    controller.report_state = cast(
+        "Any",
+        SimpleNamespace(
+            caido_url=None,
+            get_total_llm_usage=lambda: {"total_tokens": 720_400, "cost": 20.0},
+        ),
+    )
+    state = controller.snapshot()
+    state["future_oversized_field"] = "x" * 100_000
+
+    snapshot = bounded_state_projection(state)
+
+    assert snapshot["projection_truncated"] is True
+    assert snapshot["usage"] == {"total_tokens": 720_400, "cost": 20.0}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- preserve `total_tokens` and `cost` when the TUI state projection exceeds its byte budget
- retain that compact usage summary in the defensive final projection
- add regression coverage for both truncation paths

## Root cause
The TUI snapshot includes growing per-request usage history. Once the projected state exceeds 48 KiB, the backend replaced the complete `usage` object with `{}`, so the renderer stopped showing both token count and cost.

## Testing
- `uv run pytest tests` (922 passed)
- `uv run pytest tests/test_tui_backend_server.py -q` (18 passed)
- `uv run ruff format --check strix/interface/tui/backend/projection.py tests/test_tui_backend_server.py`
- `uv run ruff check strix/interface/tui/backend/projection.py tests/test_tui_backend_server.py`