### PR TITLE
fix(proxy): normalize optional Caido GraphQL arguments

### DIFF
--- a/strix/tools/proxy/caido_api.py
+++ b/strix/tools/proxy/caido_api.py
@@ -129,6 +129,24 @@ async def close_client() -> None:
     await client.aclose()
 
 
+def _normalize_optional_id(value: str | None, *, name: str) -> str | None:
+    """Normalize an optional Caido GraphQL ID emitted by an LLM tool call."""
+    if value is None:
+        return None
+
+    normalized = value.strip()
+    if not normalized or normalized.lower() in {"null", "none", "undefined"}:
+        return None
+
+    try:
+        numeric_id = int(normalized, 10)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer-shaped Caido ID") from exc
+    if not -(2**31) <= numeric_id < 2**31:
+        raise ValueError(f"{name} must fit in a signed 32-bit integer")
+    return str(numeric_id)
+
+
 async def list_requests_with_client(
     client: CaidoClient,
     *,
@@ -139,6 +157,7 @@ async def list_requests_with_client(
     sort_order: SortOrder = "desc",
     scope_id: str | None = None,
 ) -> Any:
+    scope_id = _normalize_optional_id(scope_id, name="scope_id")
     builder = client.request.list().first(first)
     if httpql_filter:
         builder = builder.filter(httpql_filter)
@@ -643,6 +662,9 @@ async def list_sitemap_with_client(
     pagination, so we fetch all edges for the requested level and slice
     client-side.
     """
+    scope_id = _normalize_optional_id(scope_id, name="scope_id")
+    parent_id = _normalize_optional_id(parent_id, name="parent_id")
+
     if parent_id:
         raw = await client.graphql.query(
             _SITEMAP_DESCENDANTS_QUERY,

--- a/strix/tools/proxy/caido_api.py
+++ b/strix/tools/proxy/caido_api.py
@@ -129,13 +129,21 @@ async def close_client() -> None:
     await client.aclose()
 
 
-def _normalize_optional_id(value: str | None, *, name: str) -> str | None:
-    """Normalize an optional Caido GraphQL ID emitted by an LLM tool call."""
+def _normalize_optional_string(value: str | None) -> str | None:
+    """Normalize an optional string emitted by an LLM tool call."""
     if value is None:
         return None
 
     normalized = value.strip()
     if not normalized or normalized.lower() in {"null", "none", "undefined"}:
+        return None
+    return normalized
+
+
+def _normalize_optional_id(value: str | None, *, name: str) -> str | None:
+    """Normalize and validate an optional Caido GraphQL ID."""
+    normalized = _normalize_optional_string(value)
+    if normalized is None:
         return None
 
     try:
@@ -158,6 +166,7 @@ async def list_requests_with_client(
     scope_id: str | None = None,
 ) -> Any:
     scope_id = _normalize_optional_id(scope_id, name="scope_id")
+    after = _normalize_optional_string(after)
     builder = client.request.list().first(first)
     if httpql_filter:
         builder = builder.filter(httpql_filter)

--- a/tests/test_proxy_client.py
+++ b/tests/test_proxy_client.py
@@ -29,6 +29,60 @@ class _FakeClient:
         self.closed = True
 
 
+class _FakeGraphQL:
+    def __init__(self) -> None:
+        self.variables: dict[str, Any] | None = None
+
+    async def query(self, _document: str, variables: dict[str, Any]) -> dict[str, Any]:
+        self.variables = variables
+        return {"sitemapRootEntries": {"edges": [], "count": {"value": 0}}}
+
+
+class _FakeSitemapClient:
+    def __init__(self) -> None:
+        self.graphql = _FakeGraphQL()
+
+
+class _FakeRequestListBuilder:
+    def __init__(self) -> None:
+        self.scope_id: str | None = None
+
+    def first(self, _first: int) -> _FakeRequestListBuilder:
+        return self
+
+    def filter(self, _filter: str) -> _FakeRequestListBuilder:
+        return self
+
+    def after(self, _after: str) -> _FakeRequestListBuilder:
+        return self
+
+    def scope(self, scope_id: str) -> _FakeRequestListBuilder:
+        self.scope_id = scope_id
+        return self
+
+    def ascending(self, _target: str, _field: str) -> _FakeRequestListBuilder:
+        return self
+
+    def descending(self, _target: str, _field: str) -> _FakeRequestListBuilder:
+        return self
+
+    async def execute(self) -> str:
+        return "ok"
+
+
+class _FakeRequestSDK:
+    def __init__(self) -> None:
+        self.builder = _FakeRequestListBuilder()
+
+    def list(self) -> _FakeRequestListBuilder:
+        return self.builder
+
+
+class _FakeRequestsClient:
+    def __init__(self) -> None:
+        self.request = _FakeRequestSDK()
+
+
 @pytest.fixture(autouse=True)
 def _clear_cache() -> Iterator[None]:
     caido_api._CLIENT_CACHE.clear()
@@ -207,3 +261,35 @@ def test_ctx_client_returns_client_when_present() -> None:
 def test_ctx_client_returns_none_without_client() -> None:
     assert tools._ctx_client(cast("Any", _Ctx({}))) is None
     assert tools._ctx_client(cast("Any", _Ctx(None))) is None
+
+
+async def test_list_sitemap_normalizes_empty_scope_id_to_null() -> None:
+    client = _FakeSitemapClient()
+
+    result = await caido_api.list_sitemap_with_client(
+        cast("Any", client), scope_id="  ", parent_id=""
+    )
+
+    assert result["success"] is True
+    assert client.graphql.variables == {"scopeId": None}
+
+
+async def test_list_requests_normalizes_string_null_scope_id() -> None:
+    client = _FakeRequestsClient()
+
+    result = await caido_api.list_requests_with_client(
+        cast("Any", client), scope_id="null"
+    )
+
+    assert result == "ok"
+    assert client.request.builder.scope_id is None
+
+
+@pytest.mark.parametrize("value", ["", "  ", "null", "None", "UNDEFINED"])
+def test_normalize_optional_id_treats_llm_null_sentinels_as_none(value: str) -> None:
+    assert caido_api._normalize_optional_id(value, name="scope_id") is None
+
+
+def test_normalize_optional_id_rejects_non_numeric_value() -> None:
+    with pytest.raises(ValueError, match="integer-shaped Caido ID"):
+        caido_api._normalize_optional_id("all", name="scope_id")

--- a/tests/test_proxy_client.py
+++ b/tests/test_proxy_client.py
@@ -46,6 +46,7 @@ class _FakeSitemapClient:
 class _FakeRequestListBuilder:
     def __init__(self) -> None:
         self.scope_id: str | None = None
+        self.after_cursor: str | None = None
 
     def first(self, _first: int) -> _FakeRequestListBuilder:
         return self
@@ -53,7 +54,8 @@ class _FakeRequestListBuilder:
     def filter(self, _filter: str) -> _FakeRequestListBuilder:
         return self
 
-    def after(self, _after: str) -> _FakeRequestListBuilder:
+    def after(self, after: str) -> _FakeRequestListBuilder:
+        self.after_cursor = after
         return self
 
     def scope(self, scope_id: str) -> _FakeRequestListBuilder:
@@ -274,15 +276,16 @@ async def test_list_sitemap_normalizes_empty_scope_id_to_null() -> None:
     assert client.graphql.variables == {"scopeId": None}
 
 
-async def test_list_requests_normalizes_string_null_scope_id() -> None:
+async def test_list_requests_normalizes_string_null_optional_arguments() -> None:
     client = _FakeRequestsClient()
 
     result = await caido_api.list_requests_with_client(
-        cast("Any", client), scope_id="null"
+        cast("Any", client), scope_id="null", after="null"
     )
 
     assert result == "ok"
     assert client.request.builder.scope_id is None
+    assert client.request.builder.after_cursor is None
 
 
 @pytest.mark.parametrize("value", ["", "  ", "null", "None", "UNDEFINED"])
@@ -293,3 +296,7 @@ def test_normalize_optional_id_treats_llm_null_sentinels_as_none(value: str) -> 
 def test_normalize_optional_id_rejects_non_numeric_value() -> None:
     with pytest.raises(ValueError, match="integer-shaped Caido ID"):
         caido_api._normalize_optional_id("all", name="scope_id")
+
+
+def test_normalize_optional_string_preserves_real_cursor() -> None:
+    assert caido_api._normalize_optional_string(" cursor-value ") == "cursor-value"


### PR DESCRIPTION
## Summary

Normalize optional Caido GraphQL IDs and pagination cursors before passing them to the Caido SDK.

Some LLM tool calls encode omitted optional arguments as strings such as `"null"` or `""`. These values are truthy and were being forwarded as GraphQL `ID` variables. Caido expects integer-shaped i32 IDs or an actual null value, resulting in:

```text
Invalid ID format, should be an i32
Failed to parse cursor
```

## Changes

- Add a shared helper for normalizing optional Caido IDs.
- Treat empty strings and the null-like values `"null"`, `"none"`, and `"undefined"` as omitted values.
- Validate that provided IDs are integer-shaped and fit in a signed 32-bit integer.
- Apply normalization to:
  - `list_requests.scope_id`
  - `list_requests.after`
  - `list_sitemap.scope_id`
  - `list_sitemap.parent_id`
- Add regression tests for LLM-generated null-like strings and invalid IDs.

## Why

The tool schema declares these fields as optional strings, but LLMs may emit a textual null instead of JSON null. Validation at the Strix/Caido boundary prevents invalid GraphQL requests and replaces SDK tracebacks with clear local errors.

Before this change, `scope_id="null"` was sent to Caido as `scopeId: "null"` and rejected. Likewise, `after="null"` was forwarded as a pagination cursor and failed with `Failed to parse cursor`. After this change, both values are normalized to `None`, so the omitted optional arguments are not sent to the SDK builders.

## Tests

```text
20 passed
ruff: All checks passed
```
