### PR TITLE
fix(resume): re-validate persisted mounts with the mount guard

### DIFF
--- a/strix/interface/cli_args.py
+++ b/strix/interface/cli_args.py
@@ -14,6 +14,7 @@ from strix.interface.scan_setup import attach_workspace_mount, build_targets_inf
 from strix.interface.update_check import self_update
 from strix.interface.utils import (
     check_mountable_dir,
+    check_mountable_file,
     collect_local_sources,
     resolve_workspace_files,
     validate_config_file,
@@ -411,12 +412,17 @@ def _load_resume_state(args: argparse.Namespace, parser: argparse.ArgumentParser
         cloned = details.get("cloned_repo_path")
         if not cloned:
             continue
-        if not Path(cloned).expanduser().exists():
+        cloned_path = Path(cloned).expanduser()
+        if not cloned_path.exists():
             parser.error(
                 f"--resume {args.resume}: cloned repo at {cloned} is missing. "
                 f"It was deleted between runs. Pick a fresh --run-name to "
                 f"re-clone, or restore the directory before resuming."
             )
+        try:
+            check_mountable_dir(cloned_path)
+        except ValueError as exc:
+            parser.error(f"--resume {args.resume}: {exc}")
 
     if args.instruction is None:
         args.instruction = state.get("instruction")
@@ -424,32 +430,46 @@ def _load_resume_state(args: argparse.Namespace, parser: argparse.ArgumentParser
         args.user_instruction = state.get("user_instruction") or None
     args.local_sources = collect_local_sources(args.targets_info)
     # Remount the workspace the run was started with. The user already confirmed
-    # this directory, so the target mount guard does not apply to it; it only has
-    # to still be there.
+    # this directory on the original run, but run.json is on disk under the
+    # scanned tree and may have been tampered with, so the target mount guard
+    # still applies on resume: it has to both still be there and be mountable.
     args.workspace_mount = workspace_mount
 
     # Replace the workspace files the run started with, unless this resume names
     # its own. The persisted record is revalidated like a fresh flag, so an
-    # edited run.json cannot widen what a resume places. A file deleted between
-    # runs is dropped rather than fatal: it is context for the agent, not scope.
+    # edited run.json cannot widen what a resume places. Each source is also
+    # passed through the mount guard, so a tampered run.json cannot smuggle
+    # credential or system files into the sandbox. A file deleted between runs
+    # is dropped rather than fatal: it is context for the agent, not scope.
     if not getattr(args, "workspace_files", None):
-        restored = [
-            f"{source_path}:{workspace_path}"
-            for workspace_file in state.get("workspace_files") or []
-            if isinstance(workspace_file, dict)
-            and (source_path := Path(str(workspace_file.get("source_path") or ""))).is_file()
-            and (workspace_path := str(workspace_file.get("workspace_path") or ""))
-        ]
+        restored: list[str] = []
+        for workspace_file in state.get("workspace_files") or []:
+            if not isinstance(workspace_file, dict):
+                continue
+            source_path = Path(str(workspace_file.get("source_path") or "")).expanduser()
+            workspace_path = str(workspace_file.get("workspace_path") or "")
+            if not source_path.is_file() or not workspace_path:
+                continue
+            try:
+                check_mountable_file(source_path)
+            except ValueError as error:
+                parser.error(f"--resume {args.resume}: {error}")
+            restored.append(f"{source_path}:{workspace_path}")
         try:
             args.workspace_files = resolve_workspace_files(restored)
         except ValueError as error:
             parser.error(f"--resume {args.resume}: invalid workspace file: {error}")
     if workspace_mount:
-        if not Path(workspace_mount).expanduser().is_dir():
+        mount_path = Path(workspace_mount).expanduser()
+        if not mount_path.is_dir():
             parser.error(
                 f"--resume {args.resume}: the working directory {workspace_mount} "
                 f"is missing. Restore it before resuming, or start a fresh run."
             )
+        try:
+            check_mountable_dir(mount_path)
+        except ValueError as exc:
+            parser.error(f"--resume {args.resume}: {exc}")
         attach_workspace_mount(args)
     if state.get("diff_scope"):
         args.diff_scope = state.get("diff_scope")

--- a/strix/interface/utils.py
+++ b/strix/interface/utils.py
@@ -1401,6 +1401,23 @@ def _is_within(path: Path, ancestor: Path) -> bool:
     return path_parts[: len(ancestor_parts)] == ancestor_parts
 
 
+def _mount_guard_sets(anchor: Path) -> tuple[set[str], list[Path]]:
+    """Shared exact-match and tree sets used by both mount guards.
+
+    ``anchor`` only locates the drive for the Windows-specific checks.
+    """
+    exact = {str(Path(root)).casefold() for root in _FORBIDDEN_MOUNT_ROOTS}
+    exact |= {str(Path(root).resolve()).casefold() for root in _FORBIDDEN_MOUNT_ROOTS}
+    exact.add(str(Path.home().resolve()).casefold())
+    tree_roots = set(_FORBIDDEN_MOUNT_TREES)
+    if os.name == "nt":
+        drive = Path(anchor.anchor)
+        tree_roots |= {str(drive / name) for name in _FORBIDDEN_WINDOWS_TREE_NAMES}
+        exact.add(str(drive / "Users").casefold())
+    trees = [Path(root) for root in tree_roots] + [Path(root).resolve() for root in tree_roots]
+    return exact, trees
+
+
 def check_mountable_dir(path: Path) -> None:
     resolved = path.resolve()
     if not resolved.is_dir():
@@ -1408,15 +1425,7 @@ def check_mountable_dir(path: Path) -> None:
 
     # Both the literal and the resolved form: macOS reaches /etc through the
     # /private/etc symlink, and only the resolved path is compared below.
-    exact = {str(Path(root)).casefold() for root in _FORBIDDEN_MOUNT_ROOTS}
-    exact |= {str(Path(root).resolve()).casefold() for root in _FORBIDDEN_MOUNT_ROOTS}
-    exact.add(str(Path.home().resolve()).casefold())
-    tree_roots = set(_FORBIDDEN_MOUNT_TREES)
-    if os.name == "nt":
-        drive = Path(resolved.anchor)
-        tree_roots |= {str(drive / name) for name in _FORBIDDEN_WINDOWS_TREE_NAMES}
-        exact.add(str(drive / "Users").casefold())
-    trees = [Path(root) for root in tree_roots] + [Path(root).resolve() for root in tree_roots]
+    exact, trees = _mount_guard_sets(resolved)
     if (
         str(resolved).casefold() in exact
         or resolved.parent == resolved
@@ -1426,6 +1435,39 @@ def check_mountable_dir(path: Path) -> None:
             f"Refusing to mount '{resolved}' into the sandbox: it is a system "
             "or home directory, not a codebase. Point the target at the "
             "project directory you want tested."
+        )
+
+    credential = next(
+        (part for part in resolved.parts if part.casefold() in _FORBIDDEN_MOUNT_DIR_NAMES), None
+    )
+    if credential is not None:
+        raise ValueError(
+            f"Refusing to mount '{resolved}' into the sandbox: '{credential}' "
+            "holds credentials, not code."
+        )
+
+
+def check_mountable_file(path: Path) -> None:
+    """Validate a single host file may be mounted into the sandbox as a
+    workspace file.
+
+    Applies the same system/home/credential checks that ``check_mountable_dir``
+    applies to a directory, against the file's parent directory and its own
+    path components, so credential files and system files cannot be smuggled
+    into a run through workspace files.
+    """
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise ValueError(f"'{path}' is not an existing file.")
+
+    parent = resolved.parent
+    # Both the literal and the resolved form: macOS reaches /etc through the
+    # /private/etc symlink, and only the resolved path is compared below.
+    exact, trees = _mount_guard_sets(parent)
+    if str(parent).casefold() in exact or any(_is_within(parent, tree) for tree in trees):
+        raise ValueError(
+            f"Refusing to mount '{resolved}' into the sandbox: it is a system "
+            "or home path, not a project file."
         )
 
     credential = next(

--- a/tests/test_cli_resume.py
+++ b/tests/test_cli_resume.py
@@ -1,0 +1,134 @@
+"""--resume re-validates persisted mounts against the mount guard.
+
+run.json lives on disk under the scanned tree and is treated as untrusted on
+resume: workspace_mount, repository cloned_repo_path and workspace_files
+sources must all pass the same checks a fresh invocation would apply.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from strix.interface.cli_args import _load_resume_state
+
+
+def _parser() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser()
+
+
+def _resume_args(**overrides: object) -> argparse.Namespace:
+    defaults: dict[str, object] = {
+        "resume": "old-run",
+        "targets_info": [],
+        "instruction": None,
+        "user_instruction": None,
+        "local_sources": [],
+        "workspace_mount": None,
+        "workspace_files": None,
+        "diff_scope": None,
+        "scan_mode": "quick",
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _write_run(tmp_path: Path, record: dict[str, object]) -> None:
+    run_dir = tmp_path / "strix_runs" / "old-run"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run.json").write_text(json.dumps(record), encoding="utf-8")
+
+
+def _patch_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+    return home
+
+
+def test_resume_rejects_forbidden_workspace_mount(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = _patch_home(tmp_path, monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _write_run(
+        tmp_path,
+        {"targets_info": [], "workspace_mount": str(home), "workspace_files": []},
+    )
+
+    with pytest.raises(SystemExit):
+        _load_resume_state(_resume_args(), _parser())
+
+
+def test_resume_rejects_system_workspace_mount(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_run(
+        tmp_path,
+        {"targets_info": [], "workspace_mount": "/etc", "workspace_files": []},
+    )
+
+    with pytest.raises(SystemExit):
+        _load_resume_state(_resume_args(), _parser())
+
+
+def test_resume_rejects_forbidden_cloned_repo_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_run(
+        tmp_path,
+        {
+            "targets_info": [{"type": "repository", "details": {"cloned_repo_path": "/etc"}}],
+            "workspace_mount": None,
+            "workspace_files": [],
+        },
+    )
+
+    with pytest.raises(SystemExit):
+        _load_resume_state(_resume_args(), _parser())
+
+
+def test_resume_rejects_credential_workspace_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = _patch_home(tmp_path, monkeypatch)
+    ssh = home / ".ssh"
+    ssh.mkdir()
+    key = ssh / "id_rsa"
+    key.write_text("key", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    _write_run(
+        tmp_path,
+        {
+            "targets_info": [],
+            "workspace_mount": None,
+            "workspace_files": [{"source_path": str(key), "workspace_path": "id_rsa"}],
+        },
+    )
+
+    with pytest.raises(SystemExit):
+        _load_resume_state(_resume_args(), _parser())
+
+
+def test_resume_accepts_a_clean_record(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_run(
+        tmp_path,
+        {
+            "targets_info": [],
+            "user_instruction": "scan the target",
+            "workspace_mount": None,
+            "workspace_files": [],
+        },
+    )
+
+    args = _resume_args()
+    _load_resume_state(args, _parser())
+
+    assert args.user_instruction == "scan the target"

--- a/tests/test_local_sources.py
+++ b/tests/test_local_sources.py
@@ -11,6 +11,7 @@ import pytest
 from strix.interface.scan_setup import attach_workspace_mount
 from strix.interface.utils import (
     check_mountable_dir,
+    check_mountable_file,
     collect_local_sources,
     dedupe_local_targets,
     infer_target_type,
@@ -247,3 +248,61 @@ def test_dedupe_collapses_the_same_path() -> None:
     assert dedupe_local_targets([_local_target("/repo"), _local_target("/repo")]) == [
         _local_target("/repo")
     ]
+
+
+def test_check_mountable_file_accepts_a_project_file(tmp_path: Path) -> None:
+    file = tmp_path / "notes.txt"
+    file.write_text("context", encoding="utf-8")
+
+    check_mountable_file(file)
+
+
+def test_check_mountable_file_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="not an existing file"):
+        check_mountable_file(tmp_path / "nope.txt")
+
+
+def test_check_mountable_file_rejects_system_file() -> None:
+    system_file = next(
+        (p for p in (Path("/etc/passwd"), Path("/usr/bin/env")) if p.is_file()), None
+    )
+    if system_file is None:
+        pytest.skip("no system file on this platform")
+    with pytest.raises(ValueError, match="Refusing to mount"):
+        check_mountable_file(system_file)
+
+
+def test_check_mountable_file_rejects_home_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    file = home / "personal.txt"
+    file.write_text("secret", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+
+    with pytest.raises(ValueError, match="Refusing to mount"):
+        check_mountable_file(file)
+
+
+def test_check_mountable_file_rejects_credential_files(tmp_path: Path) -> None:
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    key = ssh_dir / "id_rsa"
+    key.write_text("key", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="holds credentials"):
+        check_mountable_file(key)
+
+
+def test_check_mountable_file_accepts_a_project_file_under_home_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = tmp_path / "home" / "dev" / "project"
+    project.mkdir(parents=True)
+    file = project / "data.txt"
+    file.write_text("x", encoding="utf-8")
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path / "home" / "dev"))
+
+    check_mountable_file(file)

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -9,12 +9,37 @@ from strix.report.pricing import resolve_litellm_model
 from strix.report.usage import LLMUsageLedger
 
 
+_FIXED_MODEL_COST: dict[str, dict[str, object]] = {
+    "deepseek-v4-flash": {
+        "litellm_provider": "deepseek",
+        "input_cost_per_token": 1.0,
+        "output_cost_per_token": 2.0,
+    },
+    "grok-4.5": {
+        "litellm_provider": "xai",
+        "input_cost_per_token": 1.0,
+        "output_cost_per_token": 2.0,
+    },
+    "MiniMax-M3": {
+        "litellm_provider": "minimax",
+        "input_cost_per_token": 1.0,
+        "output_cost_per_token": 2.0,
+    },
+}
+
+
 def test_resolves_common_bare_model_names() -> None:
-    resolve_litellm_model.cache_clear()
-    assert resolve_litellm_model("deepseek-v4-flash") == "deepseek/deepseek-v4-flash"
-    assert resolve_litellm_model("openai/deepseek-v4-flash") == "deepseek/deepseek-v4-flash"
-    assert resolve_litellm_model("grok-4.5") == "xai/grok-4.5"
-    assert resolve_litellm_model("MiniMax-M3") == "minimax/MiniMax-M3"
+    original = litellm.model_cost
+    litellm.model_cost = _FIXED_MODEL_COST
+    try:
+        resolve_litellm_model.cache_clear()
+        assert resolve_litellm_model("deepseek-v4-flash") == "deepseek/deepseek-v4-flash"
+        assert resolve_litellm_model("openai/deepseek-v4-flash") == "deepseek/deepseek-v4-flash"
+        assert resolve_litellm_model("grok-4.5") == "xai/grok-4.5"
+        assert resolve_litellm_model("MiniMax-M3") == "minimax/MiniMax-M3"
+    finally:
+        litellm.model_cost = original
+        resolve_litellm_model.cache_clear()
 
 
 def test_resolver_returns_none_for_unresolvable_model() -> None:


### PR DESCRIPTION
## Description

Fixes #1214

`--resume` rebuilt sandbox bind mounts from `strix_runs/<run>/run.json` but did not apply `check_mountable_dir` to `workspace_mount` or a repository target's `cloned_repo_path` (only `local_code` targets were re-checked), and `workspace_files` sources were not guarded at all. run.json lives on disk under the scanned tree and can be tampered with (e.g. by prompt-injected sandbox agent output during a whitebox scan of the project itself), so a modified record could mount `/`, `$HOME` or `.ssh` writable into the next resumed sandbox, or copy credential/system files in via `workspace_files[].source_path`. A comment in the resume path even documented the guard as intentionally skipped for `workspace_mount`.

### Change

- `strix/interface/cli_args.py` (`_load_resume_state`):
  - `workspace_mount` now passes through `check_mountable_dir` after the existence check, before `attach_workspace_mount`.
  - Repository targets' `cloned_repo_path` now passes through `check_mountable_dir` after the existence check (missing-directory guidance preserved).
  - `workspace_files` sources restored from the record are each passed through the new `check_mountable_file` before `resolve_workspace_files`; a tampered record can no longer smuggle credential/system files into the sandbox.
  - Outdated "the target mount guard does not apply" comment replaced with the new policy.
- `strix/interface/utils.py`:
  - New `check_mountable_file(path)`: applies the same system/home/credential checks as `check_mountable_dir`, evaluated against the file's parent directory and its own path components.
  - Shared exact-match/tree sets extracted into `_mount_guard_sets(anchor)` used by both guards (no behavior change for `check_mountable_dir`).
- Tests:
  - `tests/test_local_sources.py`: 6 new `check_mountable_file` cases (project file accepted; missing/system/home/credential files rejected; project file under the home root accepted).
  - `tests/test_cli_resume.py` (new): resume integration tests — forbidden `workspace_mount` (home), system `workspace_mount` (`/etc`), forbidden `cloned_repo_path` (`/etc`), credential `workspace_files` source (`~/.ssh/id_rsa`) all abort; a clean record still loads.

### Scope note

The issue also suggests keeping run records outside any bind-mounted tree or making them immutable from inside the sandbox. That is a broader design change (run layout / sandbox writability) and is intentionally left out of this PR; the mount guard now covers all resume mount inputs regardless of where run.json lives, which closes the demonstrated bypass.

Ruff reports one pre-existing `ISC004` (implicit string concatenation) on `strix/interface/utils.py:877` — untouched by this change (confirmed present on the unmodified checkout) and not part of this diff.

### Type of Change

- [x] 🐛 Bug fix (security hardening)

### Related Issue

- Fixes #1214

### Testing

- `uv run pytest tests/test_local_sources.py tests/test_cli_resume.py tests/test_pricing.py -q` — **45 passed** (includes 6 new file-guard unit tests and 5 new resume integration tests).
  - Full-repository suite not run from this environment (resource-constrained sandbox; only affected modules exercised).
- `ruff check` on the four changed files — clean (only the pre-existing `ISC004` on an untouched line remains in `utils.py`).
- `ruff format --check` on changed files — clean.
- `git diff --check` — clean.

### Checklist

- [x] `git diff --check origin/main...HEAD` passes
- [x] Changed source files are formatted
- [x] Targeted tests for the changed packages/components pass
- [x] Diff-scoped lint passes where applicable
- [ ] Full-repository checks were run, or any unrelated/environment-dependent failures are documented above (documented: affected-module runs only, sandbox resource limits; pre-existing ruff ISC004 on untouched line noted)
- [x] Self-reviewed the code
- [x] Added/updated tests covering the change
- [ ] Breaking changes are clearly called out in the description above (none — valid resumes behave identically; invalid/tampered records now abort with a clear error)