### PR TITLE
feat: add fail-closed mount-free transport for local-code Docker scans

### DIFF
--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -140,6 +140,10 @@ When remote vars are set, Strix dual-writes telemetry to both local JSONL and th
 
 ## Sandbox Configuration
 
+<ParamField path="STRIX_REQUIRE_MOUNT_FREE" default="0" type="string">
+  Enforces mount-free (bind-mount-free) transport for local-code Docker scans. Set to `1`, `true`, `yes`, or `on` to ensure no host directories are bind-mounted into the sandbox container. Local project files are transferred as an isolated snapshot payload. The snapshot lives in the container's writable layer and is discarded with it; in-tree directory symlinks are omitted; symlinked projects are read into memory.
+</ParamField>
+
 <ParamField path="STRIX_SANDBOX_EXECUTION_TIMEOUT" default="120" type="integer">
   Maximum execution time in seconds for sandbox operations.
 </ParamField>

--- a/strix/config/models.py
+++ b/strix/config/models.py
@@ -483,6 +483,11 @@ class StrixProvider(MultiProvider):
             )
         else:
             model = super().get_model(model_name)
+            if type(model).__name__ == "LitellmModel":
+                if llm.api_key:
+                    model.api_key = llm.api_key
+                if llm.api_base:
+                    model.base_url = llm.api_base
             if llm.disable_streaming:
                 model = _NonStreamingModel(model)
                 # The wrapper emits its single event only once the whole request
@@ -562,11 +567,9 @@ def configure_sdk_model_defaults(settings: Settings) -> None:
     _configure_openrouter_attribution(llm.model)
     if llm.api_key:
         set_default_openai_key(llm.api_key, use_for_tracing=False)
-        _configure_litellm_default("api_key", llm.api_key)
         _mirror_api_key_to_provider_env(llm.model, llm.api_key)
     if llm.api_base:
         os.environ["OPENAI_BASE_URL"] = llm.api_base
-        _configure_litellm_default("api_base", llm.api_base)
         set_default_openai_api("chat_completions")
     else:
         set_default_openai_api("responses")

--- a/strix/config/settings.py
+++ b/strix/config/settings.py
@@ -110,6 +110,10 @@ class RuntimeSettings(BaseSettings):
         alias="STRIX_IMAGE",
     )
     backend: str = Field(default="docker", alias="STRIX_RUNTIME_BACKEND")
+    require_mount_free: bool = Field(
+        default=False,
+        alias="STRIX_REQUIRE_MOUNT_FREE",
+    )
     # Max screenshot/image tool outputs kept live per agent context (0 = none).
     max_context_images: int = Field(default=3, ge=0, alias="STRIX_MAX_CONTEXT_IMAGES")
 

--- a/strix/core/inputs.py
+++ b/strix/core/inputs.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from agents.model_settings import ModelSettings
 from openai.types.shared import Reasoning
 
+from strix.config.loader import load_settings
 from strix.config.models import (
     DEFAULT_MODEL_RETRY,
     OPENROUTER_ATTRIBUTION_HEADERS,
@@ -21,6 +22,7 @@ from strix.config.models import (
     routes_through_litellm,
 )
 from strix.core.sessions import scrub_images_from_items
+from strix.runtime.backends import backend_supports_bind_mounts
 
 
 if TYPE_CHECKING:
@@ -105,10 +107,24 @@ def _render_workspace_files(scan_config: dict[str, Any]) -> list[str]:
     ]
 
 
+def _describe_directory_mount() -> str:
+    backend_name = load_settings().runtime.backend
+    use_bind_mounts = (
+        backend_supports_bind_mounts(backend_name)
+        and not load_settings().runtime.require_mount_free
+    )
+    if use_bind_mounts:
+        return (
+            "this is the user's real directory, mounted live and writable — "
+            ".git/.agents/.codex are read-only"
+        )
+    return "this is a bounded snapshot of the user's directory, isolated from the live host system"
+
+
 def build_root_task(scan_config: dict[str, Any]) -> str:
     targets = scan_config.get("targets", []) or []
     diff_scope = scan_config.get("diff_scope") or {}
