### PR TITLE
chore(tui): bump golang.org/x/text to v0.41.0

### DIFF
--- a/strix/interface/tui/go.mod
+++ b/strix/interface/tui/go.mod
@@ -28,5 +28,5 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/text v0.3.8 // indirect
+	golang.org/x/text v0.41.0 // indirect
 )

--- a/strix/interface/tui/go.sum
+++ b/strix/interface/tui/go.sum
@@ -57,5 +57,5 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
 golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
-golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
-golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
+golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=


### PR DESCRIPTION
## Summary

Bump the Bubble Tea TUI indirect dependency `golang.org/x/text` from v0.3.8 to v0.41.0.

## The problem

Trivy flags [CVE-2026-56852](https://nvd.nist.gov/vuln/detail/CVE-2026-56852) / [GO-2026-5970](https://pkg.go.dev/vuln/GO-2026-5970) in `golang.org/x/text` v0.3.8. That version can loop on invalid UTF-8 in `unicode/norm`. The TUI module pulled it transitively (`bubbletea` -> `go-localereader` -> `x/text/transform`). The advisory is fixed in v0.39.0.

This pin arrived with the Bubble Tea TUI in [#941](https://github.com/usestrix/strix/pull/941).

## The change

- `strix/interface/tui/go.mod` and `go.sum`: v0.3.8 -> v0.41.0 (current latest, includes the v0.39.0 fix).
- Consumer `go` line stays at `1.24.0` so [release CI](https://github.com/usestrix/strix/blob/main/.github/workflows/build-release.yml) (`go-version: 1.24.x`) still builds. `go mod tidy` on Go 1.25+ will try to raise that line because patched `x/text` releases declare `go 1.25.0`; do not apply that rewrite here.

aiohttp 3.14.3 and cryptography 50.0.0 are intentionally not in this PR. Those bumps already have open PRs ([#967](https://github.com/usestrix/strix/pull/967), [#1066](https://github.com/usestrix/strix/pull/1066), [#966](https://github.com/usestrix/strix/pull/966), [#1067](https://github.com/usestrix/strix/pull/1067)), and cryptography is still capped `<49` for the Intel macOS universal2 wheel ([#859](https://github.com/usestrix/strix/pull/859)).

## Validation

- `GOTOOLCHAIN=go1.24.11 CGO_ENABLED=0 go build` in `strix/interface/tui`
- `GOTOOLCHAIN=go1.24.11 go test -race ./...` (app, protocol, render all ok)
- `make tui-lint` and `make tui-build`

This is a lockfile-only bump, so there is no new suite test.

## Related

- [CVE-2026-56852](https://nvd.nist.gov/vuln/detail/CVE-2026-56852)
- [GO-2026-5970](https://pkg.go.dev/vuln/GO-2026-5970)
- [#941](https://github.com/usestrix/strix/pull/941) introduced the v0.3.8 pin
