### PR TITLE
fix(report): raise RuntimeError on non-object run.json (fixes #1109)

### DIFF
--- a/strix/interface/cli_args.py
+++ b/strix/interface/cli_args.py
@@ -346,7 +346,7 @@ def _load_resume_state(args: argparse.Namespace, parser: argparse.ArgumentParser
         )
     try:
         state = read_run_record(run_dir)
-    except RuntimeError as exc:
+    except (RuntimeError, TypeError) as exc:
         parser.error(f"--resume {args.resume}: run.json unreadable: {exc}")
 
     args.targets_info = state.get("targets_info") or []

--- a/tests/test_cli_target_list.py
+++ b/tests/test_cli_target_list.py
@@ -227,3 +227,18 @@ def test_resume_still_requires_targets_or_a_workspace(
         cli_main.parse_arguments()
 
     assert "has no targets_info" in capsys.readouterr().err
+
+def test_resume_non_object_run_json_exits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.chdir(tmp_path)
+    run_dir = tmp_path / "strix_runs" / "pentest_abcd"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run.json").write_text("[]", encoding="utf-8")
+
+    monkeypatch.setattr(sys, "argv", ["strix", "--resume", "pentest_abcd"])
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.parse_arguments()
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "run.json unreadable" in captured.err
+    assert "not an object" in captured.err


### PR DESCRIPTION
### Summary
Fixes #1109.

- Added type validation in `read_run_record()` (`strix/report/writer.py`) to raise `RuntimeError` when `run.json` contains a valid but non-dict JSON root (such as a list or string).
- Updated `test_read_run_record_non_object_raises` in `tests/test_report_writer.py` to expect `RuntimeError` instead of `TypeError`, preventing uncaught exceptions during `--resume` runs.


<img width="1417" height="317" alt="image" src="https://github.com/user-attachments/assets/f9be2cc6-1cbc-4a85-bbef-2315c08427f5" />
