### PR TITLE
Add LLM_API_BASE environment variable to OpenRouter Doc

### DIFF
--- a/docs/llm-providers/openrouter.mdx
+++ b/docs/llm-providers/openrouter.mdx
@@ -10,6 +10,7 @@ description: "Configure Strix with models via OpenRouter"
 ```bash
 export STRIX_LLM="openrouter/openai/gpt-5.4"
 export LLM_API_KEY="sk-or-..."
+export LLM_API_BASE='https://openrouter.ai/api/v1'
 ```
 
 ## Available Models


### PR DESCRIPTION
I ran into the same problem as described in https://github.com/usestrix/strix/issues/170#issuecomment-3697788431.  I can confirm setting `LLM_API_BASE` worked for me as well.