### PR TITLE
test(pricing): make bare-model resolution test deterministic

### DIFF
--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -9,12 +9,37 @@ from strix.report.pricing import resolve_litellm_model
 from strix.report.usage import LLMUsageLedger
 
 
+_FIXED_MODEL_COST: dict[str, dict[str, object]] = {
+    "deepseek-v4-flash": {
+        "litellm_provider": "deepseek",
+        "input_cost_per_token": 1.0,
+        "output_cost_per_token": 2.0,
+    },
+    "grok-4.5": {
+        "litellm_provider": "xai",
+        "input_cost_per_token": 1.0,
+        "output_cost_per_token": 2.0,
+    },
+    "MiniMax-M3": {
+        "litellm_provider": "minimax",
+        "input_cost_per_token": 1.0,
+        "output_cost_per_token": 2.0,
+    },
+}
+
+
 def test_resolves_common_bare_model_names() -> None:
-    resolve_litellm_model.cache_clear()
-    assert resolve_litellm_model("deepseek-v4-flash") == "deepseek/deepseek-v4-flash"
-    assert resolve_litellm_model("openai/deepseek-v4-flash") == "deepseek/deepseek-v4-flash"
-    assert resolve_litellm_model("grok-4.5") == "xai/grok-4.5"
-    assert resolve_litellm_model("MiniMax-M3") == "minimax/MiniMax-M3"
+    original = litellm.model_cost
+    litellm.model_cost = _FIXED_MODEL_COST
+    try:
+        resolve_litellm_model.cache_clear()
+        assert resolve_litellm_model("deepseek-v4-flash") == "deepseek/deepseek-v4-flash"
+        assert resolve_litellm_model("openai/deepseek-v4-flash") == "deepseek/deepseek-v4-flash"
+        assert resolve_litellm_model("grok-4.5") == "xai/grok-4.5"
+        assert resolve_litellm_model("MiniMax-M3") == "minimax/MiniMax-M3"
+    finally:
+        litellm.model_cost = original
+        resolve_litellm_model.cache_clear()
 
 
 def test_resolver_returns_none_for_unresolvable_model() -> None:


### PR DESCRIPTION
## Description

Fixes #1213

`tests/test_pricing.py::test_resolves_common_bare_model_names` asserted `resolve_litellm_model("MiniMax-M3") == "minimax/MiniMax-M3"` against LiteLLM's **mutable** `model_cost` registry. The resolver deliberately refuses to guess between differently priced providers (`strix/report/pricing.py:39-52` returns `None` when multiple routes with different prices match, as covered by `test_resolver_does_not_guess_between_differently_priced_providers`).

Whether the test passed depended on runtime environment: when LiteLLM fetched its remote model cost map (`minimax/MiniMax-M3`, `deepinfra/MiniMaxAI/MiniMax-M3`, `together_ai/MiniMaxAI/MiniMax-M3`, `wandb/MiniMaxAI/MiniMax-M3` — multiple prices) the resolver returned `None` and the test failed; when it fell back to the local backup (single route) the test passed. I reproduced the failure with the exact remote 4-route registry (see Testing).

This change makes the test deterministic by mocking a small fixed `litellm.model_cost` registry, using the same try/finally pattern already used by the other resolver tests in this file. No production code is touched.

### Change

- `tests/test_pricing.py`: extracted `_FIXED_MODEL_COST` — a small fixed registry with exactly one provider route per asserted model (`deepseek-v4-flash` → deepseek, `grok-4.5` → xai, `MiniMax-M3` → minimax).
- `test_resolves_common_bare_model_names` now temporarily replaces `litellm.model_cost` with that registry (restored in `finally`, resolver cache cleared both before and after), so assertions never depend on external registry state.

### Scope note

None — single-file test change; production behavior unchanged.

### Type of Change

- [x] 🐛 Bug fix (test determinism)

### Related Issue

- Fixes #1213

### Testing

- Reproduced the reported failure first: with a 4-route differently-priced MiniMax-M3 registry (as in LiteLLM's remote model cost map), `resolve_litellm_model("MiniMax-M3")` returns `None`, i.e. the old assertion fails exactly as reported.
- With the fix, `uv run pytest tests/test_pricing.py -q` — **8 passed** (log: test_pricing.py, 8 items, 3.45s).
  - Note: full-repository suite not run from this environment (resource-constrained agent sandbox; only the affected file's tests are exercised). The change is isolated to one test function plus a module constant.
- `ruff check tests/test_pricing.py` — clean
- `git diff --check` — clean

### Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above (documented: only the affected test file was run, due to sandbox resource limits)
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Breaking changes are clearly called out in the description above (none)