### PR TITLE
fix(warmup): wait for the import warm-up before the main thread enters the scan graph

### DIFF
--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -450,7 +450,7 @@ def main() -> None:
 
         sys.exit(run_cloud(sys.argv[2:]))
 
-    from strix.llm.warmup import start_import_warmup
+    from strix.llm.warmup import start_import_warmup, wait_for_import_warmup
 
     start_import_warmup()
 
@@ -465,6 +465,12 @@ def main() -> None:
     check_docker_installed()
     pull_docker_image()
     validate_environment()
+
+    # Everything past this point imports from the warmed graph on this thread
+    # (the agents SDK via warm_up_llm and the runner, the TUI's live view).
+    # Importing that graph concurrently from two threads is not safe, see
+    # strix.llm.warmup, so the warm-up thread has to be finished first.
+    wait_for_import_warmup()
 
     if args.non_interactive:
         _bootstrap_scan(args)

--- a/strix/llm/warmup.py
+++ b/strix/llm/warmup.py
@@ -92,7 +92,7 @@ def start_import_warmup(modules: tuple[str, ...] = WARMUP_MODULES) -> threading.
         return _thread
 
 
-def wait_for_import_warmup(timeout: float | None = None) -> None:
+def wait_for_import_warmup() -> None:
     """Block until the warm-up thread has finished; a no-op if none was started.
 
     Call this before the first import from the warmed graph on the calling
@@ -105,4 +105,4 @@ def wait_for_import_warmup(timeout: float | None = None) -> None:
         thread = _thread
     if thread is None or thread is threading.current_thread():
         return
-    thread.join(timeout)
+    thread.join()

--- a/strix/llm/warmup.py
+++ b/strix/llm/warmup.py
@@ -5,9 +5,19 @@ Caido SDK, the Docker SDK) costs seconds to import cold, but none of it is
 needed until a scan actually starts. Importing it on a daemon thread at CLI
 entry overlaps that cost with the I/O-bound startup work that always precedes
 a scan (argument parsing, Docker checks, image pull, TUI setup), so by the
-time the scan begins the modules are already in ``sys.modules``. Any thread
-that needs one of them before the warm-up finishes just blocks on the normal
-import lock, so behaviour is unchanged either way.
+time the scan begins the modules are already in ``sys.modules``.
+
+The one rule: no other thread may import from the warmed graph while the
+warm-up thread is still running. CPython's per-module import locks do not make
+that safe. When two threads walk a package graph with internal import cycles
+(the agents SDK has them), each ends up waiting for a lock the other holds,
+and the import system breaks the cycle by failing one of the two imports
+outright. The failed package is dropped from ``sys.modules`` while the other
+thread is still inside it, which surfaces as ``KeyError: 'agents.models'`` or
+``ImportError: cannot import name ... from partially initialized module``.
+Callers must therefore :func:`wait_for_import_warmup` before the first import
+from the warmed graph on any other thread; once the warm-up is done the call
+returns immediately.
 """
 
 from __future__ import annotations
@@ -80,3 +90,19 @@ def start_import_warmup(modules: tuple[str, ...] = WARMUP_MODULES) -> threading.
         )
         _thread.start()
         return _thread
+
+
+def wait_for_import_warmup(timeout: float | None = None) -> None:
+    """Block until the warm-up thread has finished; a no-op if none was started.
+
+    Call this before the first import from the warmed graph on the calling
+    thread. If the warm-up already finished this returns at once. If it is
+    still running, the caller would otherwise have to import the same modules
+    itself (or race the warm-up thread for them, see the module docstring), so
+    waiting here costs nothing.
+    """
+    with _lock:
+        thread = _thread
+    if thread is None or thread is threading.current_thread():
+        return
+    thread.join(timeout)

--- a/tests/test_import_warmup.py
+++ b/tests/test_import_warmup.py
@@ -7,15 +7,31 @@ hooks -> report.state). CPython's deadlock avoidance breaks such a cycle by
 failing one import, which strands finished submodules in ``sys.modules`` with
 their parent package gone — and the next import of one of those submodules
 crashes with "partially initialized module".
