### PR TITLE
fix: don't block viewer/CLI on telemetry HTTP

### DIFF
--- a/strix/telemetry/_common.py
+++ b/strix/telemetry/_common.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 import logging
 import platform
 import sys
+import threading
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 logger = logging.getLogger(__name__)
@@ -20,6 +25,22 @@ SESSION_ID: str = uuid4().hex[:16]
 SEND_TIMEOUT: tuple[float, float] = (2.0, 3.0)
 
 _FIRST_RUN_CACHED: bool | None = None
+
+
+def dispatch(func: Callable[[], None]) -> None:
+    """Run a best-effort telemetry send off the caller's thread.
+
+    Telemetry is a beacon: operator-facing paths (``strix view``, scan start,
+    the viewer's ``/api/event`` handler) must never block on it. A daemon
+    thread keeps a slow or MITM-intercepted TLS handshake from stalling the UI,
+    and won't hold the process open at exit -- the beacon is simply dropped if
+    the process exits first, which is acceptable for telemetry. The per-send
+    ``SEND_TIMEOUT`` still bounds each request.
+    """
+    try:
+        threading.Thread(target=func, daemon=True).start()
+    except Exception:  # noqa: BLE001
+        logger.debug("telemetry dispatch failed", exc_info=True)
 
 
 def get_version() -> str:

--- a/strix/telemetry/_common.py
+++ b/strix/telemetry/_common.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import platform
+import queue
 import sys
 import threading
 from importlib.metadata import PackageNotFoundError, version
@@ -26,19 +27,56 @@ SEND_TIMEOUT: tuple[float, float] = (2.0, 3.0)
 
 _FIRST_RUN_CACHED: bool | None = None
 
+# One daemon worker drains this queue, so the number of telemetry threads and
+# in-flight sockets stays fixed no matter how fast events arrive. The queue is
+# bounded: the viewer's /api/event endpoint is request-triggered, so an
+# unbounded per-event thread would let a burst against a slow endpoint pile up
+# threads until the process is starved. When the queue is full we drop the
+# event -- telemetry is best-effort.
+_SEND_QUEUE_MAXSIZE = 256
+_send_queue: queue.Queue[Callable[[], None]] = queue.Queue(maxsize=_SEND_QUEUE_MAXSIZE)
+_worker_lock = threading.Lock()
+_worker_started = False
+
+
+def _worker() -> None:
+    while True:
+        func = _send_queue.get()
+        try:
+            func()
+        except Exception:  # noqa: BLE001
+            logger.debug("telemetry send failed", exc_info=True)
+        finally:
+            _send_queue.task_done()
+
+
+def _ensure_worker() -> None:
+    global _worker_started  # noqa: PLW0603
+    if _worker_started:
+        return
+    with _worker_lock:
+        if _worker_started:
+            return
+        threading.Thread(target=_worker, name="telemetry-sender", daemon=True).start()
+        _worker_started = True
+
 
 def dispatch(func: Callable[[], None]) -> None:
-    """Run a best-effort telemetry send off the caller's thread.
+    """Queue a best-effort telemetry send to run off the caller's thread.
 
     Telemetry is a beacon: operator-facing paths (``strix view``, scan start,
-    the viewer's ``/api/event`` handler) must never block on it. A daemon
-    thread keeps a slow or MITM-intercepted TLS handshake from stalling the UI,
-    and won't hold the process open at exit -- the beacon is simply dropped if
-    the process exits first, which is acceptable for telemetry. The per-send
-    ``SEND_TIMEOUT`` still bounds each request.
+    the viewer's ``/api/event`` handler) must never block on it. The send runs
+    on a single shared daemon worker, so a slow or MITM-intercepted TLS
+    handshake can't stall the UI and can't spawn an unbounded number of threads
+    when events arrive in bursts. The per-send ``SEND_TIMEOUT`` still bounds
+    each request. Sends still in the queue when the process exits are dropped,
+    which is acceptable for telemetry.
     """
     try:
-        threading.Thread(target=func, daemon=True).start()
+        _ensure_worker()
+        _send_queue.put_nowait(func)
+    except queue.Full:
+        logger.debug("telemetry queue full; dropping event")
     except Exception:  # noqa: BLE001
         logger.debug("telemetry dispatch failed", exc_info=True)
 

--- a/strix/telemetry/posthog.py
+++ b/strix/telemetry/posthog.py
@@ -8,6 +8,7 @@ from strix.telemetry._common import (
     SEND_TIMEOUT,
     SESSION_ID,
     base_props,
+    dispatch,
     is_first_run,
 )
 
@@ -27,24 +28,31 @@ def _is_enabled() -> bool:
 
 
 def _send(event: str, properties: dict[str, Any]) -> bool:
+    # Best-effort beacon: dispatch the HTTP call to a daemon thread so no
+    # operator-facing path (strix view, scan start, the viewer request thread)
+    # blocks on a slow or intercepted TLS handshake. The bool reports whether
+    # the event was *dispatched*, not delivered.
     if not _is_enabled():
         logger.debug("posthog disabled; skipping event %s", event)
         return False
-    try:
-        payload = {
-            "api_key": _POSTHOG_PUBLIC_API_KEY,
-            "event": event,
-            "distinct_id": SESSION_ID,
-            "properties": properties,
-        }
-        with requests.post(f"{_POSTHOG_HOST}/capture/", json=payload, timeout=SEND_TIMEOUT):
-            pass
-    except Exception:  # noqa: BLE001
-        logger.debug("posthog send failed for event %s", event, exc_info=True)
-        return False
-    else:
-        logger.debug("posthog event sent: %s", event)
-        return True
+
+    def _deliver() -> None:
+        try:
+            payload = {
+                "api_key": _POSTHOG_PUBLIC_API_KEY,
+                "event": event,
+                "distinct_id": SESSION_ID,
+                "properties": properties,
+            }
+            with requests.post(f"{_POSTHOG_HOST}/capture/", json=payload, timeout=SEND_TIMEOUT):
+                pass
+        except Exception:  # noqa: BLE001
+            logger.debug("posthog send failed for event %s", event, exc_info=True)
+        else:
+            logger.debug("posthog event sent: %s", event)
+
+    dispatch(_deliver)
+    return True
 
 
 def start(

--- a/strix/telemetry/scarf.py
+++ b/strix/telemetry/scarf.py
@@ -11,6 +11,7 @@ from strix.telemetry._common import (
     SEND_TIMEOUT,
     SESSION_ID,
     base_props,
+    dispatch,
     get_version,
     is_first_run,
 )
@@ -30,27 +31,34 @@ def _is_enabled() -> bool:
 
 
 def _send(event: str, properties: dict[str, Any]) -> bool:
+    # Best-effort beacon: dispatch the HTTP call to a daemon thread so no
+    # operator-facing path (strix view, scan start, the viewer request thread)
+    # blocks on a slow or intercepted TLS handshake. The bool reports whether
+    # the event was *dispatched*, not delivered.
     if not _is_enabled():
         logger.debug("scarf disabled; skipping event %s", event)
         return False
-    try:
-        props = dict(properties)
-        version = str(props.pop("strix_version", get_version()) or "unknown")
-        path = f"/{urllib.parse.quote(event, safe='')}/{urllib.parse.quote(version, safe='')}"
-        query = urllib.parse.urlencode(
-            {k: ("" if v is None else str(v)) for k, v in props.items()},
-        )
-        url = f"{_SCARF_ENDPOINT}{path}"
-        if query:
-            url = f"{url}?{query}"
-        with requests.post(url, timeout=SEND_TIMEOUT):
-            pass
-    except Exception:  # noqa: BLE001
-        logger.debug("scarf send failed for event %s", event, exc_info=True)
-        return False
-    else:
-        logger.debug("scarf event sent: %s", event)
-        return True
+
+    def _deliver() -> None:
+        try:
+            props = dict(properties)
+            version = str(props.pop("strix_version", get_version()) or "unknown")
+            path = f"/{urllib.parse.quote(event, safe='')}/{urllib.parse.quote(version, safe='')}"
+            query = urllib.parse.urlencode(
+                {k: ("" if v is None else str(v)) for k, v in props.items()},
+            )
+            url = f"{_SCARF_ENDPOINT}{path}"
+            if query:
+                url = f"{url}?{query}"
+            with requests.post(url, timeout=SEND_TIMEOUT):
+                pass
+        except Exception:  # noqa: BLE001
+            logger.debug("scarf send failed for event %s", event, exc_info=True)
+        else:
+            logger.debug("scarf event sent: %s", event)
+
+    dispatch(_deliver)
+    return True
 
 
 def start(

--- a/tests/test_telemetry_nonblocking.py
+++ b/tests/test_telemetry_nonblocking.py
@@ -1,0 +1,68 @@
+"""Telemetry must never block the caller's thread.
+
+`_send` dispatches the HTTP beacon to a daemon thread, so operator-facing
+paths (strix view, scan start, the viewer's /api/event handler) return
+immediately even when the TLS handshake hangs or is intercepted.
+"""
+
+import threading
+import time
+from typing import Self
+
+import pytest
+
+from strix.telemetry import posthog, scarf
+
+
+class _Resp:
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+
+@pytest.mark.parametrize("telemetry", [posthog, scarf])
+def test_send_does_not_block_caller(telemetry, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(telemetry, "_is_enabled", lambda: True)
+
+    started = threading.Event()
+    done = threading.Event()
+    caller_thread = threading.get_ident()
+    seen: dict[str, int] = {}
+
+    def _slow_post(*_args: object, **_kwargs: object) -> _Resp:
+        seen["thread"] = threading.get_ident()
+        started.set()
+        time.sleep(1.0)  # simulate a hanging / MITM-intercepted TLS handshake
+        done.set()
+        return _Resp()
+
+    monkeypatch.setattr(telemetry.requests, "post", _slow_post)
+
+    start = time.perf_counter()
+    dispatched = telemetry._send("viewer_opened", {"x": 1})
+    elapsed = time.perf_counter() - start
+
+    # Returns immediately (reporting "dispatched") even though the POST hangs 1s.
+    assert dispatched is True
+    assert elapsed < 0.5
+    # The HTTP actually runs, on a background thread -- not the caller's.
+    assert started.wait(2.0)
+    assert seen["thread"] != caller_thread
+    assert done.wait(2.0)
+
+
+@pytest.mark.parametrize("telemetry", [posthog, scarf])
+def test_send_disabled_returns_false_without_dispatch(
+    telemetry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(telemetry, "_is_enabled", lambda: False)
+    called: list[bool] = []
+    monkeypatch.setattr(
+        telemetry.requests, "post", lambda *_a, **_k: called.append(True)
+    )
+
+    assert telemetry._send("viewer_opened", {"x": 1}) is False
+    time.sleep(0.1)
+    assert called == []

--- a/tests/test_telemetry_nonblocking.py
+++ b/tests/test_telemetry_nonblocking.py
@@ -53,6 +53,27 @@ def test_send_does_not_block_caller(telemetry, monkeypatch: pytest.MonkeyPatch) 
     assert done.wait(2.0)
 
 
+def test_burst_does_not_spawn_unbounded_threads(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(posthog, "_is_enabled", lambda: True)
+
+    def _slow_post(*_args: object, **_kwargs: object) -> _Resp:
+        time.sleep(0.5)  # keep the shared worker busy so the queue backs up
+        return _Resp()
+
+    monkeypatch.setattr(posthog.requests, "post", _slow_post)
+
+    start = time.perf_counter()
+    for i in range(200):
+        posthog._send("viewer_cta_clicked", {"i": i})
+    elapsed = time.perf_counter() - start
+
+    # Enqueuing a large burst stays fast and non-blocking...
+    assert elapsed < 1.0
+    # ...and telemetry runs on exactly one shared worker thread, not one per event.
+    sender_threads = [t for t in threading.enumerate() if t.name == "telemetry-sender"]
+    assert len(sender_threads) == 1
+
+
 @pytest.mark.parametrize("telemetry", [posthog, scarf])
 def test_send_disabled_returns_false_without_dispatch(
     telemetry, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Closes #1197.

## What & why

Telemetry is meant to be a fire-and-forget beacon — `strix/telemetry/_common.py` says it is "never something a user waits on." But `telemetry._send` (PostHog and Scarf) did a **synchronous** `requests.post(...)` on the caller's thread, and operator-facing paths call it inline:

- **`strix view` startup** — `posthog.viewer_opened()` runs in `viewer/cli.py` *before* the tokened URL is printed.
- **`POST /api/event`** — `_handle_event` in `viewer/server.py` forwards `cta_clicked` / email-funnel / `agent_steered` events, *then* writes `204`.
- **scan start** — `telemetry_start` → `posthog.start` + `scarf.start`, same synchronous shape.

When the endpoint is slow, blackholed, or its TLS is intercepted (a corporate proxy presenting a leaf `certifi` rejects), each send blocks for up to `SEND_TIMEOUT` (2s connect + 3s read) even though the error is swallowed and nothing is delivered. The operator-visible latency is the defect. The skill-load path already avoids this by dispatching on a daemon thread — these paths just didn't.

## The fix

Add a shared `dispatch()` helper in `_common.py` that runs a send on a daemon thread, and have both `posthog._send` / `scarf._send` dispatch the HTTP call instead of running it inline:

```python
def _send(event, properties) -> bool:
    if not _is_enabled():
        return False

    def _deliver() -> None:
        try:
            with requests.post(..., timeout=SEND_TIMEOUT):
                pass
        except Exception:
            logger.debug("send failed", exc_info=True)

    dispatch(_deliver)   # daemon thread; per-request SEND_TIMEOUT still applies
    return True
```

Every caller — `viewer_opened`, the `/api/event` handlers, scan start, and the existing skill-load path — is now non-blocking. Opt-out (`STRIX_TELEMETRY=0`) and the collected fields are unchanged.

## Before / after

With the telemetry endpoint hanging (simulated 1s TLS stall), `_send` returns in **~1 ms** instead of blocking the caller:

```
# before: caller blocks until the POST returns or SEND_TIMEOUT trips (up to ~5s)
# after:
_send returned True in 1.0 ms
posthog POST ran on a background daemon thread (not the caller's)
```

Operator-visible: `strix view` prints the URL immediately; `/api/event` returns `204` without waiting on PostHog.

## Contract note

`_send` now returns whether the beacon was **dispatched**, not delivered. Its only consumer is `end()`'s `scan_ended` idempotency guard (`posthog_scan_ended_sent = _send(...)`), which still fires exactly once. As with skill-load today, a beacon may be dropped if the process exits before the daemon finishes — an accepted trade-off for best-effort telemetry.

## Tests

Added `tests/test_telemetry_nonblocking.py` (parametrized over PostHog and Scarf): asserts `_send` returns immediately against a 1s-hanging POST, that the HTTP runs on a background thread (not the caller's), and that the disabled path returns `False` without dispatching.

> Note: I couldn't run the full suite locally (missing runtime deps in my env); `ruff` passes on all changed files, and I verified the non-blocking behavior with a standalone harness. The repo has no pull_request CI, so `make check-all` / pre-commit is the gate — please run it on review.