### PR TITLE
Fix ruff, bandit and Pydantic-deprecation gate failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,6 +280,9 @@ ignore = [
 # a runtime ``Callable`` annotation on ``vulnerability_found_callback``.
 "strix/report/state.py" = ["TC003", "PLR0912", "PLR0915", "E501", "PERF401", "PLC0415"]
 "strix/report/usage.py" = ["PLC0415"]
+# Lazy import of litellm keeps the heavy dependency off the import path until a
+# cost estimate is actually requested.
+"strix/report/pricing.py" = ["PLC0415"]
 # Lazy import of strix.config.models avoids a circular dependency between the
 # report pipeline and the config layer.
 "strix/report/dedupe.py" = ["PLC0415"]

--- a/strix/config/codex.py
+++ b/strix/config/codex.py
@@ -183,7 +183,7 @@ def build_authorize_url(challenge: str, state: str) -> str:
         "code_challenge": challenge,
         "code_challenge_method": "S256",
         "state": state,
-        "id_token_add_organizations": "true",
+        "id_token_add_organizations": "true",  # nosec B105 - OAuth flag value, not a secret
         "codex_cli_simplified_flow": "true",
         "originator": ORIGINATOR,
     }

--- a/strix/config/loader.py
+++ b/strix/config/loader.py
@@ -60,7 +60,7 @@ def persist_current() -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
 
     env_block: dict[str, str] = {}
-    for sub_name in s.model_fields:
+    for sub_name in type(s).model_fields:
         sub_model = getattr(s, sub_name)
         if not isinstance(sub_model, BaseModel):
             continue


### PR DESCRIPTION
Running the project's own quality gates on a fresh clone surfaced three failures. This PR fixes all three; `ruff`, `ruff-format`, `mypy` and `bandit` are now clean and all **921 tests pass**.

### 1. ruff `PLC0415` — `strix/report/pricing.py`
The in-function `import litellm` is a deliberate lazy import that keeps the heavy dependency off the import path until a cost estimate is actually requested. Its sibling report modules that do the same (`report/usage.py`, `report/state.py`, `report/dedupe.py`) are already in `per-file-ignores`; `pricing.py` was the only one missed. Added it with a matching comment.

### 2. bandit `B105` — `strix/config/codex.py`
`"id_token_add_organizations": "true"` is an OAuth authorize-URL flag value, not a secret — bandit trips on the `token` substring in the key. Suppressed with `# nosec B105`, matching the existing `# nosec B105` on `TOKEN_URL` in the same file.

### 3. Pydantic deprecation — `strix/config/loader.py`
Accessing `model_fields` on a model **instance** is deprecated in Pydantic V2.11 and removed in V3. Read it from the class via `type(s).model_fields` (surfaced as a `PydanticDeprecatedSince211` warning in `tests/test_config_loader.py`).

### Verification
```
ruff check .        → clean
ruff format --check → clean
mypy strix/         → clean
bandit -r strix/    → 0 issues
pytest              → 921 passed
```

*Note: pyright in strict mode reports pre-existing `reportUnknown*` findings, but it's not part of pre-commit or CI, so it's left untouched here.*