+
+Second field failure: with the sandbox image already present, ``main()`` got
+from ``start_import_warmup()`` to ``warm_up_llm`` (the first agents-SDK import
+on the main thread) in a few hundred milliseconds, while the warm-up thread was
+still inside the agents package. The two imports deadlocked on each other's
+module locks, CPython failed the warm-up's import to break the cycle, and the
+main thread died with ``KeyError: 'agents.models'``. The main thread must wait
+for the warm-up before it imports from that graph.
 """
 
 from __future__ import annotations
 
+import importlib
 import subprocess
 import sys
 import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
 
 from strix.llm import warmup
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _run(code: str) -> subprocess.CompletedProcess[str]:
@@ -97,3 +113,80 @@ def test_purge_does_not_touch_preexisting_or_healthy_modules() -> None:
     warmup._purge_orphaned_modules(before)
     assert "strix.llm.warmup" in sys.modules  # parent chain intact -> kept
     assert "strix" in sys.modules
+
+
+def test_wait_for_import_warmup_returns_once_the_thread_has_finished() -> None:
+    result = _run(
+        """
+        import pathlib
+        import sys
+        import tempfile
+
+        from strix.llm import warmup
+
+        root = pathlib.Path(tempfile.mkdtemp())
+        (root / "slow_pkg").mkdir()
+        (root / "slow_pkg" / "__init__.py").write_text(
+            "import time\\ntime.sleep(0.5)\\nREADY = True"
+        )
+        sys.path.insert(0, str(root))
+
+        thread = warmup.start_import_warmup(("slow_pkg",))
+        assert thread.is_alive()
+        warmup.wait_for_import_warmup()
+        assert not thread.is_alive()
+        assert sys.modules["slow_pkg"].READY
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_wait_for_import_warmup_without_a_warm_up_is_a_noop() -> None:
+    result = _run(
+        """
+        from strix.llm import warmup
+
+        warmup.wait_for_import_warmup()
+        assert warmup._thread is None
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_main_waits_for_the_import_warm_up_before_entering_the_scan_phase(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # ``strix.interface`` re-exports the ``main`` function under the module's name.
+    main_mod = importlib.import_module("strix.interface.main")
+
+    (tmp_path / "slow_pkg").mkdir()
+    (tmp_path / "slow_pkg" / "__init__.py").write_text("import time\ntime.sleep(0.5)\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, "slow_pkg", raising=False)
+    monkeypatch.setattr(warmup, "_thread", None)
+    real_start = warmup.start_import_warmup
+    monkeypatch.setattr(warmup, "start_import_warmup", lambda: real_start(("slow_pkg",)))
+
+    for name in (
+        "start_background_check",
+        "check_docker_installed",
+        "pull_docker_image",
+        "validate_environment",
+    ):
+        monkeypatch.setattr(main_mod, name, lambda: None)
+
+    seen: dict[str, bool] = {}
+
+    def fake_bootstrap(_args: object) -> None:
+        thread = warmup._thread
+        seen["warmup_alive"] = thread is not None and thread.is_alive()
+        seen["warmed"] = "slow_pkg" in sys.modules
+        raise SystemExit(0)
+
+    monkeypatch.setattr(main_mod, "_bootstrap_scan", fake_bootstrap)
+    monkeypatch.setattr(sys, "argv", ["strix", "-n", "--target", str(tmp_path)])
+
+    with pytest.raises(SystemExit):
+        main_mod.main()
+
+    assert seen == {"warmup_alive": False, "warmed": True}


### PR DESCRIPTION
## Problem

Since v1.6.0 every non-interactive scan run from the release binary in GitHub Actions dies at bootstrap, before the first model call:

```
File "main.py", line 138, in warm_up_llm
File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
File "<frozen importlib._bootstrap>", line 1314, in _find_and_load_unlocked
KeyError: 'agents.models'
[PYI-2301:ERROR] Failed to execute script 'main' due to unhandled exception!
```

Across our repos this was 9 of 9 runs on `ubuntu-24.04` runners with 1.6.0 and 1.6.1 (`strix -n --target ./ --scan-mode quick`, installed via `curl -sSL https://strix.ai/install | bash`). Every run of 1.5.3 from the same workflow scanned normally. The same crash is reported in #1230 (`--resume`, macOS) and, through a different first import, in #1190 and #1163.

## Root cause

It is not the PyInstaller spec: `strix.spec` and the `from agents.models.interface import ModelTracing` line are identical in 1.5.3, which works. It is the import warm-up thread added in 1.6.0.

1. `main()` calls `start_import_warmup()`, which imports `strix.core.runner` on a daemon thread. That pulls in the `agents` SDK, whose package graph has internal import cycles (`agents/__init__` imports `.models.interface`, which imports `..agent_output`, `..handoffs`, `..items`, `..tool`, and so on).
2. The main thread continues with `parse_arguments()`, the Docker checks and `validate_environment()`, then `_bootstrap_scan()` calls `warm_up_llm()`, whose first statement is `from agents.models.interface import ModelTracing`.
3. If step 2 happens while step 1 is still inside the `agents` package, the two threads end up waiting on each other's per-module import locks. CPython breaks the cycle by raising `_DeadlockError` in the thread that blocked second. When that is the warm-up thread, its `agents` import fails, `agents` is dropped from `sys.modules`, and `_purge_orphaned_modules` then removes the stranded `agents.*` entries, including the `agents.models` the main thread is standing on: `KeyError: 'agents.models'` at `_find_and_load_unlocked`. When the main thread is the one that loses, the symptom is `ImportError: cannot import name ... from partially initialized module` (the trace in #1163).

Why CI hits it every single time: the install script pulls the sandbox image itself, so by the time `strix -n` starts, `pull_docker_image()` is a local image inspect. From one run log: image pull finished at 17:21:07.15, `strix -n` started at 17:21:07.16, traceback at 17:21:09.47. The main thread reaches `warm_up_llm` a few hundred milliseconds after the warm-up thread started, which is exactly the failure window measured below. Any developer machine with the image already cached is in the same situation, which is why #1190 reports it as 100% reproducible.

Reproduction on a source checkout, emulating `main()`: start the warm-up, sleep, then run the import that `warm_up_llm` does. 4 runs per delay:

| Python | delay 0.02 s to 0.3 s | delay 0.4 s | other delays (0, 0.5 s to 3 s) |
|---|---|---|---|
| 3.12.12 (what the release binary ships) | 4/4 fail, `KeyError: 'agents.models'` every time | 0/4 | 0/4 |
| 3.14.3 | 0/4 | 3/4 fail, `ImportError: cannot import name 'AgentOutputSchemaBase' from partially initialized module 'agents.agent_output'` | 0/4 |

```python
import time
from strix.llm.warmup import start_import_warmup
t = start_import_warmup()
time.sleep(DELAY)
from agents.models.interface import ModelTracing  # what warm_up_llm does first
t.join()
```

## Fix

Add `wait_for_import_warmup()` to `strix/llm/warmup.py` and call it in `main()` once the startup I/O is done, right before `_bootstrap_scan()` / `run_cli` / `run_tui`. Everything past that point imports from the warmed graph on the main thread, so the warm-up thread has to be finished first.

This keeps the optimisation: the warm-up still overlaps with argument parsing, the update check and the Docker checks and image pull. The scan needs the warmed modules immediately after the wait anyway, so if the thread is still running at that point the main thread would otherwise have been blocked on the same imports (or racing them). `--help`, `--version`, `view`, `auth`, `cloud` and `completion` are untouched, which is the cold-start regression Greptile flagged on #1163's synchronous approach.

The module docstring claimed that a second thread "just blocks on the normal import lock, so behaviour is unchanged either way". That is the assumption this bug disproves, so it now documents the actual rule.

With the fix the same sweep is 0/56 failures on 3.12 and 0/56 on 3.14.

## Tests

- `test_wait_for_import_warmup_returns_once_the_thread_has_finished`
- `test_wait_for_import_warmup_without_a_warm_up_is_a_noop`
- `test_main_waits_for_the_import_warm_up_before_entering_the_scan_phase`: runs `main()` with the I/O steps stubbed and a slow warm-up module, and asserts the warm-up thread is already finished when `_bootstrap_scan` is entered. This test fails on `main` without the `main.py` change.

`uv run pytest`: 1679 passed on 3.14, the warm-up file also green on 3.12. `ruff check`, `ruff format --check` and `mypy strix/` are clean.

Closes #1230. Closes #1190. Alternative to #1163 that keeps the background warm-up. #1233 is a different bug in the same function (the shared httpx client outliving the warm-up's event loop) and is not addressed here.