-    user_instructions = scan_config.get("user_instructions", "") or ""
+    user_instructions = (scan_config.get("user_instructions") or "").strip()
 
     sections: dict[str, list[str]] = {
         "Repositories": [],
@@ -120,8 +136,8 @@ def build_root_task(scan_config: dict[str, Any]) -> str:
 
     for target in targets:
         ttype = target.get("type")
-        details = target.get("details") or {}
-        workspace_subdir = details.get("workspace_subdir")
+        details = target.get("details") or target.get("target_details") or {}
+        workspace_subdir = details.get("workspace_subdir") or target.get("workspace_subdir") or ""
         workspace_path = f"/workspace/{workspace_subdir}" if workspace_subdir else "/workspace"
 
         if ttype == "repository":
@@ -132,11 +148,8 @@ def build_root_task(scan_config: dict[str, Any]) -> str:
             )
         elif ttype == "local_code":
             path = details.get("target_path", "unknown")
-            sections["Local Codebases"].append(
-                f"- {path} (available at: {workspace_path}; "
-                "this is the user's real directory, mounted live and writable — "
-                ".git/.agents/.codex are read-only)"
-            )
+            desc = _describe_directory_mount()
+            sections["Local Codebases"].append(f"- {path} (available at: {workspace_path}; {desc})")
         elif ttype == "web_application":
             sections["URLs"].append(f"- {details.get('target_url', '')}")
         elif ttype == "ip_address":
@@ -155,12 +168,9 @@ def build_root_task(scan_config: dict[str, Any]) -> str:
     if workspace_mount := scan_config.get("workspace_mount") or "":
         subdir = scan_config.get("workspace_subdir") or ""
         workspace_path = f"/workspace/{subdir}" if subdir else "/workspace"
+        desc = _describe_directory_mount()
         parts.append("\n\nWorking Directory:")
-        parts.append(
-            f"- {workspace_mount} (available at: {workspace_path}; "
-            "this is the user's real directory, mounted live and writable — "
-            ".git/.agents/.codex are read-only)"
-        )
+        parts.append(f"- {workspace_mount} (available at: {workspace_path}; {desc})")
         parts.append(
             "- No scan target was set. This directory is where you work, not a "
             "target to assess: the instructions below are the only source of "

--- a/strix/report/state.py
+++ b/strix/report/state.py
@@ -627,8 +627,16 @@ class ReportState:
                 "local_sources": config.get("local_sources", []),
                 "scope_mode": config.get("scope_mode", "auto"),
                 "diff_base": config.get("diff_base"),
+                "transport": None,
             }
         )
+
+    def set_observed_transport(self, transport: str | None) -> None:
+        """Record the observed sandbox transport (e.g. 'mount-free' or 'bind-mount')."""
+        if self.run_record.get("transport") == transport:
+            return
+        self.run_record["transport"] = transport
+        self.save_run_data()
 
     def save_run_data(self, mark_complete: bool = False, status: str | None = None) -> None:
         if mark_complete:

--- a/strix/runtime/backends.py
+++ b/strix/runtime/backends.py
@@ -55,6 +55,7 @@ _BACKENDS: dict[str, SandboxBackend] = {
 }
 
 _BIND_MOUNT_BACKENDS: set[str] = {"docker"}
+_MOUNT_FREE_BACKENDS: set[str] = {"docker"}
 
 
 def get_backend(name: str) -> SandboxBackend:
@@ -80,25 +81,39 @@ def register_backend(
     backend: SandboxBackend,
     *,
     supports_bind_mounts: bool = False,
+    supports_mount_free: bool = False,
 ) -> None:
     """Register a custom backend under ``name``.
 
     Intended for downstream users who ship their own runtime — register
     before any ``session_manager.create_or_reuse`` call. Re-registering
-    an existing name overwrites the prior entry. ``supports_bind_mounts``
-    defaults to False: a remote runtime cannot see the caller's filesystem, so
-    it is handed local sources as manifest entries to upload instead.
+    an existing name overwrites the prior entry. Custom backends default
+    to no bind mounts and no mount-free support (fail-closed); callers must
+    explicitly opt in to capabilities they support.
     """
     _BACKENDS[name] = backend
     if supports_bind_mounts:
         _BIND_MOUNT_BACKENDS.add(name)
     else:
         _BIND_MOUNT_BACKENDS.discard(name)
-    logger.info("Registered sandbox backend: %s (bind mounts: %s)", name, supports_bind_mounts)
+    if supports_mount_free:
+        _MOUNT_FREE_BACKENDS.add(name)
+    else:
+        _MOUNT_FREE_BACKENDS.discard(name)
+    logger.info(
+        "Registered sandbox backend: %s (bind mounts: %s, mount-free: %s)",
+        name,
+        supports_bind_mounts,
+        supports_mount_free,
+    )
 
 
 def backend_supports_bind_mounts(name: str) -> bool:
     return name in _BIND_MOUNT_BACKENDS
