### PR TITLE
fix: guard agents.models import in warm_up_llm against cross-thread partial-import race (#1248)

### DIFF
--- a/strix/interface/main.py
+++ b/strix/interface/main.py
@@ -135,6 +135,12 @@ def _subscription_error_hint(exc: BaseException) -> str | None:
 
 
 async def warm_up_llm(show_model_warning: bool = True) -> None:
+    # Issue #1248: the import warm-up daemon may still be populating
+    # agents.models in sys.modules. Wait for that subpackage only — do not
+    # join the rest of the warm-up thread — then import.
+    from strix.llm.warmup import wait_for_agents_models
+
+    wait_for_agents_models()
     from agents.models.interface import ModelTracing
 
     from strix.config.models import (

--- a/strix/interface/scan_setup.py
+++ b/strix/interface/scan_setup.py
@@ -64,6 +64,11 @@ async def preflight_model_connection(
     settings: Settings | None = None,
 ) -> None:
     """Verify the configured model route before starting a scan."""
+    # Same agents.models race as warm_up_llm (issue #1248); the TUI path
+    # enters here without going through that function.
+    from strix.llm.warmup import wait_for_agents_models
+
+    wait_for_agents_models()
     from agents.models.interface import ModelTracing
 
     from strix.config.models import StrixProvider, configure_sdk_model_defaults

--- a/strix/llm/warmup.py
+++ b/strix/llm/warmup.py
@@ -5,9 +5,19 @@ Caido SDK, the Docker SDK) costs seconds to import cold, but none of it is
 needed until a scan actually starts. Importing it on a daemon thread at CLI
 entry overlaps that cost with the I/O-bound startup work that always precedes
 a scan (argument parsing, Docker checks, image pull, TUI setup), so by the
-time the scan begins the modules are already in ``sys.modules``. Any thread
-that needs one of them before the warm-up finishes just blocks on the normal
-import lock, so behaviour is unchanged either way.
+time the scan begins the modules are already in ``sys.modules``.
+
+CPython's per-module import locks do **not** make a second thread importing
+from that graph safe. The agents SDK has internal import cycles; when the
+warm-up thread and the main thread walk them at once, deadlock avoidance
+fails one import and drops a half-built package from ``sys.modules``. The
+main thread then crashes with ``KeyError: 'agents.models'`` (issue #1248) or
+``ImportError: cannot import name ... from partially initialized module``.
+
+Call :func:`wait_for_agents_models` before the first ``agents.models`` import
+on any other thread. That wait is released once the runner (which loads
+``agents.models``) has finished — not when the whole warm-up thread joins —
+so LiteLLM / Caido / Docker continue overlapping later scan work.
 """
 
 from __future__ import annotations
@@ -27,8 +37,14 @@ WARMUP_MODULES = (
     "docker",
 )
 
+# ``strix.core.runner`` transitively imports the agents SDK, including
+# ``agents.models``. Waiters for that subpackage are released after these
+# modules finish (or fail); later WARMUP_MODULES keep running.
+_AGENTS_GRAPH_MODULES = frozenset({"strix.core.runner"})
+
 _lock = threading.Lock()
 _thread: threading.Thread | None = None
+_agents_models_ready = threading.Event()
 
 
 def _purge_orphaned_modules(before: frozenset[str]) -> None:
@@ -55,14 +71,31 @@ def _purge_orphaned_modules(before: frozenset[str]) -> None:
             parent = parent.rpartition(".")[0]
 
 
+def _import_one(name: str) -> None:
+    before = frozenset(sys.modules)
+    try:
+        importlib.import_module(name)
+    except Exception:  # noqa: BLE001 - a failed warm-up must never fail the run.
+        logger.debug("Import warm-up for %r failed", name, exc_info=True)
+        _purge_orphaned_modules(before)
+
+
 def _warm(modules: tuple[str, ...]) -> None:
-    for name in modules:
-        before = frozenset(sys.modules)
-        try:
-            importlib.import_module(name)
-        except Exception:  # noqa: BLE001 - a failed warm-up must never fail the run.
-            logger.debug("Import warm-up for %r failed", name, exc_info=True)
-            _purge_orphaned_modules(before)
+    pending_graph = set(_AGENTS_GRAPH_MODULES.intersection(modules))
+    try:
+        for name in modules:
+            _import_one(name)
+            if name in pending_graph:
+                pending_graph.discard(name)
+                if not pending_graph:
+                    # agents.models is fully loaded (or the attempt failed).
+                    # Do not join the rest of this thread — see #1248.
+                    _agents_models_ready.set()
+    finally:
+        # Always release waiters: a failed or runner-less warm-up must not
+        # deadlock the main thread (e.g. missing optional deps, no API key
+        # needed here — this path is import-only).
+        _agents_models_ready.set()
 
 
 def start_import_warmup(modules: tuple[str, ...] = WARMUP_MODULES) -> threading.Thread:
@@ -80,3 +113,26 @@ def start_import_warmup(modules: tuple[str, ...] = WARMUP_MODULES) -> threading.
         )
         _thread.start()
         return _thread
+
+
+def wait_for_agents_models() -> None:
+    """Block until ``agents.models`` is fully imported, without joining warm-up.
+
+    The import warm-up daemon loads ``agents.models`` transitively via
+    ``strix.core.runner``. ``warm_up_llm`` used to import
+    ``agents.models.interface`` on the main thread at the same time, which
+    races CPython into ``KeyError: 'agents.models'`` (issue #1248).
+
+    This waits on :data:`_agents_models_ready`, set as soon as that
+    subpackage's loader (the runner) has finished or failed. It does **not**
+    ``join()`` the warm-up thread, so LiteLLM / Caido / Docker keep importing
+    in the background.
+
+    No-op if warm-up was never started, so embedders and tests cannot
+    deadlock. Safe to call from the warm-up thread itself.
+    """
+    with _lock:
+        thread = _thread
+    if thread is None or thread is threading.current_thread():
+        return
+    _agents_models_ready.wait()

--- a/tests/test_import_warmup.py
+++ b/tests/test_import_warmup.py
@@ -7,6 +7,12 @@ hooks -> report.state). CPython's deadlock avoidance breaks such a cycle by
 failing one import, which strands finished submodules in ``sys.modules`` with
 their parent package gone — and the next import of one of those submodules
 crashes with "partially initialized module".
+
+Second field failure (#1248): ``warm_up_llm`` imported
+``agents.models.interface`` on the main thread while the daemon was still
+populating ``agents.models``, producing ``KeyError: 'agents.models'``. The
+main thread must wait for that subpackage (via ``wait_for_agents_models``)
+without joining the rest of the warm-up thread.
 """
 
 from __future__ import annotations
@@ -97,3 +103,86 @@ def test_purge_does_not_touch_preexisting_or_healthy_modules() -> None:
     warmup._purge_orphaned_modules(before)
     assert "strix.llm.warmup" in sys.modules  # parent chain intact -> kept
     assert "strix" in sys.modules
+
+
+def test_wait_for_agents_models_without_a_warm_up_is_a_noop() -> None:
+    result = _run(
+        """
+        from strix.llm import warmup
+
+        warmup.wait_for_agents_models()
+        assert warmup._thread is None
+        assert not warmup._agents_models_ready.is_set()
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_wait_for_agents_models_does_not_join_the_rest_of_warmup() -> None:
+    result = _run(
+        """
+        import pathlib
+        import sys
+        import tempfile
+
+        from strix.llm import warmup
+
+        root = pathlib.Path(tempfile.mkdtemp())
+        (root / "quick_pkg").mkdir()
+        (root / "quick_pkg" / "__init__.py").write_text("READY = True\\n")
+        (root / "slow_pkg").mkdir()
+        (root / "slow_pkg" / "__init__.py").write_text(
+            "import time\\ntime.sleep(1.0)\\nREADY = True\\n"
+        )
+        sys.path.insert(0, str(root))
+
+        warmup._AGENTS_GRAPH_MODULES = frozenset({"quick_pkg"})
+        thread = warmup.start_import_warmup(("quick_pkg", "slow_pkg"))
+        warmup.wait_for_agents_models()
+        assert sys.modules["quick_pkg"].READY
+        assert thread.is_alive(), "wait_for_agents_models joined the whole warm-up thread"
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+        assert sys.modules["slow_pkg"].READY
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_wait_for_agents_models_unblocks_when_graph_import_fails() -> None:
+    result = _run(
+        """
+        import pathlib
+        import sys
+        import tempfile
+
+        from strix.llm import warmup
+
+        root = pathlib.Path(tempfile.mkdtemp())
+        (root / "boom_pkg").mkdir()
+        (root / "boom_pkg" / "__init__.py").write_text("raise RuntimeError('boom')\\n")
+        sys.path.insert(0, str(root))
+
+        warmup._AGENTS_GRAPH_MODULES = frozenset({"boom_pkg"})
+        warmup.start_import_warmup(("boom_pkg",))
+        warmup.wait_for_agents_models()
+        assert "boom_pkg" not in sys.modules
+        """
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_wait_for_agents_models_then_interface_import_succeeds() -> None:
+    """Regression for #1248: importing ModelTracing after the wait must not KeyError."""
+    result = _run(
+        """
+        from strix.llm.warmup import start_import_warmup, wait_for_agents_models
+
+        start_import_warmup()
+        wait_for_agents_models()
+        from agents.models.interface import ModelTracing
+
+        assert ModelTracing is not None
+        """
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Fresh (non-resume) scans crash at LLM warm-up with `KeyError: 'agents.models'` because `warm_up_llm` imported `agents.models.interface` on the main thread while the #1141 daemon was still populating that package (`#1248`).
- Add an `Event` (`_agents_models_ready`) released after `strix.core.runner` finishes (it loads `agents.models`) or fails. `wait_for_agents_models()` blocks on that Event only — it does **not** `join()` the warm-up thread — then the original import runs. LiteLLM / Caido / Docker keep overlapping model preflight.
- The Event is set in a `finally` so a failed warm-up (missing optional deps, etc.) cannot deadlock waiters. `_purge_orphaned_modules` is unchanged. `--resume` shares this `warm_up_llm` path, so it is covered rather than regressed.

## Test plan
- [x] `uv run pytest tests/test_import_warmup.py` (8 passed), including: wait is a no-op without warm-up; wait does not join remaining modules; wait returns when the graph import fails; `from agents.models.interface import ModelTracing` after the wait succeeds.
- [x] `ruff check` / `ruff format --check` / `mypy` on the touched files.
- [x] Drive `main()` with Docker stubbed using `--target http://example.com --instruction-file … --scan-mode quick --max-budget 2 --non-interactive`: import survives; process reaches real model preflight (401 on a dummy key), not `KeyError`.
- [x] `wait_for_agents_models()` returns with `LLM_API_KEY` unset (warm-up is import-only).
- [x] Real CLI with Docker running and the sandbox image **already cached** (the #1248 race window: `pull_docker_image()` is a local inspect, a few hundred milliseconds). 3/3 runs, no `KeyError: 'agents.models'`. The process gets past import warm-up and reaches live model preflight.

### Real CLI logs (macOS arm64, source install, image cached)

```bash
uv run strix --target http://example.com \
  --instruction-file /tmp/strix-1248-instructions.txt \
  --scan-mode quick --max-budget 2 --non-interactive
```

`STRIX_LLM=anthropic/claude-sonnet-5`, dummy `LLM_API_KEY` (enough to prove we get past the import; the original crash happened before any provider call).

Run 1/2/3 — all exit 1 at preflight, none at `agents.models`:

```
╭─ STRIX ──────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  LLM CONNECTION FAILED                                                       │
│                                                                              │
│  Could not establish connection to the language model.                       │
│  Please check your configuration and try again.                              │
│                                                                              │
│  Error: litellm.AuthenticationError: AnthropicException -                    │
│  {"type":"error","error":{"type":"authentication_error","message":"API key   │
│  is invalid."},"request_id":null}                                            │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

Exit 1 is expected (invalid key). Before this fix the same command died at `warm_up_llm` with `KeyError: 'agents.models'` and never sent a request.

Closes #1248.
Related: #1230 (same crash site on `--resume`; this guards that import without a full-thread join).