### PR TITLE
docs: add Vercel AI Gateway provider guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -36,6 +36,7 @@
               "llm-providers/openai",
               "llm-providers/anthropic",
               "llm-providers/openrouter",
+              "llm-providers/vercel-ai-gateway",
               "llm-providers/vertex",
               "llm-providers/bedrock",
               "llm-providers/azure",

--- a/docs/llm-providers/overview.mdx
+++ b/docs/llm-providers/overview.mdx
@@ -46,6 +46,9 @@ See the [Local Models guide](/llm-providers/local) for setup instructions and re
   <Card title="OpenRouter" href="/llm-providers/openrouter">
     Access 100+ models through a single API.
   </Card>
+  <Card title="Vercel AI Gateway" href="/llm-providers/vercel-ai-gateway">
+    Access models from multiple providers through one endpoint.
+  </Card>
   <Card title="Google Vertex AI" href="/llm-providers/vertex">
     Gemini 3 models via Google Cloud.
   </Card>

--- a/docs/llm-providers/vercel-ai-gateway.mdx
+++ b/docs/llm-providers/vercel-ai-gateway.mdx
@@ -1,0 +1,39 @@
+---
+title: "Vercel AI Gateway"
+description: "Configure Strix with models via Vercel AI Gateway"
+---
+
+[Vercel AI Gateway](https://vercel.com/docs/ai-gateway) provides an OpenAI-compatible API for models from multiple providers.
+
+## Setup
+
+Create an [AI Gateway API key](https://vercel.com/docs/ai-gateway/authentication-and-byok), then configure Strix:
+
+```bash
+export STRIX_LLM="openai/anthropic/claude-opus-5"
+export LLM_API_KEY="your-ai-gateway-api-key"
+export LLM_API_BASE="https://ai-gateway.vercel.sh/v1"
+```
+
+The first `openai/` segment tells Strix to use its OpenAI-compatible client. The remaining value is the [AI Gateway model ID](https://vercel.com/docs/ai-gateway/models-and-providers).
+
+## Available Models
+
+Use any language model returned by the AI Gateway models endpoint:
+
+```text
+https://ai-gateway.vercel.sh/v1/models
+```
+
+Prefix its model ID with `openai/` when setting `STRIX_LLM`. For example, the Gateway model ID `anthropic/claude-opus-5` becomes `openai/anthropic/claude-opus-5` in Strix.
+
+## Get API Key
+
+1. Open the [AI Gateway API key settings](https://vercel.com/docs/ai-gateway/authentication-and-byok)
+2. Create an API key
+3. Set the key as `LLM_API_KEY`
+
+## Benefits
+
+- Access models from multiple providers through one endpoint
+- Track Gateway usage and cost in Vercel


### PR DESCRIPTION
## What

Adds [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) as an LLM provider option in the docs: a new provider guide, a card in the overview, and a nav entry after OpenRouter. Docs only, no code changes.

## Why

Gateway exposes an OpenAI-compatible endpoint, so Strix already works with it today through the existing `openai/` prefix and `LLM_API_BASE` (no code change needed) — it just wasn't documented. This gives users a one-endpoint way to reach models across providers with usage and cost tracked in Vercel.

## Setup it documents

```bash
export STRIX_LLM="openai/anthropic/claude-opus-5"
export LLM_API_KEY="your-ai-gateway-api-key"
export LLM_API_BASE="https://ai-gateway.vercel.sh/v1"
```

The `openai/` prefix selects Strix's OpenAI-compatible client; the rest is the Gateway model ID.

I verified this config end to end against the live Gateway (`/v1/models` reachable, tool-calling works streaming and non-streaming) before writing the page. The new page mirrors the structure of the existing provider guides (OpenRouter, Anthropic, etc.).