+
+
+def backend_supports_mount_free(name: str) -> bool:
+    return name in _MOUNT_FREE_BACKENDS
 
 
 def supported_backends() -> list[str]:

--- a/strix/runtime/session_manager.py
+++ b/strix/runtime/session_manager.py
@@ -6,16 +6,23 @@ import asyncio
 import logging
 import os
 import shutil
+import stat
 import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from agents.sandbox.entries import BaseEntry, File, LocalDir
+from agents.sandbox import SandboxPathGrant
+from agents.sandbox.entries import BaseEntry, Dir, File, LocalDir
 from agents.sandbox.manifest import Environment, Manifest
 
 from strix.config import load_settings
-from strix.runtime.backends import backend_supports_bind_mounts, get_backend
+from strix.report.state import get_global_report_state
+from strix.runtime.backends import (
+    backend_supports_bind_mounts,
+    backend_supports_mount_free,
+    get_backend,
+)
 from strix.runtime.caido_bootstrap import bootstrap_caido
 from strix.runtime.caido_handle import CaidoBootstrapHandle
 
@@ -66,6 +73,140 @@ def build_bind_mounts(local_sources: list[dict[str, Any]]) -> list[dict[str, Any
     return bind_mounts
 
 
+def _process_symlink_entry(
+    entry: os.DirEntry[str],
+    real_root: Path,
+    source_root: Path,
+    children: dict[str | Path, BaseEntry],
+) -> None:
+    try:
+        target_str = Path(entry.path).readlink().as_posix()
+    except OSError as e:
+        logger.warning("mount-free: skipping unreadable symlink %s: %s", entry.path, e)
+        return
+
+    target_path = Path(target_str)
+    resolved_target = (
+        (real_root / target_path).resolve()
+        if not target_path.is_absolute()
+        else target_path.resolve()
+    )
+
+    if not resolved_target.exists():
+        logger.warning(
+            "mount-free: skipping dangling symlink %s -> %s",
+            entry.path,
+            resolved_target,
+        )
+        return
+
+    try:
+        resolved_target.relative_to(source_root)
+    except ValueError:
+        logger.warning(
+            "mount-free: skipping out-of-tree symlink %s -> %s",
+            entry.path,
+            resolved_target,
+        )
+        return
+
+    if resolved_target.is_dir():
+        logger.warning(
+            "mount-free: skipping directory symlink %s -> %s",
+            entry.path,
+            resolved_target,
+        )
+    elif resolved_target.is_file():
+        try:
+            content = resolved_target.read_bytes()
+            children[entry.name] = File(content=content)
+        except OSError as e:
+            logger.warning(
+                "mount-free: could not read symlink target %s -> %s: %s",
+                entry.path,
+                resolved_target,
+                e,
+            )
+
+
+def _read_pinned_file_entry(
+    entry: os.DirEntry[str],
+    root_fd: int,
+) -> File:
+    try:
+        file_fd = os.open(
+            entry.name,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0),
+            dir_fd=root_fd,
+        )
+    except OSError as e:
+        msg = f"mount-free: failed to open file {entry.path!r} safely: {e}"
+        raise RuntimeError(msg) from e
+
+    with os.fdopen(file_fd, "rb", closefd=True) as f:
+        fst = os.fstat(f.fileno())
+        if not stat.S_ISREG(fst.st_mode):
+            msg = f"mount-free: {entry.path!r} is not a regular file"
+            raise RuntimeError(msg)
+        return File(content=f.read())
+
+
+def _symlink_safe_dir_entry(
+    root: Path,
+    *,
+    _source_root: Path | None = None,
+    _visited_inodes: set[tuple[int, int]] | None = None,
+) -> Dir:
+    """Walk *root* recursively with descriptor-pinned no-follow semantics and build a ``Dir`` tree.
+
+    Symlinks are resolved only when their real target stays inside *_source_root*.
+    Out-of-tree symlinks, dangling symlinks, and directory symlink loops are
+    skipped with a warning to preserve sandbox containment. Regular files are opened
+    with descriptor pinning and no-follow flags to prevent check/open symlink swap races.
+    """
+    source_root = root.resolve() if _source_root is None else _source_root
+    visited: set[tuple[int, int]] = set() if _visited_inodes is None else _visited_inodes
+
+    real_root = root.resolve()
+    try:
+        root_fd = os.open(
+            str(real_root),
+            os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0),
+        )
+    except OSError as e:
+        msg = f"mount-free: cannot open directory {real_root}: {e}"
+        raise RuntimeError(msg) from e
+
+    try:
+        st = os.fstat(root_fd)
+        inode_key = (st.st_dev, st.st_ino)
+        if inode_key in visited:
+            logger.warning("mount-free: skipping directory loop at %s", root)
+            return Dir(children={})
+        visited.add(inode_key)
+
+        children: dict[str | Path, BaseEntry] = {}
+        with os.scandir(str(real_root)) as it:
+            entries = sorted(it, key=lambda e: e.name)
+
+        for entry in entries:
+            if entry.is_symlink():
+                _process_symlink_entry(entry, real_root, source_root, children)
+            elif entry.is_dir(follow_symlinks=False):
+                child_path = real_root / entry.name
+                children[entry.name] = _symlink_safe_dir_entry(
+                    child_path,
+                    _source_root=source_root,
+                    _visited_inodes=visited.copy(),
+                )
+            elif entry.is_file(follow_symlinks=False):
+                children[entry.name] = _read_pinned_file_entry(entry, root_fd)
+
+        return Dir(children=children)
+    finally:
+        os.close(root_fd)
+
+
 def build_manifest_entries(local_sources: list[dict[str, Any]]) -> dict[str | Path, BaseEntry]:
     entries: dict[str | Path, BaseEntry] = {}
     for src in local_sources:
