### PR TITLE
fix(proxy): normalize empty sitemap scope filters

### DIFF
--- a/strix/tools/proxy/caido_api.py
+++ b/strix/tools/proxy/caido_api.py
@@ -650,6 +650,9 @@ async def list_sitemap_with_client(
         )
         data = raw.get("sitemapDescendantEntries") or {}
     else:
+        # Caido's sitemapRootEntries scopeId is an i32 ID; an empty string
+        # from the agent is rejected, so omit it (null) instead.
+        scope_id = (scope_id or "").strip() or None
         raw = await client.graphql.query(
             _SITEMAP_ROOTS_QUERY,
             variables={"scopeId": scope_id},

--- a/strix/tools/proxy/tools.py
+++ b/strix/tools/proxy/tools.py
@@ -88,13 +88,12 @@ def _no_client() -> str:
     )
 
 
-def _err(name: str, exc: Exception) -> str:
+def _err(name: str, exc: Exception, **details: Any) -> str:
     logger.exception("%s failed", name)
-    return json.dumps(
-        {"success": False, "error": f"{name} failed: {exc}"},
-        ensure_ascii=False,
-        default=str,
-    )
+    payload: dict[str, Any] = {"success": False, "error": f"{name} failed: {exc}"}
+    if details:
+        payload["details"] = details
+    return json.dumps(payload, ensure_ascii=False, default=str)
 
 
 @function_tool(timeout=120)
@@ -224,7 +223,12 @@ async def list_requests(
             default=str,
         )
     except Exception as exc:  # noqa: BLE001
-        return _err("list_requests", exc)
+        return _err(
+            "list_requests",
+            exc,
+            httpql_filter=httpql_filter,
+            scope_id=scope_id,
+        )
 
 
 @function_tool(timeout=60)
@@ -477,7 +481,13 @@ async def list_sitemap(
         )
         return json.dumps(payload, ensure_ascii=False, default=str)
     except Exception as exc:  # noqa: BLE001
-        return _err("list_sitemap", exc)
+        return _err(
+            "list_sitemap",
+            exc,
+            scope_id=scope_id,
+            parent_id=parent_id,
+            depth=depth,
+        )
 
 
 @function_tool(timeout=60)

--- a/tests/test_caido_api.py
+++ b/tests/test_caido_api.py
@@ -1,0 +1,22 @@
+"""Tests for Caido proxy API helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from strix.tools.proxy.caido_api import list_sitemap_with_client
+
+
+@pytest.mark.asyncio
+async def test_list_sitemap_omits_blank_root_scope_id() -> None:
+    query = AsyncMock(return_value={"sitemapRootEntries": {"edges": [], "count": {"value": 0}}})
+    client = SimpleNamespace(graphql=SimpleNamespace(query=query))
+
+    result = await list_sitemap_with_client(client, scope_id="   ")
+
+    assert result["success"] is True
+    assert result["entries"] == []
+    assert query.await_args.kwargs["variables"] == {"scopeId": None}


### PR DESCRIPTION
## Summary
- send null instead of an empty string for root sitemap scope filters
- return the supplied list filters in proxy error details
- add regression coverage for blank scope IDs

## Testing
- uv run pytest tests/test_caido_api.py