### PR TITLE
fix(tui): add viewer copy action

### DIFF
--- a/strix/interface/tui/go.mod
+++ b/strix/interface/tui/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/alecthomas/chroma/v2 v2.14.0
 	github.com/atotto/clipboard v0.1.4
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -15,7 +16,6 @@ require (
 )
 
 require (
-	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect

--- a/strix/interface/tui/internal/app/model.go
+++ b/strix/interface/tui/internal/app/model.go
@@ -2,10 +2,13 @@ package app
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/atotto/clipboard"
+	"github.com/aymanbagabas/go-osc52/v2"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -27,7 +30,41 @@ type splashTickMsg time.Time
 type sweepTickMsg time.Time
 type vulnerabilityCopiedMsg struct{ err error }
 
-var writeClipboard = clipboard.WriteAll
+var (
+	writeClipboard         = writeSystemClipboard
+	writeNativeClipboard   = clipboard.WriteAll
+	writeTerminalClipboard = func(value string) error {
+		sequence := osc52.New(value)
+		if strings.HasPrefix(os.Getenv("TERM"), "screen") && os.Getenv("TMUX") == "" {
+			sequence = sequence.Screen()
+		}
+		_, err := sequence.WriteTo(os.Stdout)
+		return err
+	}
+	writeTmuxClipboard = func(value string) error {
+		command := exec.Command("tmux", "load-buffer", "-w", "-")
+		command.Stdin = strings.NewReader(value)
+		return command.Run()
+	}
+)
+
+// writeSystemClipboard uses the host clipboard locally and OSC 52 through the
+// terminal remotely. tmux can forward the value itself even when applications
+// are not allowed to emit clipboard escape sequences.
+func writeSystemClipboard(value string) error {
+	remote := os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_CLIENT") != "" || os.Getenv("SSH_TTY") != ""
+	if !remote {
+		if err := writeNativeClipboard(value); err == nil {
+			return nil
+		}
+	}
+	if os.Getenv("TMUX") != "" {
+		if err := writeTmuxClipboard(value); err == nil {
+			return nil
+		}
+	}
+	return writeTerminalClipboard(value)
+}
 
 type collectionAssembly struct {
 	kind         string
@@ -123,6 +160,7 @@ type Model struct {
 	budgetPauseNotified    bool
 	followOutput           bool
 	selection              selectionState
+	viewerCollapsed        bool
 	toast                  string
 	toastID                int
 	draggingScrollbar      scrollbarTarget

--- a/strix/interface/tui/internal/app/model_test.go
+++ b/strix/interface/tui/internal/app/model_test.go
@@ -880,7 +880,11 @@ func TestRunningViewerShowsCompleteWrappedURL(t *testing.T) {
 	if !strings.Contains(view, "Viewer running") {
 		t.Fatalf("viewer status is missing: %s", view)
 	}
-	urlLines := strings.Split(strings.SplitN(view, "\n", 2)[1], "\n")
+	lines := strings.Split(strings.SplitN(view, "\n", 2)[1], "\n")
+	if actions := lines[len(lines)-1]; !strings.Contains(actions, viewerOpenLabel) || !strings.Contains(actions, viewerCopyLabel) {
+		t.Fatalf("viewer actions are missing: %s", view)
+	}
+	urlLines := lines[:len(lines)-1]
 	for i := range urlLines {
 		urlLines[i] = strings.TrimRight(urlLines[i], " ")
 	}
@@ -889,6 +893,174 @@ func TestRunningViewerShowsCompleteWrappedURL(t *testing.T) {
 	}
 	if want := strings.Count(model.viewerView(model.viewerContentWidth()), "\n") + 3; model.viewerHeight() != want {
 		t.Fatalf("viewer height = %d, want %d", model.viewerHeight(), want)
+	}
+}
+
+func TestRunningViewerButtonsCopyOrOpenWithoutCollapsing(t *testing.T) {
+	originalWriteClipboard := writeClipboard
+	t.Cleanup(func() { writeClipboard = originalWriteClipboard })
+	copied := ""
+	writeClipboard = func(value string) error {
+		copied = value
+		return nil
+	}
+
+	model, connection := newCommandTestModel(t)
+	model.width, model.height = 130, 30
+	url := "  http://127.0.0.1:43123/?token=abcdefghijklmnopqrstuvwxyz0123456789  "
+	model.snapshot.ViewerStatus = "running"
+	model.snapshot.ViewerURL = &url
+	_, sidebarWidth, chatWidth, _ := model.layout()
+	panel := model.viewerPanel(sidebarWidth)
+	openX, openY := -1, -1
+	copyX, copyY := -1, -1
+	for row, line := range strings.Split(panel, "\n") {
+		plain := ansi.Strip(line)
+		if index := strings.Index(plain, viewerOpenLabel); index >= 0 {
+			openX = chatWidth + 1 + ansi.StringWidth(plain[:index])
+			openY = row
+		}
+		if index := strings.Index(plain, viewerCopyLabel); index >= 0 {
+			copyX = chatWidth + 1 + ansi.StringWidth(plain[:index])
+			copyY = row
+		}
+	}
+	if openX < 0 || copyX < 0 {
+		t.Fatalf("viewer buttons were not rendered: %s", ansi.Strip(panel))
+	}
+
+	updated, cmd := model.updateMouse(tea.MouseMsg{
+		X: copyX, Y: copyY, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	model = updated.(Model)
+	if cmd == nil {
+		t.Fatal("clicking Copy produced no command")
+	}
+	msg := cmd()
+	if copied != strings.TrimSpace(url) {
+		t.Fatalf("copied viewer URL = %q, want %q", copied, strings.TrimSpace(url))
+	}
+	if connection.Len() != 0 {
+		t.Fatal("clicking Copy also sent viewer.open")
+	}
+	if model.viewerCollapsed {
+		t.Fatal("clicking Copy collapsed the viewer")
+	}
+	updated, _ = model.Update(msg)
+	model = updated.(Model)
+	if toast := model.toast; toast != "Copied to clipboard" {
+		t.Fatalf("copy toast = %q", toast)
+	}
+
+	updated, cmd = model.updateMouse(tea.MouseMsg{
+		X: openX, Y: openY, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	model = updated.(Model)
+	if model.viewerCollapsed {
+		t.Fatal("clicking Open collapsed the viewer")
+	}
+	if envelope := commandFromCmd(t, cmd, connection); envelope.Type != "viewer.open" {
+		t.Fatalf("Open command = %q", envelope.Type)
+	}
+}
+
+func TestRunningViewerWithoutURLHasNoCopyAction(t *testing.T) {
+	model := New(nil)
+	model.snapshot.ViewerStatus = "running"
+	if view := ansi.Strip(model.viewerView(20)); strings.Contains(view, viewerCopyLabel) {
+		t.Fatalf("viewer without a URL rendered Copy: %s", view)
+	}
+	if cmd := model.startViewerCopy(); cmd != nil {
+		t.Fatal("viewer without a URL produced a copy command")
+	}
+}
+
+func TestRunningViewerBodyCollapsesAndExpands(t *testing.T) {
+	model := New(nil)
+	model.width, model.height = 130, 30
+	url := "http://127.0.0.1:43123/?token=test"
+	model.snapshot.ViewerStatus = "running"
+	model.snapshot.ViewerURL = &url
+	expandedHeight := model.viewerHeight()
+	_, _, chatWidth, _ := model.layout()
+
+	updated, cmd := model.updateMouse(tea.MouseMsg{
+		X: chatWidth + 2, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	model = updated.(Model)
+	if cmd != nil || !model.viewerCollapsed {
+		t.Fatalf("clicking the viewer body did not collapse it: collapsed=%v cmd=%v", model.viewerCollapsed, cmd)
+	}
+	if model.viewerHeight() >= expandedHeight {
+		t.Fatalf("collapsed viewer height = %d, expanded height = %d", model.viewerHeight(), expandedHeight)
+	}
+	collapsed := ansi.Strip(model.viewerView(model.viewerContentWidth()))
+	if !strings.Contains(collapsed, "Viewer running") || strings.Contains(collapsed, url) || strings.Contains(collapsed, viewerCopyLabel) {
+		t.Fatalf("collapsed viewer rendered unexpected content: %s", collapsed)
+	}
+
+	updated, cmd = model.updateMouse(tea.MouseMsg{
+		X: chatWidth + 2, Y: 1, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress,
+	})
+	model = updated.(Model)
+	if cmd != nil || model.viewerCollapsed {
+		t.Fatalf("clicking the collapsed viewer did not expand it: collapsed=%v cmd=%v", model.viewerCollapsed, cmd)
+	}
+	if model.viewerHeight() != expandedHeight {
+		t.Fatalf("re-expanded viewer height = %d, want %d", model.viewerHeight(), expandedHeight)
+	}
+}
+
+func TestSystemClipboardUsesRemoteAndTmuxBackends(t *testing.T) {
+	originalNative := writeNativeClipboard
+	originalTerminal := writeTerminalClipboard
+	originalTmux := writeTmuxClipboard
+	t.Cleanup(func() {
+		writeNativeClipboard = originalNative
+		writeTerminalClipboard = originalTerminal
+		writeTmuxClipboard = originalTmux
+	})
+
+	nativeCalls, terminalCalls, tmuxCalls := 0, 0, 0
+	writeNativeClipboard = func(string) error {
+		nativeCalls++
+		return nil
+	}
+	writeTerminalClipboard = func(string) error {
+		terminalCalls++
+		return nil
+	}
+	writeTmuxClipboard = func(string) error {
+		tmuxCalls++
+		return nil
+	}
+
+	t.Setenv("SSH_CONNECTION", "")
+	t.Setenv("SSH_CLIENT", "")
+	t.Setenv("SSH_TTY", "")
+	t.Setenv("TMUX", "/tmp/tmux.sock,1,0")
+	if err := writeSystemClipboard("local URL"); err != nil {
+		t.Fatal(err)
+	}
+	if nativeCalls != 1 || terminalCalls != 0 || tmuxCalls != 0 {
+		t.Fatalf("local copy calls: native=%d terminal=%d tmux=%d", nativeCalls, terminalCalls, tmuxCalls)
+	}
+
+	t.Setenv("SSH_CONNECTION", "client 123 server 22")
+	t.Setenv("TMUX", "")
+	if err := writeSystemClipboard("remote URL"); err != nil {
+		t.Fatal(err)
+	}
+	if nativeCalls != 1 || terminalCalls != 1 || tmuxCalls != 0 {
+		t.Fatalf("SSH copy calls: native=%d terminal=%d tmux=%d", nativeCalls, terminalCalls, tmuxCalls)
+	}
+
+	t.Setenv("TMUX", "/tmp/tmux.sock,1,0")
+	if err := writeSystemClipboard("tmux URL"); err != nil {
+		t.Fatal(err)
+	}
+	if nativeCalls != 1 || terminalCalls != 1 || tmuxCalls != 1 {
+		t.Fatalf("tmux copy calls: native=%d terminal=%d tmux=%d", nativeCalls, terminalCalls, tmuxCalls)
 	}
 }
 

--- a/strix/interface/tui/internal/app/selection.go
+++ b/strix/interface/tui/internal/app/selection.go
@@ -145,6 +145,16 @@ func (m *Model) finishSelection() tea.Cmd {
 	}
 }
 
+func (m Model) startViewerCopy() tea.Cmd {
+	url := m.viewerURL()
+	if url == "" {
+		return nil
+	}
+	return func() tea.Msg {
+		return selectionCopiedMsg{err: writeClipboard(url)}
+	}
+}
+
 // iconPrefixes and decorativeLines port StrixTUIApp._ICON_PREFIXES and
 // _DECORATIVE_LINES: UI ornaments dropped from copied chat text.
 // kittyPlaceholderRune marks kitty graphics placeholder cells, which carry no

--- a/strix/interface/tui/internal/app/update.go
+++ b/strix/interface/tui/internal/app/update.go
@@ -161,7 +161,7 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	if m.snapshot.SetupMode {
 		return m.updateSetupMouse(msg)
 	}
-	showSidebar, _, chatWidth, chatHeight := m.layout()
+	showSidebar, sidebarWidth, chatWidth, chatHeight := m.layout()
 	viewerHeight := m.viewerHeight()
 	_, vulnHeight, mcpHeight, agentHeight := m.sidebarHeights()
 	x, y := msg.X, msg.Y
@@ -294,6 +294,23 @@ func (m Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	// Sidebar: viewer, agents, vulnerabilities, then stats.
 	switch {
 	case y < viewerHeight:
+		if m.snapshot.ViewerStatus == "running" && m.viewerCollapsed {
+			m.viewerCollapsed = false
+			return m, nil
+		}
+		if y == viewerHeight-2 {
+			panel := m.viewerPanel(sidebarWidth)
+			if labelHitAt(panel, viewerCopyLabel, chatWidth+1, 0, x, y) {
+				return m, m.startViewerCopy()
+			}
+			if labelHitAt(panel, viewerOpenLabel, chatWidth+1, 0, x, y) {
+				return m, send(m.client, "viewer.open", map[string]any{})
+			}
+		}
+		if m.snapshot.ViewerStatus == "running" && m.viewerURL() != "" {
+			m.viewerCollapsed = true
+			return m, nil
+		}
 		return m, send(m.client, "viewer.open", map[string]any{})
 	case y < viewerHeight+agentHeight:
 		m.focus = focusAgents

--- a/strix/interface/tui/internal/app/view.go
+++ b/strix/interface/tui/internal/app/view.go
@@ -525,7 +525,7 @@ func (m Model) sidebarView(width, height int) string {
 		m.scrollbarThumb(scrollbarAgents),
 	)
 	parts := []string{
-		lipgloss.NewStyle().Width(width-2).Height(m.viewerHeight()-2).Border(lipgloss.RoundedBorder()).BorderForeground(dark).Padding(0, 1).Render(m.viewerView(width - 4)),
+		m.viewerPanel(width),
 		lipgloss.NewStyle().Width(width-2).Height(agentHeight-2).Border(lipgloss.RoundedBorder()).BorderForeground(agentBorder).Padding(1, 1).Render(agents),
 	}
 	if vulnHeight > 0 {
@@ -589,13 +589,38 @@ func (m Model) viewerContentWidth() int {
 	return max(1, sidebarWidth-4)
 }
 
+func (m Model) viewerPanel(width int) string {
+	return lipgloss.NewStyle().Width(width-2).Height(m.viewerHeight()-2).
+		Border(lipgloss.RoundedBorder()).BorderForeground(dark).Padding(0, 1).
+		Render(m.viewerView(width - 4))
+}
+
+const (
+	viewerOpenLabel = "Open"
+	viewerCopyLabel = "Copy"
+)
+
+func viewerAction(label string) string {
+	return lipgloss.NewStyle().Foreground(brightWhite).Background(lipgloss.Color("#262626")).Padding(0, 1).Render(label)
+}
+
+func (m Model) viewerURL() string {
+	if m.snapshot.ViewerURL == nil {
+		return ""
+	}
+	return strings.TrimSpace(*m.snapshot.ViewerURL)
+}
+
 func (m Model) viewerView(width int) string {
 	switch m.snapshot.ViewerStatus {
 	case "running":
+		if m.viewerCollapsed {
+			return lipgloss.NewStyle().Foreground(green).Render("▶ Viewer running")
+		}
 		status := lipgloss.NewStyle().Foreground(green).Render("● Viewer running")
-		if m.snapshot.ViewerURL != nil && strings.TrimSpace(*m.snapshot.ViewerURL) != "" {
-			url := wrapBlock(strings.TrimSpace(*m.snapshot.ViewerURL), width)
-			return status + "\n" + lipgloss.NewStyle().Foreground(dim).Render(url)
+		if url := m.viewerURL(); url != "" {
+			actions := viewerAction(viewerOpenLabel) + "  " + viewerAction(viewerCopyLabel)
+			return status + "\n" + lipgloss.NewStyle().Foreground(dim).Render(wrapBlock(url, width)) + "\n" + actions
 		}
 		return status
 	case "unavailable":


### PR DESCRIPTION
## Summary

- add explicit Open and Copy controls for the running viewer URL
- copy the raw unwrapped URL through the native clipboard locally and tmux/OSC 52 over SSH
- collapse the viewer details when the panel body is clicked, while keeping button clicks independent

## Testing

- `go test -race ./...`
- `go vet ./...`
- `gofmt`
- `git diff --check`