### PR TITLE
Add reverse-engineering security skills

### DIFF
--- a/strix/skills/README.md
+++ b/strix/skills/README.md
@@ -55,6 +55,12 @@ Notable LLM security skills:
 - `llm_applications` (technologies): end-to-end OWASP 2026 LLM01-LLM10 coverage across models, RAG, vectors, agents, tools, outputs, supply chain, and resource controls
 - `llm_prompt_injection` (vulnerabilities): deep direct, indirect, multimodal, memory, and tool-result prompt-injection testing
 
+Notable reverse-engineering skills:
+- `advisory_to_poc` (custom): advisory-to-root-cause workflow for patch diffing, public PoCs, and detector design
+- `appliance_firmware` (technologies): appliance artifact, runtime, and install-state analysis
+- `protocol_reverse_engineering` (protocols): stateful/custom protocol reconstruction and controlled harnessing
+- `memory_corruption` (vulnerabilities): native crash triage, primitive quality, and exploitability constraints
+
 ---
 
 ## 🎨 Creating New Skills

--- a/strix/skills/custom/advisory_to_poc.md
+++ b/strix/skills/custom/advisory_to_poc.md
@@ -1,0 +1,235 @@
+---
+name: advisory-to-poc
+description: Vulnerability research workflow for turning advisories, patches, release artifacts, public PoCs, and incident clues into root-cause analysis, safe reproducers, reliable detectors, patch-bypass review, and adjacent-bug hypotheses
+---
+
+# Advisory to PoC
+
+Use this skill for authorized product-security and n-day research where the starting point is an advisory, fixed release, patch, public PoC, or incident evidence rather than a known vulnerable endpoint.
+
+The goal is a version-bounded root-cause explanation and reliable, reproducible validation. Do not equate a changed function, crash, scanner hit, or advisory claim with exploitability.
+
+## Evidence Ledger
+
+Keep facts, inferences, and experiments separate:
+
+| Type | Examples |
+|---|---|
+| Published fact | affected versions, CWE, exposed feature, vendor mitigation |
+| Artifact fact | changed function, new validation, removed route, configuration delta |
+| Inference | likely attacker-controlled field, suspected auth path, probable sink |
+| Experiment | vulnerable response, fixed response, crash, OAST callback, file canary |
+
+Record source URL, artifact hash, product edition/branch, build number, platform, configuration, and date. Re-check assumptions whenever the experimental result conflicts with the advisory narrative.
+
+## Research Workflow
+
+### 1. Scope the Claim
+
+- Extract affected and fixed versions, branches, platforms, roles, protocols, and feature/configuration prerequisites.
+- Note whether the vendor describes impact, root cause, mitigation, or only a CWE category.
+- Treat bundled CVEs and large release rollups as multiple candidate changes until proven otherwise.
+- Identify whether the issue is pre-auth, low-privilege, post-auth, local, or requires a victim/session bridge.
+
+### 2. Acquire Comparable Artifacts
+
+Prefer the closest vulnerable/fixed pair for the same edition and platform:
+
+- source commits, tags, tests, pull requests, and dependency lockfiles
+- packages, containers, installers, JAR/WAR/DLL/assemblies, Python bytecode, firmware, or VM images
+- web-server/reverse-proxy configuration, service definitions, scripts, and bundled third-party components
+- documentation and shipped examples that reveal routes, protocols, defaults, or extension points
+
+Hash originals and work on copies. Preserve installation lineage: default credentials, generated keys, legacy files, and retained configs may matter even if a fresh fixed install does not contain them.
+
+### 3. Reduce Diff Noise
+
+Start with inventories before line-by-line analysis:
+
+- added/removed/renamed files and dependencies
+- changed routes, authorization annotations, allowlists/denylists, parser calls, command construction, length checks, and deserialization types
+- edge configuration changes that block or rewrite a route without changing application code
+- tests added, removed, or updated; these often encode a near-ready reproducer
+- sibling call sites of the changed helper or validator
+
+For binaries, combine string/import/symbol diffing with a decompiler and a second diffing method when possible. Large compiler or bundled-library changes create false clusters; anchor on advisory-relevant constants, protocol handlers, response strings, and call graphs.
+
+### 4. Map External Reachability
+
+Work from both directions:
+
+```text
+external listener -> edge config -> router -> authentication -> parser -> sink
+known changed sink -> callers -> route/protocol -> authentication -> external listener
+```
+
+Inventory auxiliary listeners, management agents, sidecars, localhost APIs, custom RPC services, CGI/script dispatch, and framework direct-component routes. Do not assume the main web UI's authentication protects every product service.
+
+Record branch-specific and configuration-specific exposure. A powerful sink behind a disabled feature or unreachable route is not a pre-auth vulnerability.
+
+### 5. Explain the Patch Mechanism
+
+State what security invariant the patch tries to restore:
+
+- bounds, termination, initialization, or length/type consistency
+- authentication/authorization before dispatch
+- canonicalization before comparison
+- allowlisted deserialization or reflection targets
+- safe command/process APIs instead of shell construction
+- file path confinement and extension/handler restrictions
+- route removal or edge blocking
+- session-field filtering or trustworthy state reconstruction
+
+Then ask what the patch did not change: alternate callers, sibling parsers, secondary routes, nested gadgets, transitive deserialization, old aliases, different protocol handlers, and edge/application disagreement.
+
+### 6. Build a Reproducer Ladder
+
+Escalate one capability at a time:
+
+1. **Presence** - product/version/protocol fingerprint with low noise
+2. **Reachability** - expected route/parser/handler responds
+3. **Security differential** - unauthorized behavior differs from a denied control
+4. **Primitive** - safe read, controlled callback, canary write, harmless constructor, or deterministic crash in an isolated lab
+5. **Impact** - demonstrate the requested authorized impact and preserve its prerequisites
+
+Prefer distinctive non-secret response structure, benign errors, OAST DNS/HTTP callbacks, inert file markers, or no-op commands. For deserialization, use a non-executing network gadget before command execution. For memory corruption, establish the bug and mitigation constraints in a lab; a connection close or crash is not proof of RCE.
+
+### 7. Calibrate on Controls
+
+Run the same reproducer against:
+
+- vulnerable version
+- fixed version
+- unaffected neighboring version where available
+- feature disabled / hardened configuration
+- malformed but non-triggering negative input
+- authentication present vs absent, if the claim crosses an auth boundary
+
+Repeat enough times to distinguish deterministic behavior from crashes, timing noise, worker restarts, load balancers, and transient network failures.
+
+### 8. Hunt Adjacent and Partial Fixes
+
+After reproducing the primary issue:
+
+- enumerate every call site of the patched function/validator
+- cluster nearby handlers using the same parser, session format, command wrapper, or file primitive
+- replay the old PoC and structural variants against the first fixed version
+- inspect whether the patch blocks the route while leaving the sink reachable elsewhere
+- test nested/transitive objects rather than only top-level denylisted types
+- check whether one advisory/CVE bundles multiple distinct vulnerable paths
+
+Do not call a variant a bypass until the fixed version demonstrably remains vulnerable.
+
+## Tool Routing
+
+Use the lightest maintained tool that answers the current question. Pin versions in research notes and preserve generated outputs so another analyst can reproduce the diff.
+
+### Artifact and Package Diff: diffoscope
+
+[diffoscope](https://diffoscope.org/) is the default first pass for packages, directories, archives, and binaries. Use it to build a changed-file/config/package manifest before opening a decompiler. For hostile artifacts, keep inputs read-only, disable network, and run the helper-heavy comparison in an isolated environment.
+
+### Firmware and Appliance Artifacts
+
+When the starting point is firmware, a virtual appliance, or a nested image format, load `appliance_firmware`. That skill owns extraction, package/rootfs/runtime correlation, Ghidra/BinDiff routing, overlay/install-state analysis, and device-lifecycle caveats.
+
+### Java/JVM: Vineflower
+
+Use maintained [Vineflower](https://github.com/Vineflower/vineflower) for JAR/class decompilation. Diff archive inventories before decompiled text; compiler, obfuscator, and synthetic-code changes produce noise. Confirm suspicious control flow with bytecode (`javap -c`) rather than treating reconstructed Java as source truth.
+
+### .NET: ILSpy / ilspycmd
+
+Use [ILSpy](https://github.com/icsharpcode/ILSpy) for managed assemblies. Work offline, inspect IL/metadata when the C# reconstruction is ambiguous, and use only GitHub Releases or NuGet.
+
+### Native Code: Ghidra and BinDiff
+
+Use official [Ghidra](https://github.com/NationalSecurityAgency/ghidra) for cross-architecture disassembly/decompilation and [BinDiff](https://github.com/google/bindiff) only after the file/package diff has narrowed the relevant binaries. Keep the toolchain pinned, offline where practical, and non-executing. Decompiler output and similarity scores are triage aids, not proof.
+
+## Source and Binary Techniques
+
+### Source-Available Products
+
+- Search route declarations, filters/interceptors, auth decorators, and direct framework component dispatch.
+- Trace attacker-controlled fields through type coercion, validation, shell/process APIs, filesystem operations, reflection, template/XSLT evaluation, and deserialization.
+- Compare callers, not just the patched callee. The same helper may be safe in one route and exposed in another.
+- Read tests and examples for expected protocol syntax and serialized message shapes.
+
+### Managed Artifacts
+
+- Decompile JAR/WAR and .NET assemblies; diff namespaces/classes/method bodies and embedded configuration.
+- Trace public setters, opaque identifiers, type metadata, and framework serialization hooks.
+- Inspect bundled libraries and version changes, but prove application reachability before assigning impact.
+
+### Native Binaries and Firmware
+
+- Inventory architecture, mitigations, imports, strings, services, and exposed ports before deep reversing.
+- Diff functions around new bounds checks, initialization, string termination, length casts, command builders, and protocol parsers.
+- Reconstruct the smallest valid protocol state machine before mutating the suspected field.
+- Use debuggers, sanitizers, traces, and process monitors inside an isolated lab when available.
+- Separate bug existence from exploitability under ASLR, NX, stack canaries, allocator behavior, architecture, and restart model.
+
+### Public PoC or Incident First
+
+- First decompose and neutralize a public or captured PoC; reproduce its stages in an isolated lab while preserving the headers, ordering, sessions, and negotiation relevant to each stage.
+- Decompose the PoC into stages and identify the oracle for each stage.
+- Work backward from the final sink to root cause and forward from the entry point to confirm reachability.
+- If no patch pair exists, controlled honeypot/instrumentation can reveal in-the-wild request structure; never expose a live vulnerable system beyond an isolated, monitored environment.
+
+Pair `protocol_reverse_engineering` when the external entry point is binary, TLS-wrapped, message-oriented, or stateful.
+
+## Detector Design
+
+A detector must distinguish the vulnerable behavior reliably from fixed and unaffected behavior:
+
+- match a structural response or deterministic state change, not a secret value
+- use a unique per-target canary and clean it up when the test writes data
+- distinguish patched denial from generic 404/500, WAF blocking, authentication failure, and connection loss
+- complete protocol/session prerequisites instead of relying on a single raw request
+- rate-limit crash-prone or resource-intensive probes and keep them opt-in
+- calibrate templates against vulnerable, fixed, and negative-control targets
+
+When scaling, separate fingerprinting from exploitation. Presence can prioritize assets; it does not confirm the vulnerability.
+
+## Exploitability Triage
+
+Rate each condition explicitly:
+
+- attacker position and credentials
+- default vs optional feature/configuration
+- internet-facing vs auxiliary/local listener
+- data/byte/control precision
+- restart, race, victim action, or environment requirements
+- available mitigations and architecture
+- reliable primitive vs crash-only or unstable behavior
+- practical post-primitive chain in the product's default deployment
+
+Down-rate unrealistic chains even when the underlying bug is real. Conversely, revisit “low” primitives such as SSRF, reflection, arbitrary write, cache control, or information disclosure in product context; native admin features may convert them into RCE.
+
+## Validation Deliverable
+
+Include:
+
+1. exact affected/fixed artifacts and hashes
+2. authoritative published claims and unresolved ambiguity
+3. minimal relevant diff and restored invariant
+4. external route/protocol and auth/config prerequisites
+5. source-to-sink or packet-to-sink trace
+6. safe reproducer plus positive and negative controls
+7. vulnerable vs fixed results across repeat runs
+8. exploitability constraints and why the demonstrated impact follows
+9. adjacent paths reviewed and any partial-fix evidence
+
+## Anti-Patterns
+
+- Trusting the advisory CWE/title as the actual root cause
+- Diffing only application code while ignoring edge/proxy/service configuration
+- Treating any crash, close, 500, scanner alert, or changed function as exploitation
+- Running a weaponized public PoC before isolating its stages and side effects
+- Claiming pre-auth impact without tracing the complete auth and routing path
+- Assuming one CVE maps to one code path or one patch fixes the whole vulnerability class
+- Searching only for the published payload instead of the restored invariant
+- Reporting a registry/download/callback signal without separating automated noise from authentic target execution
+- Generalizing from one appliance/version/configuration without testing prerequisites
+
+## Summary
+
+Advisory-driven research is evidence-driven reverse engineering. Acquire comparable artifacts, reduce the diff to a security invariant, prove external reachability, climb a safe reproducer ladder, calibrate against fixed and negative controls, and then audit sibling paths and partial fixes. The reusable output is the method and invariant—not the vendor-specific exploit string.

--- a/strix/skills/protocols/protocol_reverse_engineering.md
+++ b/strix/skills/protocols/protocol_reverse_engineering.md
@@ -1,0 +1,176 @@
+---
+name: protocol-reverse-engineering
+description: Authorized analysis of undocumented, proprietary, binary, or stateful network protocols using passive captures, client/server artifacts, explicit state machines, bounded lab harnesses, and semantic vulnerable-versus-fixed validation
+---
+
+# Protocol Reverse Engineering
+
+Use this skill when an exposed service cannot be tested correctly as isolated HTTP-like requests: custom RPC, binary framing, TLS-wrapped management protocols, message queues, VPN negotiation, in-band control records, or any protocol whose authentication and parsing depend on prior state.
+
+The objective is a reviewable protocol model and controlled evidence that proves or disproves a security property. A socket connection, completed TLS handshake, `200`, or parser crash does not prove authentication, authorization, or code execution.
+
+## Authorization and Safety Boundary
+
+- Work from supplied artifacts, offline captures, or an isolated lab target unless active testing is explicitly authorized.
+- Prefer offline parsing. Captures may contain credentials, session material, personal data, or private topology; minimize, encrypt, redact, and expire them.
+- Never replay production credentials or captured authentication material.
+- Put active harnesses in a network namespace or isolated VLAN with an explicit destination allowlist, low rate, bounded retries, and one mutation at a time.
+- Do not broadcast, scan unrelated addresses, or start mutation/fuzz loops by default.
+- Treat a malformed-packet crash as a denial-of-service test. Perform it only in a restartable lab and never infer RCE from it.
+
+## Build the Protocol Model
+
+Record each layer separately:
+
+| Layer | Questions |
+|---|---|
+| Transport | TCP, UDP, HTTP tunnel, queue, Unix socket, reconnect behavior? |
+| Security | TLS/mTLS, certificate role, message MAC/signature, encryption boundary? |
+| Framing | magic, version, type, flags, length, checksum, terminator, nesting? |
+| State | negotiation, challenge, authentication, session, command, teardown? |
+| Identity | where is peer/user/device identity introduced and verified? |
+| Authorization | which state or role permits each operation? |
+| Data model | integers, strings, TLV, XML/JSON, compression, serialization? |
+| Responses | acknowledgements, errors, correlation IDs, timing, connection close? |
+
+Maintain a message-field ledger:
+
+```text
+offset/path | size/type | endian/encoding | producer | consumer | validation | state | confidence
+```
+
+Label every statement as observed, inferred, or experimentally confirmed. Unknown bytes remain unknown; do not name them after a single sample.
+
+## Workflow
+
+### 1. Collect Passive Evidence
+
+Use, in order of preference:
+
+- official protocol or integration documentation
+- offline captures of a legitimate client/server exchange
+- client binaries, SDKs, schemas, constants, error strings, and debug logs
+- server handlers, dispatch tables, configuration, and certificate logic
+- vulnerable/fixed captures or binaries from the same branch
+
+Use two supplied or explicitly authorized successful sessions and controlled variations when available. Otherwise record the evidence gap; do not obtain or replay production credentials merely to complete the model. Compare message boundaries, counters, nonces, lengths, identity fields, and state-dependent responses. Keep the original capture immutable and hash it.
+
+Use [TShark](https://www.wireshark.org/docs/man-pages/tshark.html) for reproducible offline extraction:
+
+```bash
+tshark -r session.pcapng -q -z conv,tcp
+tshark -r session.pcapng -Y 'tcp.stream == 0' -T fields \
+  -e frame.number -e tcp.seq -e tcp.len -e tcp.payload
+```
+
+Prefer `-r` over live capture. Do not run Wireshark/TShark as root, capture unrelated production traffic, or assume dissector output is safe or correct; use a patched build in an isolated environment for hostile captures.
+
+### 2. Reconstruct Framing Before Meaning
+
+- Reassemble streams before assigning message boundaries; TCP packets are not application messages.
+- Test length hypotheses against multiple messages and both directions.
+- Identify byte order, signedness, alignment, padding, compression, and checksums.
+- Separate outer transport/tunnel framing from the inner application message.
+- For nested formats, model each parser boundary independently.
+- Reject impossible lengths before allocation, recursion, decompression, or slicing.
+
+When the layout stabilizes, encode it in a declarative grammar such as [Kaitai Struct](https://kaitai.io/). Add `valid` constraints and strict size/count limits; generated parsers can still allocate or recurse dangerously on hostile lengths. Keep compiler/runtime versions aligned and regression-test the grammar on positive, truncated, oversized, and unknown-type samples.
+
+### 3. Recover the State Machine
+
+Write transitions explicitly:
+
+```text
+DISCONNECTED -> TRANSPORT -> NEGOTIATED -> PEER_VERIFIED
+             -> USER_AUTHENTICATED -> AUTHORIZED -> OPERATION
+```
+
+For every transition, record:
+
+- initiating message and required prior state
+- server-side check and identity source
+- success, denial, and malformed responses
+- state stored across messages or reconnects
+- timeout/replay/counter behavior
+- whether an alternate message type reaches the same handler
+
+Distinguish transport establishment, peer verification, user authentication, session creation, role authorization, and successful privileged action. Prove the specific boundary relevant to the security claim.
+
+### 4. Trace Fields to Decisions and Sinks
+
+From binaries or source, anchor on message IDs, error strings, constants, certificate handling, dispatcher tables, and changed functions. Trace attacker-controlled fields through:
+
+- length arithmetic, allocation, copy, termination, and integer conversion
+- parser state, tag nesting, recursion, and unknown-field behavior
+- identity selection, trust flags, signature/certificate verification, and session lookup
+- shell/process calls, filesystem paths, deserialization, reflection, or product-native admin operations
+
+Decompiler output is a hypothesis. Confirm important conditions in assembly, bytecode, runtime logs, or controlled packet results.
+
+### 5. Build a Bounded Active Harness
+
+Only craft packets after valid framing and state are understood. [Scapy](https://scapy.readthedocs.io/en/stable/) is appropriate for packet layers and stateful automata:
+
+```bash
+python -m pip install 'scapy==<reviewed-version>'
+```
+
+Start with a local responder or replay parser, not the appliance. Preserve a known-good transcript, mutate one semantic field, recompute dependent lengths/checksums, and compare the response. The harness must enforce:
+
+- exact destination/port allowlist
+- one target and one mutation by default
+- rate, packet count, response size, timeout, and retry ceilings
+- no broadcast/multicast and no automatic crash retry
+- artifact logging without credentials or secret payloads
+- cleanup and target health check after each risky case
+
+Raw sockets may require privilege; isolate socket creation and drop privileges afterward where possible.
+
+### 6. Design Semantic Experiments
+
+Prefer experiments that answer one question:
+
+- Does an invalid identity or signature reach the authorized state?
+- Does a declared length govern copying, parsing, or only framing?
+- Do duplicate/unknown fields change the selected handler?
+- Does patched behavior add validation, change state, or block an outer route?
+- Does a response prove the operation, or merely that dispatch began?
+
+Use vulnerable, fixed, and malformed-negative controls. Repeat enough to separate deterministic semantics from loss, retransmission, process restart, load balancing, and timeout noise.
+
+## Safe Oracles
+
+Prefer, from least to most invasive:
+
+1. distinctive protocol/version field
+2. deterministic denial-versus-accept response
+3. synthetic-account no-op or non-secret lab read
+4. unique constant callback through explicitly authorized, preferably self-hosted OAST
+5. inert canary write with cleanup
+6. process execution only under separate explicit authorization when no lower-harm oracle can establish the required impact
+
+A connection close is normally an ambiguous result. If crash validation is unavoidable, combine lab-only process logs, restart evidence, and a non-triggering control; report bug existence separately from exploitability.
+
+When the starting point is an advisory, fixed build, patch, or public PoC, pair this skill with `advisory_to_poc` for evidence classification, artifact comparison, and partial-fix review.
+
+## Patch and Version Differentials
+
+- Compare message/state behavior across the closest vulnerable and fixed builds of the same branch.
+- Derive a fingerprint from the restored invariant, not only from banners.
+- Check configuration, certificate role, feature enablement, architecture, and deployment mode.
+- Treat protocol differences as version evidence unless they directly prove vulnerable behavior.
+- When one handler is patched, enumerate sibling message types, alternate transports, and pre-auth dispatch paths using the same parser or decision.
+
+## Validation Deliverable
+
+Include:
+
+1. target versions, platform, configuration, and artifact/capture hashes
+2. layered protocol diagram and message-field ledger
+3. explicit state machine and identity/authentication/authorization boundaries
+4. source/binary trace for the relevant field and decision
+5. bounded harness with rate/destination safeguards
+6. vulnerable, fixed, and negative-control results
+7. minimum safe oracle and any side effects/cleanup
+8. unresolved fields, assumptions, and confidence levels
+9. bug-existence versus exploitability assessment

--- a/strix/skills/technologies/appliance_firmware.md
+++ b/strix/skills/technologies/appliance_firmware.md
@@ -1,0 +1,253 @@
+---
+name: appliance-firmware
+description: Security analysis of appliances and firmware through artifact provenance, safe extraction, root filesystem and runtime mapping, listener and trust-boundary inventory, patch comparison, managed/native code triage, hardware constraints, and isolated device validation
+---
+
+# Appliance and Firmware Analysis
+
+Use this skill for VPNs, firewalls, storage/backup systems, management appliances, embedded products, virtual appliances, and other packaged systems where security behavior is split across firmware, web-server configuration, native daemons, scripts, managed services, generated state, and hardware-specific runtime details.
+
+Appliance research is architecture research. The public web UI is only one entry point; auxiliary listeners, localhost APIs, sidecars, support agents, update services, telemetry jobs, package installers, and product-native administration features often carry equal or greater authority.
+
+## Build and Artifact Matrix
+
+Record before comparing anything:
+
+| Dimension | Examples |
+|---|---|
+| Product | model/SKU, physical/virtual/cloud image, edition/license |
+| Software | marketing version, build/revision, branch, hotfix, package set |
+| Platform | architecture, endian, kernel, libc, bootloader, filesystem |
+| Install state | factory image, upgraded system, migrated config, retained files |
+| Configuration | feature flags, listeners, authentication mode, HA/cluster role |
+| Artifact source | vendor download, updater, installed disk, backup, marketplace |
+| Update form | full image, delta package, component hotfix, rollback bundle |
+| Authenticity | signature/encryption state, certificate/key ID, manifest/base-version requirement |
+
+Hash original artifacts and preserve acquisition metadata. A neighboring version from a different SKU, edition, architecture, or installation lineage can produce a convincing but irrelevant diff.
+
+## Safe Extraction
+
+Treat firmware and every embedded archive/filesystem as hostile input. Extract as an unprivileged user into a fresh writable quota-limited output directory with no network, bounded recursion/processes, and read-only input.
+
+### unblob
+
+[unblob](https://github.com/onekey-sec/unblob) provides recursive extraction plus structured metadata for many firmware/container/filesystem formats. Prefer a reviewed container image digest:
+
+```bash
+appliance_out="$(mktemp -d)"
+docker run --rm --network none \
+  --read-only --cap-drop ALL --security-opt no-new-privileges \
+  --user "$(id -u):$(id -g)" --pids-limit 256 --memory 4g --cpus 2 \
+  --tmpfs /tmp:rw,noexec,nosuid,size=512m \
+  -v /path/to/input:/data/input:ro \
+  -v "$appliance_out":/data/output \
+  ghcr.io/onekey-sec/unblob@sha256:<reviewed-digest> \
+  -e /data/output -d 6 -p 2 --report /data/output/unblob.json \
+  /data/input/firmware.bin
+```
+
+Create the output directory first and ensure it is writable by the chosen UID/GID; otherwise the host may create a root-owned mount point. Never extract over an existing analysis tree. Inspect symlinks, device nodes, archive paths, decompression ratios, and output size before interacting with the tree.
+
+### diffoscope
+
+Use [diffoscope](https://diffoscope.org/) for a recursive format-aware first comparison of vulnerable/fixed directories, packages, images, JARs, and executables:
+
+```bash
+diffoscope --html diffoscope.html vulnerable-root/ fixed-root/
+```
+
+Run it in an isolated reviewed container when processing hostile artifacts because it invokes many external format helpers. Use the first report to narrow files/config/packages rather than repeatedly expanding the entire image.
+
+Use the unblob report and packaged filesystem metadata for ownership, mode, xattr, capability, and device-node claims; a host extraction run under your own UID can intentionally remap them. Do not mount an untrusted extracted filesystem or `chroot` into it on the analyst host.
+
+## Filesystem and Boot Architecture
+
+Inventory:
+
+- partition table, bootloader, kernel, initramfs, SquashFS/UBIFS/ext filesystems
+- init system, service definitions, inetd/socket activation, rc scripts, supervisors, and watchdogs
+- read-only base image versus writable overlay, tmpfs, bind mounts, containers/chroots, and persistent data partitions
+- factory defaults, first-boot generation, upgrade/migration scripts, rollback slots, and retained legacy files
+- environment files, credentials, certificates, secrets, licenses, databases, sessions, caches, and backup/restore formats
+- cron/timers, log rotation, telemetry, diagnostics, update checks, package deployment, support bundles, and cleanup tasks
+- ownership, group membership, capabilities, setuid/setgid, ACLs, sudo/doas rules, device access, and IPC permissions
+
+Static extracted files may not match runtime. Boot-time scripts can patch files, mount overlays, generate configs, copy certificates, activate routes, or replace binaries. Capture live filesystem/mount/process state when an apparently relevant change is absent from the disk image.
+
+## Update and Installed-State Reconstruction
+
+Before trusting a package or image diff, reconstruct how the device installs it:
+
+- verify signature and manifest order, trust anchors, and whether integrity/authenticity checks cover the whole payload or only a wrapper
+- distinguish full image, delta update, component hotfix, and required base version
+- identify target partition, boot slot, rollback path, and anti-rollback/version checks
+- review pre/post-install hooks, migrations, symlink changes, permission/capability changes, and retained/generated state
+- map overlay, bind-mount, and generated-file precedence over the extracted rootfs
+- test fresh install versus upgraded and partially rolled-back states
+- reconcile package contents with hashes/build IDs from the actual running process and live filesystem
+
+Record package-manager databases, shipped SBOM/manifests, bundled library copies, loader path, and `RPATH`/`RUNPATH` so you can distinguish a vulnerable library on disk from the library the running process actually maps.
+
+## Listener and Service Map
+
+Build a table for every network and local endpoint:
+
+```text
+address/port/socket | transport/TLS | process | config/init source
+route/message type | authentication | authorization | privilege | feature/default
+```
+
+Include:
+
+- HTTP(S) UI/API, CGI/FastCGI, WebSocket, SOAP, SAML/OIDC, upload/download
+- SSH/SFTP, VPN/IKE, message queues, databases, backup/storage protocols
+- proprietary TLS/RPC, cluster/HA, device-manager, agent, and telemetry ports
+- loopback/Unix sockets, localhost APIs, sidecars, containers, and debug/support agents
+- outbound update/download endpoints and trusted remote control planes
+
+For outbound updater, telemetry, licensing, or control-plane names, record authoritative DNS/ownership, TLS identity and pinning, proxy/fallback behavior, request data, failure behavior, manifest integrity, payload integrity, rollback/version policy, and whether the external domain, bucket, package, or provider resource can expire or be reassigned.
+
+Map edge configuration to code: reverse-proxy rules, rewrites, location blocks, authentication modules, trusted client-IP headers, TLS client certificates, and backend socket selection. A handler can be patched while a new edge rule merely hides it—or vice versa.
+
+## Trust and Authorization Boundaries
+
+Trace:
+
+```text
+external listener -> proxy/config -> router/dispatcher -> authentication
+                  -> parser -> privileged operation -> OS/service identity
+```
+
+Test conceptual boundaries such as:
+
+- public versus management interface
+- external versus localhost/sidecar trust
+- managed device versus manager/controller trust
+- cluster peer, certificate, flag, or registration state
+- web user versus OS/service/database authentication
+- direct route versus internal redirect/component dispatch
+- fresh install versus upgraded/retained installation state
+- optional feature disabled versus installed-but-reachable handler
+
+Successful TCP/TLS/WebSocket negotiation proves transport reachability, not authenticated identity or authorization. Determine the actual privileged result and which server-side flag/session/role enabled it.
+
+## Code and Configuration Triage
+
+### Scripts and Configuration
+
+- Trace Apache/nginx/lighttpd rules, CGI mappings, environment variables, and shell/Perl/Python/PHP scripts.
+- Search command construction beyond obvious shell metacharacters: arithmetic expansion, config files, response files, argument injection, newline/control characters, and third-party CLI parsing.
+- Inspect support/debug functions, backup/restore, package install, log/telemetry processors, custom tags/templates, and native admin command runners.
+- Compare configuration and init/upgrade changes alongside application code.
+
+### Java/JVM and .NET
+
+- Use [Vineflower](https://github.com/Vineflower/vineflower) for Java class/JAR reconstruction and `javap -c` to confirm ambiguous bytecode.
+- Use official [ILSpy/ilspycmd](https://github.com/icsharpcode/ILSpy) for .NET assemblies and inspect IL/metadata when reconstructed C# is ambiguous.
+- Do not build or run decompiler output, target assemblies/classes, bundled build scripts, or embedded resources in their associated target runtimes/viewers.
+- Diff class/resource inventories before decompiled text to separate compiler/obfuscator noise from semantic changes.
+
+### Native Binaries
+
+- Use official [Ghidra](https://github.com/NationalSecurityAgency/ghidra) for strings/imports/xrefs/decompilation and reproducible headless projects.
+- Use [BinDiff](https://github.com/google/bindiff) after manifest/package triage isolates the relevant native binaries, and keep the disassembler/BinExport version pair compatible across both sides.
+- Confirm changed length, auth, command, parser, and file-handling conditions in assembly/runtime; decompiler types and similarity scores are hypotheses.
+- Record architecture-specific calling convention, endian, alignment, libc, allocator, and mitigations.
+
+Load `memory_corruption` for bounds/lifetime/disclosure findings and exploitability analysis. Load `protocol_reverse_engineering` for custom/stateful message formats.
+
+## Version and Patch Analysis
+
+Compare more than one adjacent pair when possible:
+
+```text
+older unaffected/unknown -> vulnerable -> first fixed -> current
+```
+
+- Build changed-file/package/config manifests first.
+- Identify the security invariant introduced by the patch.
+- Review every caller/sibling handler using the patched helper/parser.
+- Check branch backports and inconsistent fixes across SKUs/architectures.
+- Re-test the old structural condition on the fixed build and nearby routes.
+- Inspect boot/runtime overlays and upgrade scripts if static diff shows no meaningful change.
+- Distinguish one CVE from one code path; advisories may bundle several bugs or fix only the most exposed route.
+
+Pair with `advisory_to_poc` for evidence classification, public-PoC decomposition, vulnerable/fixed controls, and detector handoff.
+
+## Hardware, Virtualization, and Emulation
+
+Record what the test environment omits:
+
+- hardware security module/TPM/secure element and device-bound keys
+- NIC/accelerator/driver behavior, DMA, endian/alignment, and kernel modules
+- boot chain, secure boot, verified partitions, recovery mode, watchdog, and HA peer
+- model-specific memory, allocator pressure, process limits, and service configuration
+- virtual appliance differences from physical products
+
+Full-system emulation can help recover routes and protocol behavior but often changes drivers, timing, entropy, memory layout, certificates, hardware identity, and mitigations. Treat emulation results as a separate platform and reproduce security-relevant behavior on the actual supported model when the claim depends on those properties.
+
+Do not disable ASLR, canaries, signature checks, or other mitigations without labeling the resulting demonstration as lab-only and nonrepresentative of default exploitability.
+
+## Physical-Lab Prerequisites
+
+Have a recovery path before live-device work:
+
+- console, serial, hypervisor, snapshot, or other known-good rollback method
+- exact in-scope image/build and a way to reapply it
+- isolated management network and controlled outbound connectivity
+- process or watchdog visibility and a safe way to capture one request at a time
+
+## Runtime Observation
+
+Within an authorized lab, collect:
+
+- process tree, executable/build ID, argv, cwd, users/groups/capabilities, open ports/sockets/files, mounts, namespaces/containers
+- service logs, audit logs, core files, watchdog/restart events, and packet captures
+- loaded mappings/libraries, relevant Unix sockets/file descriptors, and config source while sending one known request
+- filesystem/process events while sending one known request
+- boot/upgrade output and live configuration generated from templates/databases
+
+Prefer observation that explains a static hypothesis. Do not install intrusive agents or attach a debugger to production equipment.
+
+## Capability and Chain Mapping
+
+Treat findings as product-context primitives:
+
+- file read → configs, sessions, credentials, tokens, keys, topology
+- SSRF/request → loopback APIs, sidecars, metadata, package agents
+- file write → web roots, plugins, templates, restore packages, jobs, telemetry inputs
+- auth bypass → support/admin command runners, package deployment, native operations
+- parser disclosure → session/token/pointer material
+- low-privilege identity → built-in management tools and trusted peer relationships
+
+Inventory native product consumers before importing a generic exploit gadget. An appliance's normal backup, restore, diagnostic, package, scripting, or cluster function is frequently the shortest bridge between primitives.
+
+## Deliverable
+
+Include:
+
+1. artifact provenance/hashes and complete SKU/version/platform/config matrix
+2. extraction method and filesystem/boot/runtime architecture
+3. listener/service/auth/trust-boundary map
+4. changed-file/config/package manifest and relevant code path
+5. external route/protocol through privileged operation and OS identity
+6. hardware/emulation/mitigation constraints
+7. vulnerable/fixed/negative-control behavior
+8. adjacent handlers/branches/install states reviewed
+9. tool versions, generated artifacts, and unresolved assumptions
+
+## Common Errors
+
+- Diffing different SKUs/architectures and attributing packaging noise to a security fix.
+- Assuming extracted rootfs equals live state despite overlays, generation, or boot-time patches.
+- Mapping only the web UI and missing auxiliary/custom/local listeners.
+- Treating a hidden route as removed or a blocked route as a patched sink.
+- Assuming fresh-install behavior covers upgraded systems with retained files/configuration.
+- Calling a service pre-auth because a connection succeeds before a privileged operation is attempted.
+- Treating emulator-only behavior or disabled mitigations as representative of a shipping device.
+- Running an analyzed binary, extension, build script, or firmware helper on the analyst host.
+
+## Summary
+
+Appliances are integrated systems, not single applications. Preserve artifact lineage, extract safely, map boot/runtime state and every listener, trace edge configuration into code and privileged native features, compare fixes across branches and install states, and keep hardware/platform constraints attached to every finding.

--- a/strix/skills/vulnerabilities/memory_corruption.md
+++ b/strix/skills/vulnerabilities/memory_corruption.md
@@ -1,0 +1,228 @@
+---
+name: memory-corruption
+description: Native memory-safety analysis for stack and heap overflows, out-of-bounds access, uninitialized memory, use-after-free, integer and signedness errors, format strings, crash triage, exploitability constraints, and controlled lab validation
+---
+
+# Memory Corruption
+
+Use this skill for authorized analysis of native parsers, network services, firmware daemons, libraries, and mixed web/native components where attacker-controlled bytes may violate memory safety.
+
+Separate three questions throughout the work:
+
+1. **Bug existence:** does an input cause an invalid read, write, lifetime violation, or disclosure?
+2. **Primitive quality:** what bytes, address, length, timing, or object state can the attacker control or observe?
+3. **Exploitability:** can that primitive bypass the target architecture, mitigations, allocator, protocol, and restart constraints?
+
+A crash, connection close, watchdog restart, or sanitizer report proves neither instruction-pointer control nor RCE.
+
+## Lab Boundary
+
+Malformed-input and crash work is denial-of-service testing. Run it only against an explicitly authorized, restartable lab target with console/process visibility, health checks, rate ceilings, and a recovery procedure. Do not fuzz production services or automatically replay crash cases.
+
+Analyze hostile binaries, cores, packet captures, and corpora inside an isolated environment. Do not execute an unknown sample merely because a debugger or decompiler imported it.
+
+## Vulnerability Classes
+
+### Bounds and Length Errors
+
+- fixed destination with attacker-controlled copy/format length
+- allocation based on one length and copy based on another
+- off-by-one termination or delimiter handling
+- nested length fields and cumulative-size overflow
+- stack/heap out-of-bounds read or write
+- negative length converted to unsigned, truncation between integer widths, or multiplication/addition overflow
+- encoded/decoded/compressed size disagreement
+
+### Initialization and Termination
+
+- uninitialized stack/heap data returned in a response
+- reused object/buffer retaining data from another request or tenant
+- missing NUL termination followed by string length/format operations
+- partial structure initialization with stale flags, pointers, or lengths
+- padding, union, or serialization bytes copied beyond initialized fields
+
+### Lifetime and Object Confusion
+
+- use-after-free, double free, stale callback, iterator invalidation
+- type/object confusion after parsing, casting, or virtual dispatch
+- reference-count races and cross-thread ownership errors
+- reallocation invalidating stored pointers
+- constructor/destructor/finalizer behavior reached in an unexpected state
+
+### Format and Variadic Errors
+
+- attacker-controlled format string
+- type/width mismatch in variadic arguments
+- destination-size assumptions around `sprintf`-family calls
+- logging/error paths that process attacker bytes after a partial parse
+
+## Build the Input-to-Memory Model
+
+Record:
+
+```text
+transport field -> parser type/width -> normalized value -> allocation
+                -> copy/read/format operation -> object/buffer -> later use
+```
+
+For each relevant field, capture:
+
+- wire offset/path, endian, encoding, signedness, and declared versus actual size
+- validation order and parser state required to reach the operation
+- allocation expression and destination capacity
+- copy/read/write expression and implicit casts
+- terminator/padding/alignment behavior
+- attacker-controlled byte alphabet and precision
+- thread, connection, session, heap, and restart lifetime
+
+Trace both source-to-sink and sink-to-source. Start from changed bounds checks or crash instructions when available, but reconstruct the minimum valid protocol state that reaches them.
+
+## Source-Available Workflow
+
+### Compiler Instrumentation
+
+Build a lab-only target or minimal harness with the compiler's maintained sanitizers when source permits:
+
+```bash
+clang -g -O1 -fno-omit-frame-pointer \
+  -fsanitize=address,undefined \
+  harness.c parser.c -o parser-harness
+```
+
+- Keep the harness local and networkless; call the narrow parser/API directly.
+- Preserve the exact compiler, flags, architecture, allocator, and dependencies.
+- AddressSanitizer changes layout and timing. Reproduce important behavior on a representative unsanitized build under a debugger before drawing exploitability conclusions.
+- UndefinedBehaviorSanitizer may report conditions that do not produce the deployed security impact; trace each report to attacker control and later use. It does not replace explicit arithmetic and cast review.
+- For ordinary uninitialized-value hypotheses, use a separate MemorySanitizer build such as `-fsanitize=memory -fsanitize-memory-track-origins=2`; it requires an instrumented dependency set and is not interchangeable with ASan.
+- For race-dependent ownership or refcount paths, use a separate ThreadSanitizer build only when concurrency is in scope; do not imply the sanitizer families compose cleanly into one representative build.
+- Add regression cases for the minimized triggering input and neighboring non-triggering controls.
+
+### Static Review
+
+Search around input parsing for:
+
+- `memcpy`, `memmove`, `strcpy`, `strcat`, `sprintf`, `snprintf`, `scanf` families
+- manual cursor/end-pointer arithmetic and nested TLV/XML/string parsers
+- `malloc/calloc/realloc/new` size arithmetic
+- signed/unsigned conversions and narrowing casts
+- length values stored in smaller fields or reused across decoded representations
+- error cleanup, ownership transfer, callbacks, and asynchronous lifetime
+- custom allocators, pools, slabs, ring buffers, and request-buffer reuse
+
+Do not report a dangerous function name without proving attacker control, reachable state, capacity mismatch, and the actual deployed implementation.
+
+## Binary-Only Workflow
+
+1. Identify architecture, endian, ABI, OS/libc, compiler clues, and stripped/symbol state.
+2. Record NX/DEP, ASLR/PIE, stack canaries, RELRO, CFI/PAC/CET, allocator hardening, seccomp/sandbox, privilege, and restart behavior.
+3. Anchor on imports, strings, message IDs, error paths, new checks, crash PC, or advisory-relevant constants.
+4. Trace length/copy/allocation dataflow in decompiler and assembly.
+5. Record the deployed binary identity: build ID or hash, interpreter or loader, loaded modules/base addresses, allocator, and whether the runtime executable came from base image, overlay, bind mount, or update staging.
+6. Reproduce under a debugger or emulator only when its environment matches the relevant parser and allocator behavior.
+7. Compare vulnerable and fixed functions; describe the restored invariant and inspect sibling callers.
+
+Use official [Ghidra](https://github.com/NationalSecurityAgency/ghidra) for cross-architecture static analysis and [BinDiff](https://github.com/google/bindiff) for function-level version comparison after package/file diffs narrow the target. Similarity scores and decompiled C are triage aids, not proof; confirm critical conditions in assembly and runtime evidence.
+
+## Crash and Disclosure Triage
+
+Preserve one known-good transcript and then minimize while keeping the framing, checksums, parser state, and negotiation required to reach the vulnerable operation. Identify the first invalid access, not only the eventual crash site. Use a distinctive non-executable pattern to measure overwrite offset or disclosure position, classify whether the observed effect is read, write, non-control-data, pointer/object, or control-state influence, and then repeat the same case on a representative unsanitized build plus fixed and negative controls.
+
+For each case, record:
+
+- exact minimized input and protocol transcript
+- deterministic frequency and required heap/session preparation
+- signal/exception, PC, faulting instruction bytes/disassembly, fault address, access type/size, registers, stack, loaded mappings/build IDs, and relevant object memory
+- process versus worker crash, watchdog/restart, and external symptom
+- corrupted object provenance and last known-valid parser state
+- vulnerable/fixed/unaffected build behavior
+- whether the same case under debugger/sanitizer changes outcome
+
+Deduplicate by root cause, not only crash address. One overwrite may crash at many later consumers; one parser family may contain multiple distinct missing checks.
+
+For disclosures, classify the returned bytes:
+
+- predictable padding or constant data
+- same-request content
+- cross-request/tenant secrets
+- heap/stack pointers useful against ASLR
+- session tokens, keys, credentials, or application data
+
+Derive detectors from response structure or a constant non-secret marker rather than collecting sensitive memory.
+
+## Primitive Analysis
+
+### Write Primitive
+
+- location: fixed, relative, attacker-derived, heap-neighbor, object field, return/control data
+- width and count: single byte/bit, bounded span, arbitrary length, repeated writes
+- value control: exact, restricted alphabet, additive, terminator, pointer-derived
+- timing/state: before validation, after free, race-dependent, heap-shape-dependent
+- repeatability under default allocator and mitigations
+
+### Read/Leak Primitive
+
+- offset and length control
+- termination rules and response encoding
+- ability to repeat/advance across memory
+- cross-request process reuse
+- pointer or secret classification
+- noise, truncation, and crash threshold
+
+### Control-Flow/Object Primitive
+
+- overwritten callback, vtable, length, non-control-data flag, pointer, credential/session reference, allocator metadata, saved return state, or interpreter structure
+- required heap grooming/object placement
+- available modules/gadgets and address disclosure
+- thread/process privilege and sandbox boundary after control
+- whether the attacker can only corrupt a field, or can also choose the dereference target and value later consumed
+
+Document what remains constrained. “Arbitrary write” should not be used for a relative, partial, alphabet-limited, or race-only overwrite.
+
+## Exploitability Matrix
+
+| Dimension | Record |
+|---|---|
+| Reachability | listener, authentication, feature/config, valid prior state |
+| Platform | architecture, endian, ABI, firmware model/SKU |
+| Input | transport, maximum size, forbidden bytes, encoding/transforms |
+| Primitive | read/write/control precision, repeatability, heap dependence |
+| Mitigations | ASLR/PIE, NX, canary, RELRO, CFI/PAC/CET, allocator, sandbox |
+| Process | privilege, chroot/container, worker isolation, watchdog/restart |
+| Information | version fingerprint, pointer/module/heap leak availability |
+| Reliability | attempts, races, connection/session persistence, crash side effects |
+
+Rate exploitability separately from bug severity. A strong memory disclosure can enable a later control-flow bug; a large overflow may remain crash-only under the deployed constraints.
+
+## Protocol and Patch Pairing
+
+- Load `protocol_reverse_engineering` when valid negotiation/state is required before the vulnerable field.
+- Load `advisory_to_poc` for vulnerable/fixed artifact matrices and patch-invariant review.
+- Load `appliance_firmware` for rootfs, listener, runtime overlay, architecture, and device lifecycle mapping.
+- Model transformation boundaries explicitly when the memory length or type changes across transport, parser, decoder, or native FFI layers.
+
+## Validation Deliverable
+
+Include:
+
+1. exact vulnerable/fixed build, platform, configuration, and artifact hashes
+2. minimized input plus complete protocol/parser prerequisites
+3. source, IR/bytecode, or assembly trace from attacker field to invalid access, with the exact crashing process/build identity
+4. debugger/sanitizer/core evidence and non-triggering control
+5. primitive precision and constraints
+6. mitigation, architecture, allocator, process, and restart analysis
+7. bug-existence and exploitability conclusions stated separately
+8. adjacent callers/parser family reviewed
+
+## False Positives
+
+- Connection close caused by protocol rejection, idle timeout, rate limit, or load balancer behavior.
+- Process restart inferred from one failed request without process/console evidence.
+- Sanitizer finding unreachable in the deployed feature, route, architecture, or configuration.
+- Out-of-bounds read that returns only deterministic in-buffer padding, described as sensitive disclosure.
+- Crash-only overwrite called RCE without a controlled data/control primitive and mitigation analysis.
+- Decompiler type or buffer size accepted as ground truth without assembly/runtime confirmation.
+- Lab build with mitigations disabled presented as representative of production.
+
+## Summary
+
+Memory-corruption research is constraint analysis. Trace exact bytes through length, allocation, copy, object lifetime, and later use; establish the read/write/control primitive; then evaluate architecture, mitigations, allocator, protocol, and process context independently from the mere existence of a crash.


### PR DESCRIPTION
## Summary

- add advisory-to-PoC analysis for artifact comparison, root-cause reconstruction, and version-bounded validation
- add stateful and custom-protocol reverse engineering
- add appliance and firmware provenance, extraction, installed-state, listener, and runtime analysis
- add native memory-corruption triage that separates bug existence, primitive quality, and exploitability
- add the group to the notable-skills catalog

## Tooling

The skills route to maintained tools when they materially help: diffoscope, unblob, Ghidra, BinDiff, Vineflower, ILSpy, TShark/Wireshark, Kaitai Struct, and Scapy. These remain optional, task-dependent recommendations rather than required installs.

## Status

The non-reverse prerequisites are merged. Base: `main`.
This PR remains intentionally draft and unmerged.

## Validation

- loaded all four new reverse-engineering skills against current `main` through the Strix skill loader
- `tests/test_skill_dir_extension.py`
- repository pre-commit hooks on every PR diff
- `git diff --check`
