### PR TITLE
fix: restore mailbox on consume_pending session write failure

### DIFF
--- a/strix/core/agents.py
+++ b/strix/core/agents.py
@@ -350,10 +350,18 @@ class AgentCoordinator:
                         await session.add_items(items)
                 except Exception:
                     logger.exception(
-                        "failed to append %d queued messages to the session of %s",
+                        "failed to append %d queued messages to the session of %s; "
+                        "restoring them to the mailbox for retry",
                         len(items),
                         agent_id,
                     )
+                    async with self._lock:
+                        runtime.mailbox[0:0] = queued
+                        self.pending_counts[agent_id] = self.pending_counts.get(agent_id, 0) + len(
+                            queued
+                        )
+                        runtime.wake.set()
+                    return 0, []
         await self._maybe_snapshot()
         if not include_items:
             return count, []

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -658,6 +658,43 @@ async def test_send_queues_without_session_and_drains_on_consume(tmp_path: Any) 
 
 
 @pytest.mark.asyncio
+async def test_consume_pending_restores_mailbox_on_session_write_failure(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Regression test for https://github.com/usestrix/strix/issues/1107
+
+    If session.add_items fails, the drained message must not be lost: it should
+    be restored to the mailbox (so a retry can pick it up) rather than reported
+    as delivered via a positive count.
+    """
+    coordinator = AgentCoordinator()
+    await coordinator.register("root", "strix", parent_id=None)
+    session = SQLiteSession("root", tmp_path / "agents.db")
+    await coordinator.attach_runtime("root", session=session)
+
+    assert await coordinator.send("root", {"from": "user", "content": "hello"}) is True
+
+    async def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("db is locked")
+
+    monkeypatch.setattr(session, "add_items", _boom)
+
+    count, items = await coordinator.consume_pending("root", include_items=True)
+    assert (count, items) == (0, [])
+
+    runtime = coordinator.runtimes["root"]
+    assert runtime.mailbox == [{"from": "user", "content": "hello"}]
+    assert coordinator.pending_counts["root"] == 1
+
+    monkeypatch.undo()
+    count, items = await coordinator.consume_pending("root", include_items=True)
+    assert count == 1
+    assert items[0]["content"] == "hello"
+    session.close()
+
+
+@pytest.mark.asyncio
 async def test_error_parked_agent_only_released_by_user_message(tmp_path: Any) -> None:
     coordinator = AgentCoordinator()
     await coordinator.register("root", "strix", parent_id=None)


### PR DESCRIPTION
## Summary

`consume_pending()` drains the agent's mailbox and zeroes `pending_counts` under the lock, then — outside the lock — tries to persist the drained items via `session.add_items()`. On failure it only logged the exception and fell through to returning the original (now-inflated) `count` as if the write had succeeded.

Callers with `include_items=False` (`execution.py` after a wait, `respond/tool.py`) rely entirely on the session for the next turn — they don't get the items back, just a count. So a transient write failure (e.g. a locked SQLite session) silently dropped the user's message: not in the mailbox (already cleared), not in the session (write failed), and reported as delivered to the caller.

## Fix

On write failure:
- Restore the drained messages to the **front** of the mailbox (any messages that arrived concurrently while the lock was released stay after them, preserving order).
- Add their count back to `pending_counts`.
- Set `runtime.wake` so a blocked `wait_for_message()` notices the restored pending work.
- Return `(0, [])` so this attempt is honestly reported as not having delivered anything.

This makes the next `consume_pending()` call retry the same messages instead of losing them, matching the issue's suggested fix.

Fixes #1107.

## Testing

- Added `test_consume_pending_restores_mailbox_on_session_write_failure`, which injects a failing `session.add_items` via `monkeypatch`, asserts the mailbox/`pending_counts` are restored and `(0, [])` is returned, then removes the failure and confirms a subsequent `consume_pending()` call successfully delivers the same message.
- Verified red-before-green: reverted the fix, confirmed the new test fails exactly as described (`count=1` returned despite the write failing); restored the fix, confirmed it passes.
- `uv run pytest tests/test_execution.py -q`: 60 passed.
- `uv run pytest tests/ -q`: 1062 passed; 21 pre-existing failures confirmed present on unmodified `main` too (all Windows-specific — POSIX permission-bit assertions and a path-parsing bug that misreads a Windows drive letter as a path segment), none related to `agents.py` or this change.
- `uv run ruff check`, `uv run ruff format`, `uv run mypy strix/core/agents.py`: all clean.