### PR TITLE
docs: add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,58 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or Discord.**
+
+Report privately through one of these channels:
+
+1. **GitHub private vulnerability reporting** — open the
+   [Security tab](https://github.com/usestrix/strix/security) and use *Report a
+   vulnerability*. This keeps the report private, gives you a thread with the
+   maintainers, and can lead to a published advisory and a CVE.
+2. **Email** — [hi@usestrix.com](mailto:hi@usestrix.com), with `SECURITY` in the
+   subject line.
+
+## What to include
+
+A report is easiest to act on when it contains:
+
+- the affected component — the CLI, the sandbox container, the agent runtime,
+  the report writer, or the viewer;
+- the version, from `strix --version`, and how it was installed;
+- what an attacker gains, and what access they need to start;
+- steps to reproduce, ideally a minimal case;
+- any logs, scan artifacts, or proof-of-concept output.
+
+Redact scan artifacts before sending them. A run directory can contain target
+hostnames, captured credentials, and request bodies from whatever was scanned.
+
+## Scope
+
+Strix runs untrusted target content through an agent and writes artifacts a
+human later opens, so the parts most worth reporting are the ones crossing that
+boundary:
+
+- sandbox escape, or anything giving the container more host access than the
+  documented mounts and network policy;
+- exposure of LLM API keys, proxy-captured credentials, or the MITM CA key;
+- code execution or injection reached through scanned target content, including
+  the generated reports — CSV, Markdown, PDF, SARIF and JSON;
+- prompt injection from a target that escalates into actions outside the
+  sandbox.
+
+Findings that Strix reports about *your own* scan target are not
+vulnerabilities in Strix. Neither is a scan running against a host you are not
+authorised to test.
+
+## Supported versions
+
+Fixes land on the latest release. Given the current release cadence, upgrading
+to the newest version is the supported path rather than backports to older
+tags.
+
+## Disclosure
+
+Please give the maintainers a chance to ship a fix before publishing details.
+If you would like credit in the advisory, say so in your report.


### PR DESCRIPTION
Addresses the second half of #1051.

## Why

There's no `SECURITY.md` in any of the three locations GitHub reads (`/`, `.github/`, `docs/`), so the repo has no **Security policy** link and no documented private channel. As #1051 puts it, a reporter is left choosing between a public issue, Discord, or the general inbox — an awkward gap for a security tool.

## What's here

A `SECURITY.md` pointing at GitHub private vulnerability reporting (primary) and `hi@usestrix.com` (fallback), plus what to include, scope, and disclosure expectations.

Two parts are written for this project specifically rather than boilerplate:

**Scope is framed around the boundary that actually matters here.** Strix runs untrusted target content through an agent and writes artifacts a human later opens, so it calls out sandbox escape, exposure of LLM keys / proxy-captured credentials / the MITM CA key, injection reached through the generated reports (CSV, Markdown, PDF, SARIF, JSON), and prompt injection escalating outside the sandbox.

**It states the non-scope explicitly** — findings Strix reports about a user's *own* scan target aren't vulnerabilities in Strix, and neither is scanning a host you're not authorised to test. For a pentesting tool that distinction seems worth writing down, or the inbox fills with scan output.

It also asks reporters to redact scan artifacts before sending, since a run directory can carry target hostnames and captured credentials.

## Two things for you to decide

**Response timelines.** I deliberately did *not* write any — an acknowledgement window or fix SLA is a commitment only maintainers can make, and inventing numbers seemed worse than omitting them. Happy to add whatever you want to promise.

**Supported versions.** I wrote that fixes land on the latest release rather than being backported, which matches the current cadence (v1.4.1 → v1.5.3 inside a month). Correct that if the intent differs.

The other half of #1051 — enabling private vulnerability reporting under Settings → Code security — is a repo setting a PR can't touch. The policy links to the Security tab on the assumption it'll be enabled; if you'd rather not, say so and I'll drop that channel and leave email only.

## Verified

Every factual claim was checked rather than assumed: `hi@usestrix.com` is the public org email, the Security tab URL returns 200, `--version` is a real flag in `cli_args.py`, and the components named all exist (`report/sarif.py`, `interface/viewer/report_pdf.py`, `containers/`).

---

Disclosure: drafted with AI assistance (Claude Code).