### PR TITLE
fix(warmup): pre-import the agents SDK to avoid a thread-race crash

### DIFF
--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -433,9 +433,12 @@ def main() -> None:
 
     from strix.llm.warmup import start_import_warmup
 
-    start_import_warmup()
-
+    # parse_arguments() first so --version/--help/argparse errors exit before
+    # the (heavier) import warm-up runs. Warm-up then overlaps with the I/O
+    # startup below (update check, Docker checks, image pull).
     args = parse_arguments()
+
+    start_import_warmup()
 
     start_background_check()
     if not args.non_interactive and prompt_update_if_available(Console()):

--- a/strix/llm/warmup.py
+++ b/strix/llm/warmup.py
@@ -38,6 +38,24 @@ def _warm(modules: tuple[str, ...]) -> None:
             logger.debug("Import warm-up for %r failed", name, exc_info=True)
 
 
+def _preimport_thread_unsafe_sdk() -> None:
+    """Import the ``agents`` SDK once, on the caller's thread, before the daemon
+    warm-up starts.
+
+    ``openai-agents`` has an internal import cycle (``agents.agent_output`` <->
+    ``agents.agent``) that is not thread-safe: when two threads import the
+    ``agents`` package concurrently, CPython's deadlock-avoidance can hand one
+    of them a partially initialized module, raising ``ImportError: cannot
+    import name 'AgentOutputSchemaBase' ... (circular import)``. Fully importing
+    the package single-threaded here closes that race window before the daemon
+    warm-up thread (and the main thread's later report import) touch it.
+    """
+    try:
+        importlib.import_module("agents")
+    except Exception:  # noqa: BLE001 - a failed warm-up must never fail the run.
+        logger.debug("Pre-import of agents SDK failed", exc_info=True)
+
+
 def start_import_warmup(modules: tuple[str, ...] = WARMUP_MODULES) -> threading.Thread:
     """Start importing the heavy scan dependencies in the background, once.
 
@@ -48,6 +66,7 @@ def start_import_warmup(modules: tuple[str, ...] = WARMUP_MODULES) -> threading.
     with _lock:
         if _thread is not None:
             return _thread
+        _preimport_thread_unsafe_sdk()
         _thread = threading.Thread(
             target=_warm, args=(modules,), name="strix-import-warmup", daemon=True
         )

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_start_import_warmup_preimports_agents_sdk_synchronously() -> None:
+    """``start_import_warmup`` must import the thread-unsafe ``agents`` SDK on
+    the caller's thread before spawning the daemon warm-up thread.
+
+    ``openai-agents`` has an internal import cycle that is not thread-safe: if
+    the warm-up thread and the main thread import the ``agents`` package
+    concurrently, CPython can hand one of them a partially initialized module
+    (``ImportError: cannot import name 'AgentOutputSchemaBase' ... circular
+    import``). Warming ``agents`` synchronously closes that race window.
+
+    Run in a fresh interpreter with an empty ``modules`` set so the daemon
+    thread warms nothing: ``agents`` can then only be in ``sys.modules`` because
+    the synchronous pre-import ran.
+    """
+    child = textwrap.dedent(
+        """
+        import sys
+
+        assert "agents" not in sys.modules
+        from strix.llm.warmup import start_import_warmup
+
+        # Importing the warm-up module alone must not pull the agents SDK.
+        assert "agents" not in sys.modules
+        start_import_warmup(modules=())
+        assert "agents" in sys.modules, "agents SDK was not pre-imported synchronously"
+        print("OK")
+        """
+    )
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", child],
+        cwd=PROJECT_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK" in result.stdout


### PR DESCRIPTION
## Problem

Real scans intermittently crash at startup with:

```
ImportError: cannot import name 'AgentOutputSchemaBase' from partially
initialized module 'agents.agent_output' (most likely due to a circular import)
```

`--version`/`--help` never hit it — the tell that it only happens on the scan path.

## Root cause

`start_import_warmup()` runs a daemon thread that imports `strix.core.runner` → the
`openai-agents` SDK. On the scan path the **main** thread independently imports the
same package via `strix.report` → `strix.report.dedupe` →
`from agents.models.interface import ModelTracing`.

`openai-agents` has an internal import cycle (`agents.agent_output` ↔ `agents.agent`,
reached through `agents/__init__.py` → `sandbox` → `run_config` → `lifecycle` →
`agent`). A single thread resolves the cycle, but when two threads import the
`agents` package concurrently, CPython's per-module import locks + deadlock-avoidance
can let one thread proceed with a **partially initialized** module — producing the
ImportError above. It is scheduler-dependent, which matches the intermittent reports.

## Fix

Import the `agents` package once, synchronously, on the caller's thread before the
daemon warm-up thread starts, so it is fully in `sys.modules` before any concurrent
import. `start_import_warmup()` is also moved to just after `parse_arguments()` so
`--version`/`--help`/argparse errors exit before the (now partly synchronous) warm-up
runs; the warm-up still overlaps the Docker checks and image pull that follow.

## Test

Adds `tests/test_warmup.py`: in a fresh interpreter, with an empty warm set so the
daemon thread imports nothing, `start_import_warmup()` must leave `agents` in
`sys.modules` — proving the synchronous pre-import ran.

`ruff format --check`, `ruff check`, and the new test pass locally.

<details><summary>Original traceback</summary>

```
File ".../strix/interface/main.py", line 454, in main
    from strix.report.state import get_global_report_state
File ".../strix/report/__init__.py", line 3, in <module>
    from strix.report.dedupe import check_duplicate
File ".../strix/report/dedupe.py", line 11, in <module>
    from agents.models.interface import ModelTracing
File ".../agents/models/interface.py", line 10, in <module>
    from ..agent_output import AgentOutputSchemaBase
File ".../agents/agent_output.py", line 11, in <module>
    from .util import _error_tracing, _json
File ".../agents/__init__.py", line 8, in <module>
    from . import _config, sandbox
File ".../agents/sandbox/__init__.py", line 3, in <module>
    from ..run_config import SandboxArchiveLimits, SandboxConcurrencyLimits, SandboxRunConfig
File ".../agents/run_config.py", line 19, in <module>
    from .lifecycle import RunHooks
File ".../agents/lifecycle.py", line 5, in <module>
    from .agent import Agent, AgentBase
File ".../agents/agent.py", line 15, in <module>
    from .agent_output import AgentOutputSchemaBase
ImportError: cannot import name 'AgentOutputSchemaBase' from partially initialized
module 'agents.agent_output' (most likely due to a circular import)
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
