### PR TITLE
fix(config): resolve LLM CONNECTION FAILED on custom API endpoints

### DIFF
--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -483,6 +483,11 @@ class StrixProvider(MultiProvider):
             )
         else:
             model = super().get_model(model_name)
+            if type(model).__name__ == "LitellmModel":
+                if llm.api_key:
+                    model.api_key = llm.api_key
+                if llm.api_base:
+                    model.base_url = llm.api_base
             if llm.disable_streaming:
                 model = _NonStreamingModel(model)
                 # The wrapper emits its single event only once the whole request
@@ -562,11 +567,9 @@ def configure_sdk_model_defaults(settings: Settings) -> None:
     _configure_openrouter_attribution(llm.model)
     if llm.api_key:
         set_default_openai_key(llm.api_key, use_for_tracing=False)
-        _configure_litellm_default("api_key", llm.api_key)
         _mirror_api_key_to_provider_env(llm.model, llm.api_key)
     if llm.api_base:
         os.environ["OPENAI_BASE_URL"] = llm.api_base
-        _configure_litellm_default("api_base", llm.api_base)
         set_default_openai_api("chat_completions")
     else:
         set_default_openai_api("responses")


### PR DESCRIPTION
Fixes #1095
### Description
When configuring a custom `LLM_API_BASE` (e.g., for self-hosted gateways), Strix was mutating the global `litellm` module state (`litellm.api_key = ...`). Because the underlying `openai-agents` SDK explicitly passes `api_key=None` (or the actual key) as a keyword argument to `litellm.acompletion()`, this triggered a hard Python `TypeError` (`got multiple values for keyword argument 'api_key'`), aborting the agent on boot. 
This PR removes the global state mutations and safely injects the API credentials directly into the `LitellmModel` instance instead.
### Motivation and Context
The agent currently connects correctly to standard APIs, but fails instantly when a custom base URL is provided due to the global module config colliding with instance arguments. This change safely scopes the credentials down the instance chain.
### How Has This Been Tested?
- [x] Tested against a mock custom endpoint
- [x] Passed all 930 tests in the background `pytest` suite