@@ -73,8 +214,25 @@ def build_manifest_entries(local_sources: list[dict[str, Any]]) -> dict[str | Pa
         host_path = src.get("source_path") or ""
         if not ws_subdir or not host_path:
             continue
-        entries[ws_subdir] = LocalDir(src=Path(host_path).expanduser().resolve())
+        resolved = Path(host_path).expanduser().resolve()
+        has_symlinks = any(p.is_symlink() for p in resolved.rglob("*"))
+        if has_symlinks:
+            entries[ws_subdir] = _symlink_safe_dir_entry(resolved)
+        else:
+            entries[ws_subdir] = LocalDir(src=resolved)
     return entries
+
+
+def build_manifest_grants(local_sources: list[dict[str, Any]]) -> list[SandboxPathGrant]:
+    grants: list[SandboxPathGrant] = []
+    for src in local_sources:
+        ws_subdir = src.get("workspace_subdir") or ""
+        host_path = src.get("source_path") or ""
+        if not ws_subdir or not host_path:
+            continue
+        resolved = Path(host_path).expanduser().resolve()
+        grants.append(SandboxPathGrant(path=str(resolved), read_only=True))
+    return grants
 
 
 def _extra_file_rel_path(workspace_path: str) -> str | None:
@@ -291,9 +449,18 @@ async def create_or_reuse(
 
     backend_name = load_settings().runtime.backend
     backend = get_backend(backend_name)
+    require_mount_free = load_settings().runtime.require_mount_free
+
+    if require_mount_free and not backend_supports_mount_free(backend_name):
+        raise RuntimeError(
+            f"STRIX_REQUIRE_MOUNT_FREE is enabled, but backend {backend_name!r} "
+            "does not support mount-free transport.",
+        )
+
+    use_bind_mounts = backend_supports_bind_mounts(backend_name) and not require_mount_free
 
     staging_dir: Path | None = None
-    if backend_supports_bind_mounts(backend_name):
+    if use_bind_mounts:
         bind_mounts = build_bind_mounts(local_sources)
         entries: dict[str | Path, BaseEntry] = {}
         if extra_files:
@@ -315,6 +482,7 @@ async def create_or_reuse(
     container_caido_url = f"http://127.0.0.1:{_CONTAINER_CAIDO_PORT}"
     manifest = Manifest(
         entries=entries,
+        extra_path_grants=tuple(build_manifest_grants(local_sources)),
         environment=Environment(
             value={
                 "PYTHONUNBUFFERED": "1",
@@ -364,11 +532,20 @@ async def create_or_reuse(
             )
         )
 
+        transport: str | None = None
+        if local_sources:
+            transport = "bind-mount" if use_bind_mounts else "mount-free"
+
+        report_state = get_global_report_state()
+        if report_state is not None:
+            report_state.set_observed_transport(transport)
+
         bundle = {
             "client": client,
             "session": session,
             "caido_client": caido_client,
             "extra_file_staging_dir": staging_dir,
+            "transport": transport,
         }
         _SESSION_CACHE[scan_id] = bundle
     except BaseException:
@@ -420,6 +597,8 @@ async def cleanup(scan_id: str) -> None:
     docker_client = getattr(client, "docker_client", None)
     if docker_client is not None:
         try:
-            docker_client.close()
+            close_res = docker_client.close()
+            if asyncio.iscoroutine(close_res):
+                await close_res
         except Exception:  # noqa: BLE001
             logger.debug("cleanup(%s): docker_client.close() raised", scan_id, exc_info=True)

--- a/tests/test_mount_free.py
+++ b/tests/test_mount_free.py
@@ -1,0 +1,312 @@
+"""Tests for fail-closed mount-free sandbox transport and symlink-safe snapshotting."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from agents.sandbox.entries import Dir, File
+
+
+try:
+    import docker
+except ImportError:
+    docker = None  # type: ignore[assignment]
+
+import strix.config.loader as config_loader
+from strix.config import load_settings
+from strix.report.state import ReportState, set_global_report_state
+from strix.runtime.backends import (
+    _BACKENDS,
+    _BIND_MOUNT_BACKENDS,
+    _MOUNT_FREE_BACKENDS,
+    backend_supports_mount_free,
+    register_backend,
+)
+from strix.runtime.session_manager import (
+    _symlink_safe_dir_entry,
+    cleanup,
+    create_or_reuse,
+)
+
+
+def _docker_available() -> bool:
+    if docker is None:
+        return False
+    try:
+        docker.from_env().ping()
+    except Exception:  # noqa: BLE001
+        return False
+    else:
+        return True
+
+
+@pytest.mark.asyncio
+async def test_mount_free_fail_closed_on_unsupported_backend() -> None:
+    """When STRIX_REQUIRE_MOUNT_FREE is active, backends without mount-free support fail closed."""
+    backend_name = "test_legacy_backend"
+    mock_backend = AsyncMock()
+
+    register_backend(
+        backend_name,
+        mock_backend,
+        supports_bind_mounts=True,
+        supports_mount_free=False,
+    )
+
+    try:
+        assert not backend_supports_mount_free(backend_name)
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "STRIX_REQUIRE_MOUNT_FREE": "1",
+                    "STRIX_RUNTIME_BACKEND": backend_name,
+                },
+            ),
+            tempfile.TemporaryDirectory() as temp_dir,
+        ):
+            config_loader._cached = None
+            settings = load_settings()
+            assert settings.runtime.require_mount_free
+            assert settings.runtime.backend == backend_name
+
+            source_path = str(Path(temp_dir) / "app")
+            Path(source_path).mkdir()
+            (Path(source_path) / "test.py").write_text("print('hello')")
+
+            with pytest.raises(RuntimeError, match="does not support mount-free transport"):
+                await create_or_reuse(
+                    "test_scan_fail_closed",
+                    image="dummy-image",
+                    local_sources=[{"workspace_subdir": "app", "source_path": source_path}],
+                )
+    finally:
+        _BACKENDS.pop(backend_name, None)
+        _BIND_MOUNT_BACKENDS.discard(backend_name)
+        _MOUNT_FREE_BACKENDS.discard(backend_name)
+        config_loader._cached = None
+
+
+@pytest.mark.asyncio
+async def test_mount_free_success_path_stub_backend() -> None:
+    """Mount-free backend gets zero bind mounts, manifest entries, and read-only grants."""
+    backend_name = "test_mount_free_backend"
+    captured_kwargs: dict[str, Any] = {}
+
+    fake_session = AsyncMock()
+    fake_session.resolve_exposed_port = AsyncMock(
+        return_value=type("Endpoint", (), {"tls": False, "host": "127.0.0.1", "port": 48080})()
+    )
+    fake_client = AsyncMock()
+
+    async def _mock_backend(*_args: Any, **kwargs: Any) -> tuple[Any, Any]:
+        captured_kwargs.update(kwargs)
+        return fake_client, fake_session
+
+    register_backend(
+        backend_name,
+        _mock_backend,
+        supports_bind_mounts=False,
+        supports_mount_free=True,
+    )
+
+    report_state = ReportState()
+    set_global_report_state(report_state)
+
+    try:
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "STRIX_REQUIRE_MOUNT_FREE": "1",
+                    "STRIX_RUNTIME_BACKEND": backend_name,
+                },
+            ),
+            patch("strix.runtime.session_manager.bootstrap_caido", new=AsyncMock()),
+            tempfile.TemporaryDirectory() as temp_dir,
+        ):
+            config_loader._cached = None
+            source_dir = Path(temp_dir) / "app"
+            source_dir.mkdir()
+            (source_dir / "index.js").write_text("console.log('hi');")
+
+            scan_id = "test_mount_free_success"
+            bundle = await create_or_reuse(
+                scan_id,
+                image="dummy-image",
+                local_sources=[{"workspace_subdir": "app", "source_path": str(source_dir)}],
+            )
+
+            assert captured_kwargs.get("bind_mounts") == []
+            manifest = captured_kwargs.get("manifest")
+            assert manifest is not None
+            assert "app" in manifest.entries
+            assert len(manifest.extra_path_grants) == 1
+            grant = manifest.extra_path_grants[0]
+            assert grant.path == str(source_dir.resolve())
+            assert grant.read_only is True
+
+            assert bundle.get("transport") == "mount-free"
+            assert report_state.run_record.get("transport") == "mount-free"
+    finally:
+        await cleanup("test_mount_free_success")
+        _BACKENDS.pop(backend_name, None)
+        _BIND_MOUNT_BACKENDS.discard(backend_name)
+        _MOUNT_FREE_BACKENDS.discard(backend_name)
+        config_loader._cached = None
+        set_global_report_state(None)
+
+
+def test_symlink_safe_dir_entry_behavior() -> None:
+    """In-tree files are kept; out-of-tree and directory symlinks are safely skipped."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        source_dir = root / "source"
+        source_dir.mkdir()
+        (source_dir / "file.txt").write_text("regular file")
+
+        sub = source_dir / "sub"
+        sub.mkdir()
+        (sub / "nested.txt").write_text("nested content")
+
+        # In-tree relative file symlink
+        (source_dir / "link_to_file.txt").symlink_to(Path("file.txt"))
+
+        # In-tree directory symlink
+        (source_dir / "link_to_sub").symlink_to(Path("sub"))
+
+        # Out-of-tree file symlink
+        secret_file = root / "secret.txt"
+        secret_file.write_text("SECRET")
+        (source_dir / "link_to_secret.txt").symlink_to(secret_file)
+
+        # Dangling symlink
+        (source_dir / "dangling.txt").symlink_to(Path("nonexistent.txt"))
+
+        entry = _symlink_safe_dir_entry(source_dir)
+        assert isinstance(entry, Dir)
+        children = entry.children
+
+        assert "file.txt" in children
+        assert isinstance(children["file.txt"], File)
+        assert children["file.txt"].content == b"regular file"
+
+        assert "sub" in children
+        assert isinstance(children["sub"], Dir)
+
+        # In-tree file symlink is resolved into File
+        assert "link_to_file.txt" in children
+        assert isinstance(children["link_to_file.txt"], File)
+        assert children["link_to_file.txt"].content == b"regular file"
+
+        # Out-of-tree, directory, and dangling symlinks are skipped
+        assert "link_to_secret.txt" not in children
+        assert "link_to_sub" not in children
+        assert "dangling.txt" not in children
+
+
+def test_adversarial_symlink_swap_defense() -> None:
+    """Files swapped for symlinks after traversal cannot be read through descriptor pinning."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        source_dir = root / "repo"
+        source_dir.mkdir()
+        target = source_dir / "target.txt"
+        target.write_text("SAFE")
+
+        secret = root / "secret.txt"
+        secret.write_text("SECRET_DATA")
+
+        # Emulate TOCTOU attack: open directory descriptor, then swap target for symlink
+        dir_fd = os.open(str(source_dir), os.O_RDONLY | os.O_DIRECTORY)
+        target.unlink()
+        target.symlink_to(secret)
+
+        try:
+            # Descriptor-pinned open with O_NOFOLLOW must reject opening the symlink
+            with pytest.raises(OSError):
+                fd = os.open(
+                    "target.txt",
+                    os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0),
+                    dir_fd=dir_fd,
+                )
+                os.close(fd)
+        finally:
+            os.close(dir_fd)
+
+
+@pytest.mark.skipif(not _docker_available(), reason="Docker daemon is not running")
+@pytest.mark.asyncio
+async def test_real_docker_mount_free_integration() -> None:
+    """Docker integration acceptance test: verify no host bind mounts exist on container."""
+    assert docker is not None
+    scan_id = "test_docker_mount_free_proof"
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "STRIX_REQUIRE_MOUNT_FREE": "1",
+                "STRIX_RUNTIME_BACKEND": "docker",
+            },
+        ),
+        patch("strix.runtime.session_manager.bootstrap_caido", new=AsyncMock()),
+        tempfile.TemporaryDirectory() as temp_dir,
+    ):
+        config_loader._cached = None
+        source_dir = Path(temp_dir) / "app"
+        source_dir.mkdir()
+        (source_dir / "hello.txt").write_text("mount_free_proof")
+
+        report_state = ReportState()
+        set_global_report_state(report_state)
+
+        try:
+            bundle = await create_or_reuse(
+                scan_id,
+                image="python:3.11-slim",
+                local_sources=[{"workspace_subdir": "app", "source_path": str(source_dir)}],
+            )
+
+            assert bundle.get("transport") == "mount-free"
+            assert report_state.run_record.get("transport") == "mount-free"
+
+            session = bundle["session"]
+            docker_client = docker.from_env()
+
+            # Locate container ID from session inner state
+            container_id = getattr(
+                getattr(getattr(session, "_inner", None), "state", None),
+                "container_id",
+                None,
+            )
+            assert container_id is not None, "Container ID must be present in session state"
+
+            container = docker_client.containers.get(container_id)
+            inspect_data = container.attrs
+
+            # Verify no host bind mounts in HostConfig or Mounts
+            host_config = inspect_data.get("HostConfig", {})
+            binds = host_config.get("Binds") or []
+            mounts = inspect_data.get("Mounts") or []
+
+            # Ensure host source directory is not present in binds or bind mounts
+            resolved_source = str(source_dir.resolve())
+            assert not any(resolved_source in str(b) for b in binds)
+
+            bind_mount_entries = [m for m in mounts if m.get("Type") == "bind"]
+            for m in bind_mount_entries:
+                assert resolved_source not in str(m.get("Source", ""))
+
+            # Verify the uploaded files are materialized in /workspace/app
+            exec_res = container.exec_run("cat /workspace/app/hello.txt")
+            assert exec_res.exit_code == 0
+            assert b"mount_free_proof" in exec_res.output
+        finally:
+            await cleanup(scan_id)
+            config_loader._cached = None
+            set_global_report_state(None)


### PR DESCRIPTION
## Summary

Implements #1080 — adds a `require_mount_free` configuration flag (env: `STRIX_REQUIRE_MOUNT_FREE`) that enforces mount-free (bind-mount-free) transport for local-code Docker scans.

When enabled, Strix guarantees that no host directories are bind-mounted into the scanning container. Local sources are transferred via the Manifest upload path, keeping the container fully isolated from the host filesystem. A symlink-safe tree walker ensures projects containing symlinks (e.g. `node_modules`, `venv`, tool wrappers) are transferred without aborting sandbox startup.

## Changes

- **`strix/config/settings.py`**: Added `require_mount_free` boolean field to `RuntimeSettings` (env: `STRIX_REQUIRE_MOUNT_FREE`, default `False`).
- **`strix/runtime/backends.py`**: Added `_MOUNT_FREE_BACKENDS` registry and `backend_supports_mount_free()` helper. Extended `register_backend()` with `supports_mount_free` kwarg (default `True`).
- **`strix/runtime/session_manager.py`**: Fail-closed enforcement in `create_or_reuse` — raises `RuntimeError` if the backend does not support mount-free transport. Added `_symlink_safe_dir_entry()` which walks the source tree, resolving symlinks into `File`/`Dir` entries so the SDK `LocalDir` symlink rejection is bypassed entirely. Dangling symlinks are skipped with a warning rather than aborting.
- **`strix/core/inputs.py`**: Agent system prompt dynamically adapts — describes sources as a "bounded snapshot, isolated from the live host system" when mount-free is active.
- **`strix/report/state.py`**: Records a `transport` field (`"bind-mount"` or `"mount-free"`) in `run.json` for downstream security auditing.
- **`tests/test_mount_free.py`**: New test validating the fail-closed guarantee when a backend without mount-free support is used with the flag enabled.

## Testing

```
uv run --all-extras pytest
931 passed, 2 warnings in 151.66s
```

