### PR TITLE
fix(interface): prevent path traversal and argument injection in clone_repository

### DIFF
--- a/strix/interface/utils.py
+++ b/strix/interface/utils.py
@@ -1563,19 +1563,34 @@ def clone_repository(repo_url: str, run_name: str, dest_name: str | None = None)
     if dest_name:
         repo_name = dest_name
     else:
-        repo_name = Path(repo_url).stem if repo_url.endswith(".git") else Path(repo_url).name
+        repo_name = derive_repo_base_name(repo_url)
 
-    clone_path = temp_dir / repo_name
+    # Guard against path traversal: the derived name must not resolve
+    # outside the temp directory (e.g. ".." or ".").
+    clone_path = (temp_dir / repo_name).resolve()
+    if not str(clone_path).startswith(str(temp_dir.resolve())):
+        raise ValueError(
+            f"Refusing to clone: derived directory name '{repo_name}' "
+            f"escapes the temporary directory"
+        )
 
     if clone_path.exists():
         shutil.rmtree(clone_path)
 
     try:
+        # Reject targets that start with '-' to block argument injection
+        if repo_url.startswith("-"):
+            raise ValueError(
+                f"Refusing to clone: target '{repo_url}' starts with '-' "
+                f"and would be interpreted as a git flag"
+            )
+
         with console.status(f"[bold cyan]Cloning repository {repo_url}...", spinner="dots"):
             subprocess.run(  # noqa: S603
                 [
                     git_executable,
                     "clone",
+                    "--",          # end-of-options: everything after is a positional arg
                     repo_url,
                     str(clone_path),
                 ],

--- a/strix/interface/utils.py
+++ b/strix/interface/utils.py
@@ -1565,10 +1565,14 @@ def clone_repository(repo_url: str, run_name: str, dest_name: str | None = None)
     else:
         repo_name = derive_repo_base_name(repo_url)
 
-    # Guard against path traversal: the derived name must not resolve
-    # outside the temp directory (e.g. ".." or ".").
+    # Guard against path traversal: the derived name must resolve to a
+    # strict child of the temp directory — not temp_dir itself, and not
+    # any path outside it (e.g. "." or "..").
     clone_path = (temp_dir / repo_name).resolve()
-    if not str(clone_path).startswith(str(temp_dir.resolve())):
+    temp_dir_resolved = temp_dir.resolve()
+    if clone_path == temp_dir_resolved or not str(clone_path).startswith(
+        str(temp_dir_resolved) + os.sep
+    ):
         raise ValueError(
             f"Refusing to clone: derived directory name '{repo_name}' "
             f"escapes the temporary directory"


### PR DESCRIPTION
## Summary

Fixes #1133 and #1134.

Two security bugs in `clone_repository()` (`strix/interface/utils.py`):

### Bug 1 — Path traversal via crafted repo URL (#1133)

**Before:** The repo directory name was derived using `Path(repo_url).stem` / `.name`. A crafted target like `..git` causes `.stem` to return `.`, making `clone_path = temp_dir / "."` resolve to `temp_dir` itself. The subsequent `shutil.rmtree(clone_path)` then deletes the entire parent temp directory and all sibling clone directories.

**Fix:**
- Replaced the unsafe `Path().stem`/`.name` derivation with `derive_repo_base_name()`, which already exists in the codebase, strips `.git` suffixes properly, and sanitizes via regex.
- Added a resolved-path containment check: `clone_path.resolve()` must start with `temp_dir.resolve()`, rejecting any traversal attempt with a clear error.

### Bug 2 — Argument injection in git clone (#1134)

**Before:** `repo_url` was passed directly as a positional argument to `git clone` without a `--` end-of-options separator. A target starting with `-` (e.g. `--upload-pack="malicious command"`) would be interpreted as a git flag, potentially leading to remote code execution on the Strix host.

**Fix:**
- Added `--` separator before `repo_url` in the subprocess argument list, so git treats everything after it as positional arguments regardless of leading dashes.
- Added explicit validation that rejects any `repo_url` starting with `-` before the subprocess is even invoked, with a clear error message.

## Changes

- `strix/interface/utils.py`: Modified `clone_repository()` function (+17 lines, -2 lines)

## Testing

Both attack vectors can be verified:

```bash
# Path traversal (before fix: deletes temp_dir; after fix: raises ValueError)
strix --target "..git"

# Argument injection (before fix: interpreted as git flag; after fix: raises ValueError)
strix --target "--upload-pack=touch /tmp/pwned"
```
